### PR TITLE
Run pip as edxapp when installing gitreload

### DIFF
--- a/salt/edx/gitreload.sls
+++ b/salt/edx/gitreload.sls
@@ -64,6 +64,7 @@ install_gitreload:
     - exists_action: w
     - bin_env: {{ gr_env.VIRTUAL_ENV }}
     - upgrade: True
+    - user: edxapp
 
 {% for path in [gr_dir, gr_log_dir, gr_env.REPODIR] %}
 create_{{ path }}_directories:


### PR DESCRIPTION
Otherwise, it installs the package + it's dependencies as root in the virtualenv!