### PR TITLE
Fix for master render errors

### DIFF
--- a/salt/reactors/edx/draft_disk_cleanup.sls
+++ b/salt/reactors/edx/draft_disk_cleanup.sls
@@ -1,5 +1,5 @@
 remove_exported_courses_from_disk:
   local.cmd.run:
-    - tgt: {{ data['data']['id'] }}
+    - tgt: {{ data['id'] }}
     - arg:
         - rm -rf /edx/var/edxapp/export_course_repos/*


### PR DESCRIPTION
Noticed errors in master log about "Jinja variable 'dict object' has no attribute 'data'" on draft_disk _cleanup.sls file. This should fix the problem.