### PR TITLE
Added state for resizing EBS root partition

### DIFF
--- a/salt/utils/grow_partition.sls
+++ b/salt/utils/grow_partition.sls
@@ -1,0 +1,15 @@
+{% set devicename = salt.grains.get('ec2:block_device_mapping:root') %}
+{% set part_number = 1 %}
+
+install_parted:
+  pkg.installed:
+    - name: parted
+    - refresh: True
+
+resize_root_partition:
+  cmd.run:
+    - name: parted {{ devicename }} {{ part_number }} yes 100%
+
+resize_file_system:
+  cmd.run:
+    - name: resize2fs {{ devicename }}{{ part_number }}


### PR DESCRIPTION
On Debian AMIs the root partition is automatically set to the default
size of 8 GB, regardless of the actual EBS volume capacity. In order to
take advantage of the full volume it is necessary to resize the
partition and filesystem.