### PR TITLE
Configure Hubblestack Pulsar

### DIFF
--- a/salt/hubblestack/pulsar_dependency.sls
+++ b/salt/hubblestack/pulsar_dependency.sls
@@ -1,0 +1,3 @@
+install_pulsar_dependency:
+  pkg.installed:
+    - name: python-pyinotify

--- a/salt/hubblestack/pulsar_dependency.sls
+++ b/salt/hubblestack/pulsar_dependency.sls
@@ -1,3 +1,0 @@
-install_pulsar_dependency:
-  pkg.installed:
-    - name: python-pyinotify

--- a/salt/reactors/edx/pulsar_mitx.sls
+++ b/salt/reactors/edx/pulsar_mitx.sls
@@ -1,0 +1,8 @@
+pulsar_mitx:
+  local.slack.post_message:
+    - tgt: {{ data['id'] }}
+    - kwarg:
+       channel: "#devops"
+       message: "Hubblestack Pulsar FMI - Detected change - Host:`{{ data['id'] }}` - File modified:`{{ data['path'] }}` - User:`{{ data['stats']['user'] }}`"
+       from_name: "saltbot"
+       api_key: {{ salt.pillar.get('slack_api_token') }}

--- a/salt/reactors/edx/pulsar_mitx.sls
+++ b/salt/reactors/edx/pulsar_mitx.sls
@@ -1,8 +1,9 @@
 pulsar_mitx:
   local.slack.post_message:
-    - tgt: {{ data['id'] }}
+    - tgt: 'roles:master'
+    - expr_form: grain
     - kwarg:
-       channel: "#devops"
-       message: "Hubblestack Pulsar FMI - Detected change - Host:`{{ data['id'] }}` - File modified:`{{ data['path'] }}` - User:`{{ data['stats']['user'] }}`"
-       from_name: "saltbot"
-       api_key: {{ salt.pillar.get('slack_api_token') }}
+        channel: "#devops"
+        message: "Hubblestack Pulsar FMI - Detected change - Host:`{{ data['id'] }}` - File modified:`{{ data['path'] }}` - Details: `{{ data }}`"
+        from_name: "saltbot"
+        api_key: {{ salt.pillar.get('slack_api_token') }}

--- a/salt/reactors/edx/pulsar_mitx.sls
+++ b/salt/reactors/edx/pulsar_mitx.sls
@@ -4,6 +4,5 @@ pulsar_mitx:
     - expr_form: grain
     - kwarg:
         channel: "#devops"
-        message: "Hubblestack Pulsar FMI - Detected change - Host:`{{ data['id'] }}` - File modified:`{{ data['path'] }}` - Details: `{{ data }}`"
+        message: "Hubblestack Pulsar FIM - Detected change - Host:`{{ data['id'] }}` - File modified:`{{ data['path'] }}` - Details: `{{ data }}`"
         from_name: "saltbot"
-        api_key: {{ salt.pillar.get('slack_api_token') }}

--- a/salt/utils/install_pip.sls
+++ b/salt/utils/install_pip.sls
@@ -1,6 +1,6 @@
 {% set python_dependencies = salt.grains.filter_by({
     'default': {
-      'python_libs': ['testinfra']
+      'python_libs': ['testinfra', 'python-pyinotify']
     },
     'Debian': {
       'pkgs': ['python-dev', 'python', 'curl'],

--- a/salt/utils/install_pip.sls
+++ b/salt/utils/install_pip.sls
@@ -1,6 +1,6 @@
 {% set python_dependencies = salt.grains.filter_by({
     'default': {
-      'python_libs': ['testinfra', 'python-pyinotify']
+      'python_libs': ['testinfra', 'pyinotify']
     },
     'Debian': {
       'pkgs': ['python-dev', 'python', 'curl'],


### PR DESCRIPTION
### What are the relevant tickets?
[Issue#166](https://github.com/mitodl/salt-ops/issues/166)

### What does this PR do?
Hubblestack Pulsar is used for file integrity monitoring and in this case, we will be using it for the mitx instances. This PR does the following:
- Created a hubblestack folder that includes a simple state file to install python-pyinotify on the minion
- Added a reactor for edx that posts a slack message anytime there's a modification to a list of watched files