### PR TITLE
Updating instance sizes to reflect actual usage patterns

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
+++ b/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
@@ -6,6 +6,9 @@ elasticsearch:
   ssh_interface: private_ips
   block_device_mappings:
     - DeviceName: /dev/xvda
+      Ebs.VolumeSize: 20
+      Ebs.VolumeType: gp2
+    - DeviceName: /dev/xvdb
       Ebs.VolumeSize: 400
       Ebs.VolumeType: gp2
   ebs_optimized: True

--- a/salt/orchestrate/aws/cloud_profiles/mongodb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/mongodb.conf
@@ -1,13 +1,16 @@
 mongodb:
   provider: mitx
-  size: m4.large
+  size: t2.medium
   image: ami-49e5cb5e
   ssh_username: admin
   ssh_interface: private_ips
   script_args: -U -Z -P -A salt.private.odl.mit.edu
   block_device_mappings:
     - DeviceName: /dev/xvda
-      Ebs.VolumeSize: 400
+      Ebs.VolumeSize: 20
+      Ebs.VolumeType: gp2
+    - DeviceName: /dev/xvdb
+      Ebs.VolumeSize: 250
       Ebs.VolumeType: gp2
   ebs_optimized: True
   iam_profile: mongodb-instance-role

--- a/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
+++ b/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
@@ -1,6 +1,6 @@
 rabbitmq:
   provider: mitx
-  size: m3.medium
+  size: t2.medium
   image: ami-49e5cb5e
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/map_templates/elasticsearch.yml
+++ b/salt/orchestrate/aws/map_templates/elasticsearch.yml
@@ -1,6 +1,7 @@
 elasticsearch:
   {% for id_num in range(3) %}
   - elasticsearch-{{ environment_name }}-{{ id_num }}:
+      size: t2.medium
       network_interfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: True
@@ -8,6 +9,9 @@ elasticsearch:
           SecurityGroupId: {{ securitygroupid }}
       block_device_mappings:
         - DeviceName: /dev/xvda
+          Ebs.VolumeSize: {{ volume_size }}
+          Ebs.VolumeType: gp2
+        - DeviceName: /dev/xvdb
           Ebs.VolumeSize: {{ volume_size }}
           Ebs.VolumeType: gp2
       tag:

--- a/salt/orchestrate/aws/map_templates/mongodb.yml
+++ b/salt/orchestrate/aws/map_templates/mongodb.yml
@@ -1,6 +1,7 @@
 mongodb:
   {% for id_num in range(3) %}
   - mongodb-{{ environment_name }}-{{ id_num }}:
+      size: t2.medium
       network_interfaces:
         - DeviceIndex: 0
           AssociatePublicIpAddress: True

--- a/salt/orchestrate/edx/services/elasticsearch.sls
+++ b/salt/orchestrate/edx/services/elasticsearch.sls
@@ -42,6 +42,35 @@ deploy_elasticsearch_nodes:
     - require:
         - file: generate_elasticsearch_cloud_map_file
 
+format_data_drive:
+  salt.function:
+    - tgt: 'G@roles:elasticsearch and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - blockdev.formatted
+    - kwarg:
+        name: /dev/xvdb
+        fs_type: ext4
+    - require:
+        - salt: deploy_elasticsearch_nodes
+
+mount_data_drive:
+  salt.function:
+    - tgt: 'G@roles:elasticsearch and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - mount.mounted
+    - kwarg:
+        name: /var/lib/elasticsearch
+        device: /dev/xvdb
+        fstype: ext4
+        mkmnt: True
+        opts: 'relatime,user'
+    - require:
+        - salt: format_data_drive
+
 load_pillar_data_on_mitx_elasticsearch_nodes:
   salt.function:
     - name: saltutil.refresh_pillar


### PR DESCRIPTION
After viewing the actual usage of disk and memory resources it was
evident that most of the services are running on oversized
instances. Updated the profiles to use smaller and cheaper instance types.