### PR TITLE
Updated ELB orchestration to add sticky sessions

### DIFF
--- a/salt/orchestrate/aws/dogwood_rp_elb.sls
+++ b/salt/orchestrate/aws/dogwood_rp_elb.sls
@@ -8,24 +8,31 @@
 {% endfor %}
 
 {% for edx_type in ['draft', 'live'] %}
+{% set elb_name = 'edx-{0}-dogwood-rp'.format(edx_type) %}
+
 create_elb_for_edx_{{ edx_type }}:
   boto_elb.present:
-    - name: edx-{{ edx_type }}-dogwood-rp
+    - name: {{ elb_name }}
     - listeners:
         - elb_port: 443
           instance_port: 443
           elb_protocol: HTTPS
           instance_protocol: HTTPS
           certificate: arn:aws:iam::610119931565:server-certificate/mitx-wildcard-cert
+          policies:
+            - {{ elb_name }}-sticky-cookie-policy
         - elb_port: 80
           instance_port: 80
           elb_protocol: HTTP
           instance_protocol: HTTP
+          policies:
+            - {{ elb_name }}-sticky-cookie-policy
     - attributes:
         cross_zone_load_balancing:
           enabled: True
-        sticky_sessions:
+        connection_draining:
           enabled: True
+          timeout: 300
     - cnames:
         {% if edx_type == 'draft' %}
         {% for domain in ['staging', 'preview', 'preview-rp', 'studio', 'studio-rp', 'gr-rp'] %}
@@ -53,6 +60,10 @@ create_elb_for_edx_{{ edx_type }}:
         target: 'HTTPS:443/heartbeat'
     - subnets: {{ subnet_ids }}
     - security_groups: {{ security_groups }}
+    - policies:
+        - policy_name: {{ elb_name }}-sticky-cookie-policy
+          policy_type: LBCookieStickinessPolicyType
+          policy: {}
 
 register_edx_{{ edx_type }}_nodes_with_elb:
   boto_elb.register_instances:


### PR DESCRIPTION
**Updated ELB orchestration to add sticky sessions**
Updated the orchestration states for the Dogwood ELBs to enable sticky
sessions for HTTP(S) connections.

@bdero