### PR TITLE
Move GA setting from env to auth config

### DIFF
--- a/salt/edx/templates/ansible_env_config.yml.j2
+++ b/salt/edx/templates/ansible_env_config.yml.j2
@@ -161,6 +161,7 @@ edxapp_generic_auth_config: &generic_auth_config
       PASSWORD: "{{ MYSQL_PASSWORD }}"
       PORT: "{{ MYSQL_PORT }}"
       USER: "{{ MYSQL_USER }}"
+  GOOGLE_ANALYTICS_ACCOUNT: "{{ EDXAPP_GOOGLE_ANALYTICS_ACCOUNT }}"
   XQUEUE_INTERFACE:
     # basic_auth:
     #   - "mitx"
@@ -323,7 +324,6 @@ edxapp_generic_env_config: &generic_env_config
   FEEDBACK_SUBMISSION_EMAIL: ""
   FILE_UPLOAD_STORAGE_BUCKET_NAME: "{{ AWS_STORAGE_BUCKET_NAME }}"
   FILE_UPLOAD_STORAGE_PREFIX: "{{ UPLOAD_STORAGE_PREFIX }}"
-  GOOGLE_ANALYTICS_ACCOUNT: "{{ EDXAPP_GOOGLE_ANALYTICS_ACCOUNT }}"
   LMS_BASE: "{{ LMS_NAME }}"
   LOCAL_LOGLEVEL: "DEBUG"
   MEDIA_URL: ""


### PR DESCRIPTION
I overlooked that `aws.py` grabs the key from `AUTH_TOKENS`. This PR fixes the GA config.