### PR TITLE
Added step to backup routines to alert on successful completion

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -123,3 +123,13 @@ alert_devops_channel_on_failure:
     - api_key: {{ salt.pillar.get('slack_api_token') }}
     - onfail:
         - salt: execute_enabled_backup_scripts
+
+alert_devops_channel_on_success:
+  slack.post_message:
+    - channel: '#devops'
+    - from_name: saltbot
+    - message: 'The scheduled backup for edX RP has succeeded.'
+    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - require:
+        - salt: execute_enabled_backup_scripts
+        - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -125,3 +125,13 @@ alert_devops_channel_on_failure:
     - api_key: {{ salt.pillar.get('slack_api_token') }}
     - onfail:
         - salt: execute_enabled_backup_scripts
+
+alert_devops_channel_on_failure:
+  slack.post_message:
+    - channel: '#devops'
+    - from_name: saltbot
+    - message: 'The scheduled restore for edX {{ ENVIRONMENT }} has failed.'
+    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - require:
+        - salt: execute_enabled_backup_scripts
+        - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -120,3 +120,13 @@ alert_devops_channel_on_failure:
     - api_key: {{ salt.pillar.get('slack_api_token') }}
     - onfail:
         - salt: execute_enabled_backup_scripts
+
+alert_devops_channel_on_success:
+  slack.post_message:
+    - channel: '#devops'
+    - from_name: saltbot
+    - message: 'The scheduled backup for operations services has succeeded.'
+    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - require:
+        - salt: execute_enabled_backup_scripts
+        - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}


### PR DESCRIPTION
In order to know that the lack of a failure message doesn't just mean
that the backup didn't get executed then we would like to be notified
on successful completion of the orchestrate routines as well. This PR
adds a step to the backup and restore scripts to notify the devops
channel on completion whether the result is success or failure.