### PR TITLE
Add RP pattern domains

### DIFF
--- a/salt/orchestrate/aws/dogwood_rp_elb.sls
+++ b/salt/orchestrate/aws/dogwood_rp_elb.sls
@@ -40,6 +40,15 @@ create_elb_for_edx_{{ edx_type }}:
           ttl: 60
         {% endfor %}
         {% endif %}
+        - name: dogwood-rp-{{ edx_type }}.mitx.mit.edu.
+          zone: mitx.mit.edu.
+          ttl: 60
+        - name: preview-dogwood-rp-{{ edx_type }}.mitx.mit.edu.
+          zone: mitx.mit.edu.
+          ttl: 60
+        - name: studio-dogwood-rp-{{ edx_type }}.mitx.mit.edu.
+          zone: mitx.mit.edu.
+          ttl: 60
     - health_check:
         target: 'HTTPS:443/heartbeat'
     - subnets: {{ subnet_ids }}


### PR DESCRIPTION
This adds DNS entries for RP that complement the naming scheme of QA. (i.e. dogwood-rp-live, studio-dogwood-rp-draft, etc)