### PR TITLE
Updated restore scripts to use force option

### DIFF
--- a/salt/backups/templates/restore_consul.sh
+++ b/salt/backups/templates/restore_consul.sh
@@ -7,6 +7,7 @@ SNAPFILE=`aws s3 ls odl-operations-backups/{{ backupdir }}/ | sort | tail -n 1 |
 
 aws s3 cp s3+http://odl-operations-backups/{{ settings.get('directory', 'consul') }}/$SNAPFILE  /{{ backupdir }}/$SNAPFILE
 
-/usr/local/bin/consul snapshot save -stale -token={{ settings.acl_token }} {{ backupdir }}/$SNAPFILE
+/usr/local/bin/consul snapshot inspect -token={{ settings.acl_token }} {{ backupdir }}/$SNAPFILE
+/usr/local/bin/consul snapshot restore -token={{ settings.acl_token }} {{ backupdir }}/$SNAPFILE
 
 rm {{ backupdir }}/$SNAPFILE

--- a/salt/backups/templates/restore_course_assets.sh
+++ b/salt/backups/templates/restore_course_assets.sh
@@ -8,4 +8,4 @@ mountpoint /mnt/efs || mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore \
           --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'course_assets') }}/ \
-          --tempdir /backups {{ backupdir }}/
+          --force --tempdir /backups {{ backupdir }}/

--- a/salt/backups/templates/restore_mongodb.sh
+++ b/salt/backups/templates/restore_mongodb.sh
@@ -6,7 +6,7 @@ mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore\
           --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mongodb') }}/ \
-          --tempdir /backups {{ backupdir }}/
+          --force --tempdir /backups {{ backupdir }}/
 
 /usr/bin/mongorestore --host {{ settings.host }} \
                       --port {{ settings.get('port', 27017) }} \

--- a/salt/backups/templates/restore_mysql.sh
+++ b/salt/backups/templates/restore_mysql.sh
@@ -6,7 +6,7 @@ mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore \
           --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/ \
-          --tempdir /backups  {{ backupdir }}/
+          --force --tempdir /backups  {{ backupdir }}/
 
 /usr/bin/mysql --host {{ settings.host }} \
                --port {{ settings.get('port', 3306) }} \


### PR DESCRIPTION
Updated the restore scripts to use the `--force` option to fix errors
when loading course assets on QA environment. Also updated the restore
script for Consul to actually perform a restore.