### PR TITLE
Additional options to backup scripts

### DIFF
--- a/salt/backups/templates/backup_course_assets.sh
+++ b/salt/backups/templates/backup_course_assets.sh
@@ -2,12 +2,16 @@
 set -e
 
 {% set backupdir = '/mnt/efs/{}'.format(settings.get('directory', 'course_assets')) %}
+{% set cachedir = '/mnt/efs/.cache/course_assets' %}
 
 mkdir -p /mnt/efs
 mountpoint /mnt/efs || mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ settings.efs_id }}.efs.us-east-1.amazonaws.com:/ /mnt/efs
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
+          --s3-use-ia \
+          --archive-dir {{ cachedir }} \
+          --full-if-older-than 1W \
           --allow-source-mismatch --tempdir /backups \
           s3+http://odl-operations-backups/{{ settings.get('directory', 'course_assets') }}/
 

--- a/salt/backups/templates/backup_mongodb.sh
+++ b/salt/backups/templates/backup_mongodb.sh
@@ -2,6 +2,7 @@
 set -e
 
 {% set backupdir = '/backups/{}'.format(settings.get('directory', 'mongodb')) %}
+{% set cacehdir = '/backups/.cache/{}'.format(settings.get('directory', 'mongodb')) %}
 mkdir -p {{ backupdir }}
 
 /usr/bin/mongodump --host {{ settings.host }} \
@@ -12,6 +13,9 @@ mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
+          --s3-use-ia \
+          --archive-dir {{ cachedir }} \
+          --full-if-older-than 1W \
           --allow-source-mismatch --tempdir /backups \
           s3+http://odl-operations-backups/{{ settings.get('directory', 'mongodb') }}/
 

--- a/salt/backups/templates/backup_mysql.sh
+++ b/salt/backups/templates/backup_mysql.sh
@@ -2,6 +2,7 @@
 set -e
 
 {% set backupdir = '/backups/{}'.format(settings.get('directory', 'mysql')) %}
+{% set cacehdir = '/backups/.cache/{}'.format(settings.get('directory', 'mysql')) %}
 mkdir -p {{ backupdir }}
 
 /usr/bin/mysqldump --host {{ settings.host }} \
@@ -14,6 +15,9 @@ mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
+          --s3-use-ia \
+          --archive-dir {{ cachedir }} \
+          --full-if-older-than 1W \
           --allow-source-mismatch --tempdir /backups \
           s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/
 


### PR DESCRIPTION
Included the following new duplicity options:
- archive-dir pointed archive dir to backup disk since that's the larger one
- full-if-older-than doing full backups once a week
- s3-use-ia infrequent access s3 and is geared for backup data