### PR TITLE
Updated provisioning of secret backends to set lease defaults

### DIFF
--- a/salt/orchestrate/edx/services/mongodb.sls
+++ b/salt/orchestrate/edx/services/mongodb.sls
@@ -1,6 +1,7 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, subnet_ids with context %}
 {% set mongo_admin_password = salt.random.get_str(42) %}
+{% set SIX_MONTHS = '4368h' %}
 
 load_mongodb_cloud_profile:
   file.managed:
@@ -127,7 +128,9 @@ configure_vault_mongodb_backend:
     - backend_type: mongodb
     - description: Backend to create dynamic MongoDB credentials for {{ ENVIRONMENT }}
     - mount_point: mongodb-{{ ENVIRONMENT }}
-    - ttl_max: 4368h
-    - ttl_default: 4368h
+    - ttl_max: {{ SIX_MONTHS }}
+    - ttl_default: {{ SIX_MONTHS }}
+    - lease_max: {{ SIX_MONTHS }}
+    - lease_default: {{ SIX_MONTHS }}
     - connection_config:
         uri: "mongodb://admin:{{ mongo_admin_password }}@mongodb-master.service.{{ ENVIRONMENT }}.consul:27017/admin"

--- a/salt/orchestrate/edx/services/rabbitmq.sls
+++ b/salt/orchestrate/edx/services/rabbitmq.sls
@@ -1,6 +1,7 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, subnet_ids with context %}
 {% set rabbit_admin_password = salt.random.get_str(42) %}
+{% set SIX_MONTHS = '4368h' %}
 
 load_rabbitmq_cloud_profile:
   file.managed:
@@ -87,5 +88,7 @@ configure_vault_rabbitmq_backend:
         connection_uri: "http://rabbitmq.service.{{ ENVIRONMENT }}.consul:15672"
         username: admin
         password: {{ rabbit_admin_password }}
-    - ttl_max: 4368h
-    - ttl_default: 4368h
+    - ttl_max: {{ SIX_MONTHS }}
+    - ttl_default: {{ SIX_MONTHS }}
+    - lease_max: {{ SIX_MONTHS }}
+    - lease_default: {{ SIX_MONTHS }}

--- a/salt/orchestrate/micromasters/rds.sls
+++ b/salt/orchestrate/micromasters/rds.sls
@@ -2,31 +2,29 @@
  ENVIRONMENT, subnet_ids with context %}
 
 {% set SIX_MONTHS = '4368h' %}
-{% set master_pass = salt.random.get_str(42) %}
-{% set master_user = salt.pillar.get('rds:master_username', salt.random.get_str(42) %}
+{% set master_pass = salt.random.get_string(42) %}
+{% set master_user = 'admin' %}
 
-create_edx_rds_db_subnet_group:
+create_{{ ENVIRONMENT }}_rds_db_subnet_group:
   boto_rds.subnet_group_present:
     - name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
     - subnet_ids: {{ subnet_ids }}
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
 
-create_edx_rds_store:
+create_{{ ENVIRONMENT }}_rds_store:
   boto_rds.present:
-    - name: {{ VPC_RESOURCE_SUFFIX }}-rds-mysql
+    - name: {{ VPC_RESOURCE_SUFFIX }}-rds-postgresql
     - allocated_storage: 200
     - db_instance_class: db.t2.medium
     - storage_type: gp2
-    - engine: mariadb
+    - engine: postgresql
     - multi_az: True
     - auto_minor_version_upgrade: True
     - publicly_accessible: False
     - master_username: {{ master_user }}
     - master_user_password: {{ master_pass }}
     - vpc_security_group_ids:
-        - {{ salt.boto_secgroup.get_group_id(
-             'edx-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         - {{ salt.boto_secgroup.get_group_id(
              'default', vpc_name=VPC_NAME) }}
         - {{ salt.boto_secgroup.get_group_id(
@@ -36,16 +34,16 @@ create_edx_rds_store:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-rds-mysql
     - require:
-        - boto_rds: create_edx_rds_db_subnet_group
+        - boto_rds: create_{{ ENVIRONMENT }}_rds_db_subnet_group
 
-configure_vault_mysql_backend:
+configure_vault_postgresql_backend:
   vault.secret_backend_enabled:
-    - backend_type: mysql
-    - description: Backend to create dynamic MySQL credentials for {{ ENVIRONMENT }}
-    - mount_point: mysql-{{ ENVIRONMENT }}
+    - backend_type: postgresql
+    - description: Backend to create dynamic PostGreSQL credentials for {{ ENVIRONMENT }}
+    - mount_point: postgresql-{{ ENVIRONMENT }}
     - ttl_max: {{ SIX_MONTHS }}
     - ttl_default: {{ SIX_MONTHS }}
     - lease_max: {{ SIX_MONTHS }}
     - lease_default: {{ SIX_MONTHS }}
     - connection_config:
-        connection_url: "{{ master_user }}:{{ master_pass }}@tcp(mysql.service.{{ ENVIRONMENT }}.consul:3306)"
+        connection_url: "postgresql://{{ master_user }}:{{ master_pass }}@tcp(postgresql.service.{{ ENVIRONMENT }}.consul:15432)"

--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -1,3 +1,5 @@
+{% set SIX_MONTHS = '4368h' %}
+
 enable_transit_secret_backend:
   vault.secret_backend_enabled:
     - backend_type: transit
@@ -8,6 +10,10 @@ enable_mitx_aws_secret_backend:
     - backend_type: aws
     - mount_point: aws-mitx
     - description: Backend to dynamically create IAM credentials
+    - ttl_max: {{ SIX_MONTHS }}
+    - ttl_default: {{ SIX_MONTHS }}
+    - lease_max: {{ SIX_MONTHS }}
+    - lease_default: {{ SIX_MONTHS }}
 
 {% for unit in salt.pillar.get('business_units', []) %}
 enable_generic_backend_for_{{ unit }}:


### PR DESCRIPTION
Updated the secret backend states to set lease TTLs to 6 months to get
everything lined up to simplify managing expiration of credentials in
deployed services.