### PR TITLE
Changed device name

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
@@ -6,7 +6,7 @@ edx-worker:
   ssh_username: ubuntu
   ssh_interface: private_ips
   block_device_mappings:
-    - DeviceName: /dev/xvda
+    - DeviceName: /dev/sda1
       Ebs.VolumeSize: 20
       Ebs.VolumeType: gp2
   iam_profile: edx-instance-role

--- a/salt/orchestrate/aws/cloud_profiles/edx.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx.conf
@@ -6,7 +6,7 @@ edx:
   ssh_username: ubuntu
   ssh_interface: private_ips
   block_device_mappings:
-    - DeviceName: /dev/xvda
+    - DeviceName: /dev/sda1
       Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
   iam_profile: edx-instance-role


### PR DESCRIPTION
Instance provisioning is adding another block device instead of sizing the root volume which is what we want. It appears that the device name needs to be '/dev/sda1' for Ubuntu AMI's instead of '/dev/xvda'.