### PR TITLE
Added python 2.7 ppa back in

### DIFF
--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -18,9 +18,13 @@
                                     'edx-east/worker.yml']) -%}
 
 {% if salt.grains.get('osfinger') == 'Ubuntu-12.04' %}
-configure_git_ppa:
+configure_git_ppa_for_edx:
   pkgrepo.managed:
     - ppa: git-core/ppa
+
+configure_python_ppa_for_edx:
+  pkgrepo.managed:
+    - ppa: fkrull/deadsnakes-python2.7
 {% endif %}
 
 install_os_packages:

--- a/salt/edx/templates/ansible_env_config.yml.j2
+++ b/salt/edx/templates/ansible_env_config.yml.j2
@@ -65,6 +65,18 @@ EDXAPP_CMS_ISSUER: "{{ EDXAPP_CMS_ROOT_URL }}/oauth2"
 EDXAPP_LMS_ROOT_URL: "{{ EDXAPP_LMS_BASE_SCHEME | default('https') }}://{{ EDXAPP_LMS_BASE }}"
 EDXAPP_LMS_ISSUER: "{{ EDXAPP_LMS_ROOT_URL }}/oauth2"
 
+common_debian_pkgs:
+  - ntp
+  - acl
+  - lynx-cur
+  - logrotate
+  - rsyslog
+  - git
+  - unzip
+  - python2.7
+  - python-pip
+  - python2.7-dev
+
 edxapp_workers:
   - queue: low
     service_variant: cms


### PR DESCRIPTION
**Added python 2.7 ppa back in**
In order to allow for a full unattended build from scratch we need to
have a more up to date version of Python installed. Added the deadsnakes
PPA back in and updated the 'common_debian_pkgs' so that version 2.7.12
will be used for everything.

This had been removed because of suspicions that it was causing SciPy to
fail to build but that was not actually attributable to the newer
version of Python.

