### PR TITLE
Added state to handle refreshing vault token on master

### DIFF
--- a/salt/vault/refresh_master_token.sls
+++ b/salt/vault/refresh_master_token.sls
@@ -1,0 +1,18 @@
+refresh_master_vault_token:
+  vault.ec2_minion_authenticated:
+    - role: salt-master
+    - is_master: True
+
+restart_salt_minion_process:
+  cmd.run:
+    - name: 'salt-call --local service.restart salt-minion'
+    - bg: True
+    - onchanges:
+        - vault: refresh_master_vault_token
+
+restart_salt_master_process:
+  cmd.run:
+    - name: 'salt-call --local service.restart salt-master'
+    - bg: True
+    - onchanges:
+        - vault: refresh_master_vault_token


### PR DESCRIPTION
In order to be able to use Vault the master needs to have a valid
token. This state will execute a token refresh and then restart the
salt processes to reread the config.