### PR TITLE
Updated the states for the secret backends to use new params

### DIFF
--- a/salt/orchestrate/edx/services/mongodb.sls
+++ b/salt/orchestrate/edx/services/mongodb.sls
@@ -127,7 +127,7 @@ configure_vault_mongodb_backend:
     - backend_type: mongodb
     - description: Backend to create dynamic MongoDB credentials for {{ ENVIRONMENT }}
     - mount_point: mongodb-{{ ENVIRONMENT }}
-    - lease_max: 4368h
-    - lease: 4368h
+    - ttl_max: 4368h
+    - ttl_default: 4368h
     - connection_config:
         uri: "mongodb://admin:{{ mongo_admin_password }}@mongodb-master.service.{{ ENVIRONMENT }}.consul:27017/admin"

--- a/salt/orchestrate/edx/services/rabbitmq.sls
+++ b/salt/orchestrate/edx/services/rabbitmq.sls
@@ -87,5 +87,5 @@ configure_vault_rabbitmq_backend:
         connection_uri: "http://rabbitmq.service.{{ ENVIRONMENT }}.consul:15672"
         username: admin
         password: {{ rabbit_admin_password }}
-    - lease: 4368h
-    - lease_max: 4368h
+    - ttl_max: 4368h
+    - ttl_default: 4368h

--- a/salt/orchestrate/edx/services/rds.sls
+++ b/salt/orchestrate/edx/services/rds.sls
@@ -42,7 +42,7 @@ configure_vault_mysql_backend:
     - backend_type: mysql
     - description: Backend to create dynamic MySQL credentials for {{ ENVIRONMENT }}
     - mount_point: mysql-{{ ENVIRONMENT }}
-    - lease_max: 4368h
-    - lease: 4368h
+    - ttl_max: 4368h
+    - ttl_default: 4368h
     - connection_config:
         connection_url: "{{ master_user }}:{{ master_pass }}@tcp(mysql.service.{{ ENVIRONMENT }}.consul:3306)"


### PR DESCRIPTION
The vault state extension was updated to expose the `ttl_max` and
`ttl_default` parameters for tuning the mount points. Updated
orchestrate states to take advantage of that fact.