### PR TITLE
Fixing consul agent timeout errors

### DIFF
--- a/salt/orchestrate/aws/mitx_qa.sls
+++ b/salt/orchestrate/aws/mitx_qa.sls
@@ -211,6 +211,26 @@ create_mitx_consul_security_group:
     - tags:
         Name: consul-mitx-qa
 
+create_mitx_consul_agent_security_group:
+  boto_secgroup.present:
+    - name: consul-agent-mitx-qa
+    - description: Access rules for Consul agent in {{ VPC_NAME }} stack
+    - vpc_name: {{ VPC_NAME }}
+    - rules:
+        - ip_protocol: tcp
+          from_port: 8300
+          to_port: 8301
+          source_group_name: consul-agent-mitx-qa
+        - ip_protocol: udp
+          from_port: 8300
+          to_port: 8301
+          source_group_name: consul-agent-mitx-qa
+    - require:
+        - boto_vpc: create_mitx_qa_vpc
+        - boto_secgroup: create_mitx_consul_security_group
+    - tags:
+        Name: consul-agent-mitx-qa
+
 create_rabbitmq_security_group:
   boto_secgroup.present:
     - name: rabbitmq-mitx-qa

--- a/salt/orchestrate/aws/mitx_rp.sls
+++ b/salt/orchestrate/aws/mitx_rp.sls
@@ -211,6 +211,26 @@ create_mitx_consul_security_group:
     - tags:
         Name: consul-mitx-rp
 
+create_mitx_consul_agent_security_group:
+  boto_secgroup.present:
+    - name: consul-agent-mitx-rp
+    - description: Access rules for Consul agent in {{ VPC_NAME }} stack
+    - vpc_name: {{ VPC_NAME }}
+    - rules:
+        - ip_protocol: tcp
+          from_port: 8300
+          to_port: 8301
+          source_group_name: consul-agent-mitx-rp
+        - ip_protocol: udp
+          from_port: 8300
+          to_port: 8301
+          source_group_name: consul-agent-mitx-rp
+    - require:
+        - boto_vpc: create_mitx_rp_vpc
+        - boto_secgroup: create_mitx_consul_security_group
+    - tags:
+        Name: consul-agent-mitx-rp
+
 create_rabbitmq_security_group:
   boto_secgroup.present:
     - name: rabbitmq-mitx-rp

--- a/salt/orchestrate/edx/init.sls
+++ b/salt/orchestrate/edx/init.sls
@@ -27,6 +27,8 @@ generate_edx_cloud_map_file:
               'default', vpc_name='MITx QA') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-qa', vpc_name='MITx QA') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-qa', vpc_name='MITx QA') }}
         subnetids: {{ subnet_ids }}
         app_types:
           draft: 2

--- a/salt/orchestrate/edx/rp.sls
+++ b/salt/orchestrate/edx/rp.sls
@@ -24,9 +24,11 @@ generate_edx_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
               'edx-mitx-rp', vpc_name='MITx RP') }}
           - {{ salt.boto_secgroup.get_group_id(
-              'default', vpc_name='MITx RP) }}
+              'default', vpc_name='MITx RP') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-rp', vpc_name='MITx RP') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-rp', vpc_name='MITx RP') }}
         subnetids: {{ subnet_ids }}
         app_types:
           draft: 4

--- a/salt/orchestrate/edx/services/consul.sls
+++ b/salt/orchestrate/edx/services/consul.sls
@@ -26,6 +26,8 @@ generate_cloud_map_file:
             'consul-mitx-qa', vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-qa', vpc_name=VPC_NAME) }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-qa', vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids }}
     - require:
         - file: load_consul_cloud_profile

--- a/salt/orchestrate/edx/services/elasticsearch.sls
+++ b/salt/orchestrate/edx/services/elasticsearch.sls
@@ -24,6 +24,8 @@ generate_elasticsearch_cloud_map_file:
             'elasticsearch-mitx-qa', vpc_name='MITx QA') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-qa', vpc_name='MITx QA') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-qa', vpc_name='MITx QA') }}
         subnetids: {{ subnet_ids }}
         volume_size: 200
         tags:

--- a/salt/orchestrate/edx/services/mongodb.sls
+++ b/salt/orchestrate/edx/services/mongodb.sls
@@ -23,6 +23,8 @@ generate_mongodb_cloud_map_file:
             'mongodb-mitx-qa', vpc_name='MITx QA') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-qa', vpc_name='MITx QA') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-qa', vpc_name='MITx QA') }}
         subnetids: {{ subnet_ids }}
     - require:
         - file: load_mongodb_cloud_profile

--- a/salt/orchestrate/edx/services/rabbitmq.sls
+++ b/salt/orchestrate/edx/services/rabbitmq.sls
@@ -23,6 +23,8 @@ generate_rabbitmq_cloud_map_file:
             'rabbitmq-mitx-qa', vpc_name='MITx QA') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-qa', vpc_name='MITx QA') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-qa', vpc_name='MITx QA') }}
         subnetids: {{ subnet_ids }}
 
 ensure_instance_profile_exists_for_rabbitmq:

--- a/salt/orchestrate/edx/services/rp/consul.sls
+++ b/salt/orchestrate/edx/services/rp/consul.sls
@@ -26,6 +26,8 @@ generate_cloud_map_file:
             'consul-mitx-rp', vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-rp', vpc_name=VPC_NAME) }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-rp', vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids }}
     - require:
         - file: load_consul_cloud_profile

--- a/salt/orchestrate/edx/services/rp/elasticsearch.sls
+++ b/salt/orchestrate/edx/services/rp/elasticsearch.sls
@@ -24,6 +24,8 @@ generate_elasticsearch_cloud_map_file:
             'elasticsearch-mitx-rp', vpc_name='MITx RP') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-rp', vpc_name='MITx RP') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-rp', vpc_name='MITx RP') }}
         subnetids: {{ subnet_ids }}
         volume_size: 200
         tags:

--- a/salt/orchestrate/edx/services/rp/mongodb.sls
+++ b/salt/orchestrate/edx/services/rp/mongodb.sls
@@ -23,6 +23,8 @@ generate_mongodb_cloud_map_file:
             'mongodb-mitx-rp', vpc_name='MITx RP') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-rp', vpc_name='MITx RP') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-rp', vpc_name='MITx RP') }}
         subnetids: {{ subnet_ids }}
     - require:
         - file: load_mongodb_cloud_profile

--- a/salt/orchestrate/edx/services/rp/rabbitmq.sls
+++ b/salt/orchestrate/edx/services/rp/rabbitmq.sls
@@ -23,6 +23,8 @@ generate_rabbitmq_cloud_map_file:
             'rabbitmq-mitx-rp', vpc_name='MITx RP') }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-mitx-rp', vpc_name='MITx RP') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-mitx-rp', vpc_name='MITx RP') }}
         subnetids: {{ subnet_ids }}
 
 ensure_instance_profile_exists_for_rabbitmq:


### PR DESCRIPTION
The consul agents need to have port 8301 open in order for the gossip
protocol to operate properly. Because it was not open it causes
occasional dropouts leading to erroneous error alerts in DataDog. This
commit adds a new security group to expose port 8300 and 8301 to all
nodes running the consul agent.