### PR TITLE
Added proper path for xqueuewatcher requirements

### DIFF
--- a/salt/edx/templates/ansible_env_config.yml.j2
+++ b/salt/edx/templates/ansible_env_config.yml.j2
@@ -49,6 +49,8 @@ xqueue_auth_config:
 MONGODB_REPLICASET: {{ salt.pillar.get('mongodb:replset_name', 'rs0') }}
 
 {% raw %}
+xqwatcher_requirements_file: "{{ xqwatcher_code_dir }}/requirements/prod.txt"
+
 EDX_DOMAIN: '{{ EDX_NAME }}.{{ EDX_ZONE }}'
 
 # Nginx sites overrides


### PR DESCRIPTION
**Added proper path for xqueuewatcher requirements**
As of the end of 2015, the requirements file for xqueue watcher is now
located at `<src_dir>/requirements/prod.txt` instead of `<src_dir>/requirements.txt`

@bdero