### PR TITLE
Changed hipchat post message to slack

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -116,12 +116,10 @@ terminate_backup_instance_in_{{ ENVIRONMENT }}:
         - salt: execute_enabled_backup_scripts
 
 alert_devops_channel_on_failure:
-  hipchat.send_message:
-    - room_id: DevOps
-    - from_name: Salt Master
-    - message: '@channel The scheduled backup for edX RP has failed.'
-    - notify: True
-    - api_key: {{ salt.pillar.get('hipchat_api_token') }}
-    - api_version: v1
+  slack.post_message:
+    - channel: '#devops'
+    - from_name: saltbot
+    - message: 'The scheduled backup for edX RP has failed.'
+    - api_key: {{ salt.pillar.get('slack_api_token') }}
     - onfail:
         - salt: execute_enabled_backup_scripts


### PR DESCRIPTION
A couple of services are still using hipchat notifications and given that the team has moved to Slack, we wanted to make sure that those notifications are now going to slack channels instead. This is related to [Issue #196](https://github.com/mitodl/salt-ops/issues/196). Interesting thing about the change is that we've had to use both a slack bot with its api token and the slack web hook url for Elastalert as this is how that service implemented their slack integration.