### PR TITLE
Added postfix configuration for MITx

### DIFF
--- a/salt/edx/smtp.sls
+++ b/salt/edx/smtp.sls
@@ -1,0 +1,36 @@
+{% set relay_host = salt.pillar.get('edx:smtp:relay_host', 'outgoing.mit.edu') -%}
+{% set relay_username = salt.pillar.get('edx:smtp:relay_username', 'mitxmail') -%}
+{% set relay_password = salt.pillar.get('edx:smtp:relay_password', '') -%}
+
+{% set root_forward = salt.pillar.get('edx:smtp:root_forward', 'cuddle-bunnies@mit.edu') -%}
+{% set root_from = salt.pillar.get('edx:smtp:root_from', 'mitxmail@mit.edu') -%}
+
+
+install_mailutils_package:
+  pkg.installed:
+    - pkgs:
+      - mailutils
+    - refresh: True
+    - refresh_modules: True
+
+create_password_maps_file:
+  file.managed:
+    - name: /etc/postfix/relay_passwd
+    - source: salt://edx/templates/relay_passwd.j2
+    - owner: root
+    - group: root
+    - mode: 600
+    - context:
+        relay_host: {{ relay_host }}
+        relay_username: {{ relay_username }}
+        relay_password: {{ relay_password }}
+
+create_canonical_file:
+  file.managed:
+    - name: /etc/postfix/canonical
+    - source: salt://edx/templates/canonical.j2
+    - owner: root
+    - group: root
+    - mode: 600
+    - context:
+        root_from: {{ relay_host }}

--- a/salt/edx/templates/canonical.j2
+++ b/salt/edx/templates/canonical.j2
@@ -1,0 +1,2 @@
+root@mitx.mit.edu   {{ root_from }}
+@mitx.mit.edu {{ root_from }}

--- a/salt/edx/templates/postfix_main.cf.j2
+++ b/salt/edx/templates/postfix_main.cf.j2
@@ -1,0 +1,35 @@
+# See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+smtpd_banner = $myhostname ESMTP $mail_name
+biff = no
+
+# appending .domain is the MUA's job.
+append_dot_mydomain = no
+
+# Uncomment the next line to generate "delayed mail" warnings
+#delay_warning_time = 4h
+
+readme_directory = no
+mydomain = mitx.mit.edu
+myorigin = mitx.mit.edu
+
+# See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
+# information on enabling SSL in the smtp client.
+
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+mydestination = localhost.localdomain, , localhost, $myhostname $mydomain
+relayhost = [{{ smtp_relay_host }}]:587
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = loopback-only
+
+
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/relay_passwd
+smtp_sasl_security_options =
+smtp_use_tls = yes
+
+# Handle sending addresses
+sender_canonical_maps = hash:/etc/postfix/canonical

--- a/salt/edx/templates/relay_passwd.j2
+++ b/salt/edx/templates/relay_passwd.j2
@@ -1,0 +1,1 @@
+{{ relay_host }} {{ relay_username }}:{{ relay_password }}


### PR DESCRIPTION
This PR contains the postfix configuration for MITx, including a root mail alias.

Resources used: 
- https://github.mit.edu/mitx-devops/mitx-ansible/blob/master/playbooks/roles/smtp/tasks/main.yml
- https://github.mit.edu/mitx-devops/mitx-ansible/blob/master/playbooks/roles/smtp/defaults/main.yml
- https://github.mit.edu/mitx-devops/mitx-ansible/blob/master/playbooks/roles/smtp/handlers/main.yml

@blarghmatey 
