### PR TITLE
Added state to create Vault roles based on pillar data

### DIFF
--- a/salt/vault/roles.sls
+++ b/salt/vault/roles.sls
@@ -1,0 +1,22 @@
+{% set roles = salt.pillar.get('vault:roles') %}
+{% for role_id, role in roles.items() %}
+{% for environment in role.environments %}
+{% set env_data = salt.pillar.get('environments:{}'.format(environment), {}) %}
+  {% for purpose in env_data.purposes %}
+create_{{ role.name }}_role_in_{{ role.backend }}_for_{{ purpose }}_in_{{ environment }}:
+  vault.role_present:
+    - name: {{ role.name }}-{{ purpose }}
+    - mount_point: {{ role.backend }}-{{ environment }}
+    - options:
+        {% for key, value in role.options.items() %}
+        {% if key == role.get('formatted_option', '') %}
+        {{ key }}: |
+            {{ value|replace('%purpose%', purpose.replace('-', '_')) }}
+        {% else %}
+        {{ key }}: |
+            {{ value }}
+        {% endif %}
+        {% endfor %}
+  {% endfor %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
In order for us to be able to handle multiple vault roles across
different environments and business needs I created a templated state
that will use information from pillar to create the appropriate state
definitions for the various backend roles that are required.