### PR TITLE
Removed symlink to course static dir in favor of ansible var

### DIFF
--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -109,15 +109,6 @@ install_edxapp_theme:
       - cmd: run_ansible
 {% endif %}
 
-create_course_asset_symlink:
-  file.symlink:
-    - name: /edx/var/edxapp/course_static
-    - target: {{ salt.pillar.get('edx:edxapp:GIT_REPO_DIR') }}
-    - makedirs: True
-    - force: True
-    - user: edxapp
-    - group: www-data
-
 {# Steps to enable git export for courses #}
 make_git_export_directory:
   file.directory:


### PR DESCRIPTION
Rather than using a symlink, updated the ansible var to point to the
proper destination for course assets.