### PR TITLE
Tests to verify status and connectivity of edx application

### DIFF
--- a/salt/edx/tests/test_edxapp_running.sls
+++ b/salt/edx/tests/test_edxapp_running.sls
@@ -22,7 +22,7 @@ our configurations. Test the following:
     'lms': 'tcp://0.0.0.0:8000',
     'gitreload_service': 'tcp://0.0.0.0:8095',
     'xqueue': 'tcp://0.0.0.0:18040',
-    'forum': 'unix:///edx/var/forum/forum.sock',
+    'forum': 'tcp://0.0.0.0:4567',
     'rabbitmq': 'tcp://rabbitmq.service.consul:15672',
     'elasticsearch': 'tcp://elasticsearch.service.consul:9200',
     'mysql':'tcp://mysql.service.consul:3306',
@@ -51,7 +51,7 @@ test_edxapp_supervisor_{{ sv_service }}:
 
 {% for connection in socket_connections %}
 test_edxapp_{{ connection }}:
-  testinfra.sockethost:
+  testinfra.socket_host:
     - name: {{ connection }}
     - is_listening: True
 {% endfor %}
@@ -70,17 +70,20 @@ test_edxapp_cms:
 
 # Check if AWS EFS is mounted
 test_edxapp_efs_mount:
-  testinfra.mountpoint:
+  testinfra.mount_point:
     - name: '/mnt/data'
+    - exists: True
     - filesystem:
         expected: nfs4
         comparison: eq
 
-{% for entry in lms_env %}
-test_edxapp_lms_env_{{ entry }}:
+{% for attribute, value in lms_env.items() %}
+test_edxapp_lms_env_{{ value }}:
   testinfra.file:
     - name: '/edx/app/edxapp/lms.env.json'
-    - contains: {{ entry }}
-    - expected: {{ entry }}
-    - comparison: eq
+    - exists: True
+    - contains:
+        parameter: {{ value }}
+        expected: True
+        comparison: is_
 {% endfor %}

--- a/salt/edx/tests/test_edxapp_running.sls
+++ b/salt/edx/tests/test_edxapp_running.sls
@@ -49,11 +49,11 @@ test_edxapp_supervisor_{{ sv_service }}:
     - is_running: True
 {% endfor %}
 
-{% for connection in socket_connections %}
-test_edxapp_{{ connection }}:
+{% for attribute, value in socket_connections.items() %}
+test_edxapp_{{ attribute }}:
   testinfra.socket_host:
-    - name: {{ connection }}
-    - is_listening: True
+    - name: {{ value }}
+    - is_reachable: True
 {% endfor %}
 
 {% for service in running_services %}
@@ -78,7 +78,7 @@ test_edxapp_efs_mount:
         comparison: eq
 
 {% for attribute, value in lms_env.items() %}
-test_edxapp_lms_env_{{ value }}:
+test_edxapp_lms_env_{{ attribute }}:
   testinfra.file:
     - name: '/edx/app/edxapp/lms.env.json'
     - exists: True

--- a/salt/edx/tests/test_edxapp_running.sls
+++ b/salt/edx/tests/test_edxapp_running.sls
@@ -49,8 +49,8 @@ test_edxapp_supervisor_{{ sv_service }}:
     - is_running: True
 {% endfor %}
 
-{% for attribute, value in socket_connections.items() %}
-test_edxapp_{{ attribute }}:
+{% for connection, value in socket_connections.items() %}
+test_edxapp_{{ connection }}:
   testinfra.socket_host:
     - name: {{ value }}
     - is_reachable: True

--- a/salt/edx/tests/test_edxapp_running.sls
+++ b/salt/edx/tests/test_edxapp_running.sls
@@ -1,0 +1,86 @@
+#!jinja|yaml
+
+{# Test to verify that the edxapp is funcitional and configured with some of
+our configurations. Test the following:
+- edxapp supervisor services are running
+- edxapp instance can reach select services
+- services that edxapp relies on locally
+- edxapp:cms service is only running on edx-draft
+- AWS EBS data repo is mounted
+- spot check custom vars are in lms.{env|auth} #}
+
+
+{% set supervisor_services = [
+    'edxapp:lms',
+    'forum',
+    'xqueue',
+    'xqueue_consumer'
+  ] %}
+
+{% set socket_connections = {
+    'ssl': 'tcp://0.0.0.0:443',
+    'lms': 'tcp://0.0.0.0:8000',
+    'gitreload_service': 'tcp://0.0.0.0:8095',
+    'xqueue': 'tcp://0.0.0.0:18040',
+    'forum': 'unix:///edx/var/forum/forum.sock',
+    'rabbitmq': 'tcp://rabbitmq.service.consul:15672',
+    'elasticsearch': 'tcp://elasticsearch.service.consul:9200',
+    'mysql':'tcp://mysql.service.consul:3306',
+    'mongodb': 'tcp://mongodb-master.service.consul:27017',
+  } %}
+
+{% set running_services = [
+    'nginx',
+    'fluentd',
+    'supervisor',
+    'gitreload'
+  ] %}
+
+{% set lms_env = {
+  'mitx_email': salt.pillar.get('edx:ansible_vars:edxapp_generic_env_config:DEFAULT_FROM_EMAIL'),
+  'mitx_theme': salt.pillar.get('edx:ansible_vars:edxapp_generic_env_config:THEME_NAME'),
+  'rabbitmq_service': salt.pillar.get('edx:ansible_vars:xqueue_env_config:RABBIT_HOST')
+  } %}
+
+{% for sv_service in supervisor_services %}
+test_edxapp_supervisor_{{ sv_service }}:
+  testinfra.supervisor:
+    - name: {{ sv_service }}
+    - is_running: True
+{% endfor %}
+
+{% for connection in socket_connections %}
+test_edxapp_{{ connection }}:
+  testinfra.sockethost:
+    - name: {{ connection }}
+    - is_listening: True
+{% endfor %}
+
+{% for service in running_services %}
+test_edxapp_{{ service }}:
+  testinfra.service:
+    - name: {{ service }}
+    - is_running: True
+{% endfor %}
+
+test_edxapp_cms:
+  testinfra.supervisor:
+      - name: 'edxapp:cms'
+      - is_running: True
+
+# Check if AWS EFS is mounted
+test_edxapp_efs_mount:
+  testinfra.mountpoint:
+    - name: '/mnt/data'
+    - filesystem:
+        expected: nfs4
+        comparison: eq
+
+{% for entry in lms_env %}
+test_edxapp_lms_env_{{ entry }}:
+  testinfra.file:
+    - name: '/edx/app/edxapp/lms.env.json'
+    - contains: {{ entry }}
+    - expected: {{ entry }}
+    - comparison: eq
+{% endfor %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -74,6 +74,7 @@ base:
     - edx.gitreload
     - edx.prod
     - edx.run_ansible
+    - edx.tests
     - fluentd
     - fluentd.plugins
     - fluentd.config


### PR DESCRIPTION
### What are the relevant tickets?
[Issue#248](https://github.com/mitodl/salt-ops/issues/248)

### What does this PR do?
Run tests specified in issue#248 to verify that the edxapp is running as expected. This PR relies on a new module (sockethost) added to the testinfra library and thus needs to be in place for all tests to work properly.

### How to test?
Run state file on one of the edx nodes