### PR TITLE
Added state to handle generic backends for business units

### DIFF
--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -8,3 +8,11 @@ enable_mitx_aws_secret_backend:
     - backend_type: aws
     - mount_point: aws-mitx
     - description: Backend to dynamically create IAM credentials
+
+{% for unit in salt.pillar.get('business_units', []) %}
+enable_generic_backend_for_{{ unit }}:
+  vault.secret_backend_enabled:
+    - backend_type: generic
+    - mount_point: secret-{{ unit }}
+    - description: Secrets storage for values pertaining to {{ unit }}
+{% endfor %}


### PR DESCRIPTION
In order to properly segregate our generic secrets I added a state to enumerate the business units that we are dealing with and mount generic secret backends for each one.