### PR TITLE
Updated profile and orchestration for ES capacity

### DIFF
--- a/cloud.profiles.d/elasticsearch.conf
+++ b/cloud.profiles.d/elasticsearch.conf
@@ -8,7 +8,7 @@ elasticsearch:
   subnetid: subnet-13305e2e
   block_device_mappings:
     - DeviceName: /dev/xvda
-      Ebs.VolumeSize: 50
+      Ebs.VolumeSize: 400
       Ebs.VolumeType: gp2
   ebs_optimized: True
   iam_profile: elasticsearch-instance-role

--- a/salt/orchestrate/logging.sls
+++ b/salt/orchestrate/logging.sls
@@ -15,6 +15,12 @@ deploy_logging_cloud_map:
         path: /etc/salt/cloud.maps.d/logging-map.yml
         parallel: True
 
+resize_root_partitions_on_elasticsearch_nodes:
+  salt.state:
+    - tgt: 'roles:elasticsearch'
+    - tgt_type: grain
+    - sls: utils.grow_partition
+
 load_pillar_data_on_logging_nodes:
   salt.function:
     - name: saltutil.refresh_pillar


### PR DESCRIPTION
Increased the root volume size on the elasticsearch profile to
accomodate a larger volume of log data. Added the state to expand the
root partition to the orchestration state for running on the
elasticsearch nodes.