### PR TITLE
Refactor backup/restore and slack secret from vault

### DIFF
--- a/salt/backups/templates/backup_course_assets.sh
+++ b/salt/backups/templates/backup_course_assets.sh
@@ -11,7 +11,7 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
           --archive-dir {{ cachedir }} \
           --full-if-older-than 1W \
-          --allow-source-mismatch --tempdir /backups \
+          --allow-source-mismatch --tempdir /backups/tmp/ \
           s3+http://odl-operations-backups/{{ settings.get('directory', 'course_assets') }}/
 
 umount /mnt/efs

--- a/salt/backups/templates/backup_mongodb.sh
+++ b/salt/backups/templates/backup_mongodb.sh
@@ -15,7 +15,7 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
           --archive-dir {{ cachedir }} \
           --full-if-older-than 1W \
-          --allow-source-mismatch --tempdir /backups \
+          --allow-source-mismatch --tempdir /backups/tmp/ \
           s3+http://odl-operations-backups/{{ settings.get('directory', 'mongodb') }}/
 
 rm -rf {{ backupdir }}

--- a/salt/backups/templates/backup_mysql.sh
+++ b/salt/backups/templates/backup_mysql.sh
@@ -18,7 +18,6 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --archive-dir {{ cachedir }} \
           --full-if-older-than 1W \
           --allow-source-mismatch --tempdir /backups/tmp/ \
-          s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/ \
-          {{ settings.database }}/
+          s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}
 
 rm -rf {{ backupdir }}

--- a/salt/backups/templates/backup_mysql.sh
+++ b/salt/backups/templates/backup_mysql.sh
@@ -17,7 +17,8 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
           --archive-dir {{ cachedir }} \
           --full-if-older-than 1W \
-          --allow-source-mismatch --tempdir /backups \
-          s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/
+          --allow-source-mismatch --tempdir /backups/tmp/ \
+          s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/ \
+          {{ settings.database }}/
 
 rm -rf {{ backupdir }}

--- a/salt/backups/templates/restore_mongodb.sh
+++ b/salt/backups/templates/restore_mongodb.sh
@@ -2,12 +2,13 @@
 set -e
 
 {% set backupdir = '/backups/{}'.format(settings.get('directory', 'mongodb')) %}
+{% set cachedir = '/backups/.cache/{}'.format(settings.get('directory', 'mongodb')) %}
 mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore\
           --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mongodb') }}/ \
-          --archive-dir /backups/.cache \
-          --force --tempdir /backups {{ backupdir }}/
+          --archive-dir {{ cachedir }}
+          --force --tempdir /backups/tmp/ {{ backupdir }}
 
 /usr/bin/mongorestore --host {{ settings.host }} \
                       --port {{ settings.get('port', 27017) }} \

--- a/salt/backups/templates/restore_mysql.sh
+++ b/salt/backups/templates/restore_mysql.sh
@@ -2,12 +2,13 @@
 set -e
 
 {% set backupdir = '/backups/{}'.format(settings.get('directory', 'mysql')) %}
+{% set cachedir = '/backups/.cache/{}'.format(settings.get('directory', 'mysql')) %}
 mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore \
           --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/ \
-          --archive-dir /backups/.cache \
-          --force --tempdir /backups  {{ backupdir }}/
+          {{ settings.database }}/ --archive-dir {{ cachedir }} \
+          --force --tempdir /backups/tmp/ {{ backupdir }}/{{ settings.database }}
 
 /usr/bin/mysql --host {{ settings.host }} \
                --port {{ settings.get('port', 3306) }} \

--- a/salt/backups/templates/restore_mysql.sh
+++ b/salt/backups/templates/restore_mysql.sh
@@ -6,8 +6,8 @@ set -e
 mkdir -p {{ backupdir }}
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore \
-          --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}/ \
-          {{ settings.database }}/ --archive-dir {{ cachedir }} \
+          --s3-use-server-side-encryption s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }} \
+          --archive-dir {{ cachedir }} \
           --force --tempdir /backups/tmp/ {{ backupdir }}/{{ settings.database }}
 
 /usr/bin/mysql --host {{ settings.host }} \

--- a/salt/edx/maintenance_tasks.sls
+++ b/salt/edx/maintenance_tasks.sls
@@ -1,4 +1,6 @@
 delete_edx_logs_older_than_30_days:
   cmd.run:
-    - name: |
-        find /edx/var/log -type f  -mtime +30 -name "*.gz" -exec rm -f {} \;
+    - name: >-
+        find /edx/var/log -not -path "/edx/var/log/tracking/*"
+        -type f \( -name "*.gz" -o -name "lms-stderr.log.*" \)
+        -mtime +30 -delete

--- a/salt/orchestrate/aws/cloud_profiles/backup_host.conf
+++ b/salt/orchestrate/aws/cloud_profiles/backup_host.conf
@@ -2,6 +2,7 @@ backup_host:
   provider: mitx
   size: t2.medium
   image: ami-49e5cb5e
+  availability_zone: us-east-1b
   ssh_username: admin
   ssh_interface: private_ips
   script_args: -Z -A salt.private.odl.mit.edu
@@ -15,9 +16,8 @@ backup_host:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 8
       Ebs.VolumeType: gp2
-    - DeviceName: /dev/xvdb
-      Ebs.VolumeSize: 400
-      Ebs.VolumeType: gp2
+    - device: /dev/xvdb
+      volume_id: vol-0bd5c579e0336bcef
   minion:
     master:
       - salt.private.odl.mit.edu

--- a/salt/orchestrate/aws/cloud_profiles/backup_host.conf
+++ b/salt/orchestrate/aws/cloud_profiles/backup_host.conf
@@ -16,8 +16,6 @@ backup_host:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 8
       Ebs.VolumeType: gp2
-    - device: /dev/xvdb
-      volume_id: vol-0bd5c579e0336bcef
   minion:
     master:
       - salt.private.odl.mit.edu

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -95,6 +95,17 @@ mount_backup_drive:
         mkmnt: True
         opts: 'relatime,user'
 
+create_backup_directory:
+  salt.function:
+    - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - file.directory
+    - kwargs:
+        name: backups
+        makedirs: True
+
 execute_enabled_backup_scripts:
   salt.state:
     - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -145,9 +145,9 @@ detach_backup_volume:
     - arg:
         - cloud.action
     - kwarg:
-        func: ec2.detach_volume
+        func: boto_ec2.detach_volume
         kwargs:
-          volume_id:
+          tags: {{ backup_volume_name }}
           instance_id: {{ instance_id }}
           device: /dev/xvdb
     - require:

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -86,6 +86,19 @@ create_attach_backup_volume:
     - require:
         salt: deploy_backup_instance_to_{{ ENVIRONMENT }}
 
+format_backup_drive:
+  salt.function:
+    - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - blockdev.formatted
+    - kwarg:
+        name: /dev/xvdb
+        fs_type: ext4
+    - require:
+        - salt: create_attach_backup_volume
+
 mount_backup_drive:
   salt.function:
     - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -77,7 +77,7 @@ create_attach_backup_volume:
         func: ec2.create_attach_volume
         kwargs:
           instance_id: {{ instance_id }}
-          volume:
+          volumes:
             volume_name: {{ backup_volume_name }}
             device: /dev/xvdb
             zone: us-east-1b

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -8,6 +8,7 @@
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
 {% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
+{% set backup_volume_name = 'odl-operations-backups-cache-{}'.format(ENVIRONMENT) %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:
@@ -62,6 +63,24 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups
 
+{# Duplicity requires an archive directory otherwise it will have to create it and download files
+from s3 buckets when called. In order to accomodate that, we have an EBS volume that will be mounted
+by the ephemeral instance that is destroyed once backups are complete. #}
+{% set instance_id = salt.boto_ec2.find_instances('name=backups-{}'.format(ENVIRONMENT)) %}
+{% if instance_id %}
+attach_backup_volume:
+  salt.function:
+    - name: saltutil.runner
+    - arg:
+        - cloud.action
+    - kwarg:
+        func: ec2.attach_volume
+        kwargs:
+          instance_id: {{ instance_id }}
+          volume_name: {{ backup_volume_name }}
+          zone: us-east-1b
+          size: 400
+
 mount_backup_drive:
   salt.function:
     - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
@@ -71,7 +90,7 @@ mount_backup_drive:
         - mount.mounted
     - kwarg:
         name: /backups
-        device: /dev/xvdb
+        device: /dev/{{ salt.grains.get('ec2:block_device_mapping:ebs2') }}
         fstype: ext4
         mkmnt: True
         opts: 'relatime,user'
@@ -88,6 +107,33 @@ execute_enabled_backup_scripts:
         - salt: deploy_backup_instance_to_{{ ENVIRONMENT }}
         - salt: mount_backup_drive
 
+unmount_backup_drive:
+  salt.function:
+    - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - mount.unmounted
+    - kwarg:
+        name: /backups
+        device: /dev/{{ salt.grains.get('ec2:block_device_mapping:ebs2') }}
+
+detach_backup_volume:
+  salt.function:
+    - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: saltutil.runner
+    - arg:
+        - cloud.action
+    - kwarg:
+        func: ec2.detach_volume
+        kwargs:
+          volume_id:
+          instance_id: {{ instance_id }}
+          device: /dev/{{ salt.grains.get('ec2:block_device_mapping:ebs2') }}
+    - require:
+        - salt: unmount_backup_drive
+
 terminate_backup_instance_in_{{ ENVIRONMENT }}:
   salt.function:
     - name: saltutil.runner
@@ -100,6 +146,8 @@ terminate_backup_instance_in_{{ ENVIRONMENT }}:
           - backup-{{ ENVIRONMENT }}
     - require:
         - salt: execute_enabled_backup_scripts
+        - salt: detach_backup_volume
+{% endif %}
 
 alert_devops_channel_on_failure:
   slack.post_message:

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -121,7 +121,7 @@ create_backup_directory:
     - arg:
         - file.directory
     - kwargs:
-        name: backups
+        name: /backups/tmp
         makedirs: True
 
 execute_enabled_backup_scripts:

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -7,6 +7,7 @@
     'public1-{}'.format(VPC_RESOURCE_SUFFIX), 'public2-{}'.format(VPC_RESOURCE_SUFFIX), 'public3-{}'.format(VPC_RESOURCE_SUFFIX)])['subnets'] %}
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
+{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:
@@ -61,19 +62,6 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups
 
-format_backup_drive:
-  salt.function:
-    - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
-    - tgt_type: compound
-    - name: state.single
-    - arg:
-        - blockdev.formatted
-    - kwarg:
-        name: /dev/xvdb
-        fs_type: ext4
-    - require:
-        - salt: deploy_backup_instance_to_{{ ENVIRONMENT }}
-
 mount_backup_drive:
   salt.function:
     - tgt: 'G@roles:backups and G@environment:{{ ENVIRONMENT }}'
@@ -87,8 +75,6 @@ mount_backup_drive:
         fstype: ext4
         mkmnt: True
         opts: 'relatime,user'
-    - require:
-        - salt: format_backup_drive
 
 execute_enabled_backup_scripts:
   salt.state:
@@ -120,7 +106,7 @@ alert_devops_channel_on_failure:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled backup for edX RP has failed.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - onfail:
         - salt: execute_enabled_backup_scripts
 
@@ -129,7 +115,7 @@ alert_devops_channel_on_success:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled backup for edX RP has succeeded.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - require:
         - salt: execute_enabled_backup_scripts
         - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -7,7 +7,7 @@
     'public1-{}'.format(VPC_RESOURCE_SUFFIX), 'public2-{}'.format(VPC_RESOURCE_SUFFIX), 'public3-{}'.format(VPC_RESOURCE_SUFFIX)])['subnets'] %}
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
-{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
+{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token').data.value) %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -7,6 +7,7 @@
     'public1-{}'.format(VPC_RESOURCE_SUFFIX), 'public2-{}'.format(VPC_RESOURCE_SUFFIX), 'public3-{}'.format(VPC_RESOURCE_SUFFIX)])['subnets'] %}
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
+{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:
@@ -122,7 +123,7 @@ alert_devops_channel_on_failure:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled restore for edX {{ ENVIRONMENT }} has failed.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - onfail:
         - salt: execute_enabled_backup_scripts
 
@@ -131,7 +132,7 @@ alert_devops_channel_on_success:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled restore for edX {{ ENVIRONMENT }} has succeeded.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - require:
         - salt: execute_enabled_backup_scripts
         - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -6,7 +6,7 @@
     'public1-{}'.format(VPC_RESOURCE_SUFFIX), 'public2-{}'.format(VPC_RESOURCE_SUFFIX), 'public3-{}'.format(VPC_RESOURCE_SUFFIX)])['subnets'] %}
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
-{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
+{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token').data.value) %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -6,6 +6,7 @@
     'public1-{}'.format(VPC_RESOURCE_SUFFIX), 'public2-{}'.format(VPC_RESOURCE_SUFFIX), 'public3-{}'.format(VPC_RESOURCE_SUFFIX)])['subnets'] %}
 {% do subnet_ids.append('{0}'.format(subnet['id'])) %}
 {% endfor %}
+{% set slack_api_token = salt.vault.read('secret-operations/global/slack/slack_api_token.data.value') %}
 
 ensure_backup_bucket_exists:
   boto_s3_bucket.present:
@@ -117,7 +118,7 @@ alert_devops_channel_on_failure:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled backup for operations services has failed.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - onfail:
         - salt: execute_enabled_backup_scripts
 
@@ -126,7 +127,7 @@ alert_devops_channel_on_success:
     - channel: '#devops'
     - from_name: saltbot
     - message: 'The scheduled backup for operations services has succeeded.'
-    - api_key: {{ salt.pillar.get('slack_api_token') }}
+    - api_key: {{ slack_api_token }}
     - require:
         - salt: execute_enabled_backup_scripts
         - salt: terminate_backup_instance_in_{{ ENVIRONMENT }}


### PR DESCRIPTION
Following changes were made:
- Changed duplicity tempdir to /backups/tmp
- Added slack api_token and webhook_url to vault and changed slack calls to read values from vault
- Added the mysql database name to cover the edxapp and xqueue db
- Pointed archive dir to cache dir
- Created 400GB EBS volume and pointed backup host to mount that and use as persistent storage for duplicity cache. Had to specify host's availability zone since EBS volume is not multi-zone.