### PR TITLE
Added script for using with Consul check

### DIFF
--- a/salt/mongodb/consul_check.sls
+++ b/salt/mongodb/consul_check.sls
@@ -1,0 +1,15 @@
+create_mongodb_consul_check_script:
+  file.managed:
+    - name: /consul/scripts/mongo_is_master.sh
+    - makedirs: True
+    - mode: 0755
+    - contents: |
+        #!/bin/bash
+
+        ISMASTER=$(/usr/bin/mongo --quiet --eval 'db.isMaster().ismaster')
+        if [ "$ISMASTER" = "true" ]
+        then
+            exit 0
+        else
+            exit 2
+        fi

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -36,6 +36,7 @@ base:
   'G@roles:mongodb and G@environment:dogwood-qa':
     - match: compound
     - mongodb
+    - mongodb.consul_check
     - datadog.plugins
   'roles:aggregator':
     - match: grain


### PR DESCRIPTION
**Added script for using with Consul check**
In order to verify whether a node is master, added a script to run via
Consul. This will allow us to expose a service of
`master.mongodb.service.consul` for easier connection to replica sets.

