### PR TITLE
Updated backup instances to have the consul-agent security group

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -57,6 +57,8 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
                      'salt_master-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(
                      'edx-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
+                - {{ salt.boto_secgroup.get_group_id(
+                     'consul-agent-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
     - require:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -59,6 +59,8 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
                      'edx-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(
                      'default', vpc_name=VPC_NAME) }}
+                - {{ salt.boto_secgroup.get_group_id(
+                     'consul-agent-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
     - require:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -54,6 +54,8 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
               SecurityGroupId:
                 - {{ salt.boto_secgroup.get_group_id(
                      'default'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
+                - {{ salt.boto_secgroup.get_group_id(
+                     'consul-agent-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
     - require:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups


### PR DESCRIPTION
In order for the backup/restore nodes to be able to resolve the
location of the resources they are backing up they need to be able to
properly connect their Consul agents for DNS lookups.