### PR TITLE
Delete old edx log files

### DIFF
--- a/salt/edx/maintenance_tasks.sls
+++ b/salt/edx/maintenance_tasks.sls
@@ -1,0 +1,4 @@
+delete_edx_logs_older_than_30_days:
+  cmd.run:
+    - name: |
+        find /edx/var/log -type f  -mtime +30 -name "*.gz" -exec rm -f {} \;

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -75,6 +75,7 @@ base:
     - edx.prod
     - edx.run_ansible
     - edx.tests
+    - edx.maintenance_tasks
     - fluentd
     - fluentd.plugins
     - fluentd.config


### PR DESCRIPTION
- gzipped files older than 30 days should be deleted on a weekly schedule given the limited storage restrictions we have on the edx instances
- updated top file