### PR TITLE
Changed 'format' and 'fun'

### DIFF
--- a/salt/backups/mount_drive.sls
+++ b/salt/backups/mount_drive.sls
@@ -1,5 +1,5 @@
 format_backup_drive:
-  blockdev.format:
+  blockdev.formatted:
     - device: /dev/xvdb
     - fs_type: ext4
 

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -72,7 +72,8 @@ create_attach_backup_volume:
     - name: cloud.action
     - tgt: 'roles:master'
     - tgt_type: grain
-    - fun: ec2.create_attach_volumes
+    - arg:
+        - create_attach_volumes
     - kwarg:
         instance: {{ instance_name }}
         name: {{ instance_name }}


### PR DESCRIPTION
Formatted is the right salt function call and not 'format'. Changed 'fun' to 'arg' as the create_attach_volume wasn't being called. Also noticed that salt.cloud when running from command line to troubleshoot was calling 'ec2.ec2.' so removed that.