### PR TITLE
Stop instance on completion

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -61,6 +61,9 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
                 - {{ salt.boto_secgroup.get_group_id(
                      'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           block_device_mappings:
+            - DeviceName: /dev/xvda
+              Ebs.VolumeSize: 8
+              Ebs.VolumeType: gp2
             - DeviceName: /dev/xvdb
               Ebs.VolumeSize: 400
               Ebs.VolumeType: gp2


### PR DESCRIPTION
Resized instance primary volume and instead of terminating it on completion, will be stopping it once backups are complete. Next time it runs, instance is powered on and backup scripts are called.