### PR TITLE
Minor bug fixes

### DIFF
--- a/salt/master_utils/libgit.sls
+++ b/salt/master_utils/libgit.sls
@@ -22,7 +22,8 @@
             'make',
             'openssl-devel',
             'libssh-devel',
-            'python-pip',
+            'python2-pip',
+            'python-cffi',
             'python-devel'
         ]
     }
@@ -39,7 +40,7 @@ download_libgit_source:
     - source: https://github.com/libgit2/libgit2/archive/{{ libgit.tag }}.tar.gz
     - source_hash: {{ libgit.hash }}
     - archive_format: tar
-    - tar_options: xv
+    - options: xv
 
 compile_libgit:
   cmd.run:
@@ -52,6 +53,6 @@ compile_libgit:
 
 install_pygit:
   pip.installed:
-    - name: pygit2
+    - name: pygit2 == {{ libgit.tag.strip('v') }}
     - require:
         - cmd: compile_libgit


### PR DESCRIPTION
RHEL/CentOS python packages are changing names and it is being rolled out in phases. The pip package has been changed to python2-pip. 

libgit now requires python-cffi, which is still on the old naming scheme.

Salt has replaced tar_options with options. tar_options is deprecated now.

The pip install command was missing the version number which could lead to a failure during installation if the libgit version being built is not the most recent.