### PR TITLE
Changed console-agent sec group to match environment name

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -61,7 +61,7 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
                 - {{ salt.boto_secgroup.get_group_id(
                      'edx-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(
-                     'consul-agent-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
+                     'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
     - require:
         - file: load_backup_host_cloud_profile
         - boto_iam_role: ensure_instance_profile_exists_for_backups


### PR DESCRIPTION
Existing sec_group for dogwood rp is called consul-agent-mitx-rp but we had it resolve to consul-agent-dogwood-rp and it wasn't able to find the sec_group. Used environment variable (mitx-rp) for that sec_group which is the right one.