### PR TITLE
Updated tags to quote datetimes due to parsing errors

### DIFF
--- a/salt/orchestrate/aws/bootcamp-ecommerce/rds.sls
+++ b/salt/orchestrate/aws/bootcamp-ecommerce/rds.sls
@@ -13,7 +13,7 @@ create_{{ ENVIRONMENT }}_rds_db_subnet_group:
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_rds_store:
   boto_rds.present:
@@ -40,7 +40,7 @@ create_{{ ENVIRONMENT }}_rds_store:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-rds-mysql
         business_unit: bootcamps
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - require:
         - boto_rds: create_{{ ENVIRONMENT }}_rds_db_subnet_group
 

--- a/salt/orchestrate/aws/bootcamp-ecommerce/vpc.sls
+++ b/salt/orchestrate/aws/bootcamp-ecommerce/vpc.sls
@@ -15,7 +15,7 @@ create_{{ ENVIRONMENT }}_vpc:
     - tags:
         Name: {{ VPC_NAME }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_internet_gateway:
   boto_vpc.internet_gateway_present:
@@ -26,7 +26,7 @@ create_{{ ENVIRONMENT }}_internet_gateway:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-igw
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_1:
   boto_vpc.subnet_present:
@@ -39,7 +39,7 @@ create_{{ ENVIRONMENT }}_public_subnet_1:
     - tags:
         Name: public1-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_2:
   boto_vpc.subnet_present:
@@ -52,7 +52,7 @@ create_{{ ENVIRONMENT }}_public_subnet_2:
     - tags:
         Name: public2-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_3:
   boto_vpc.subnet_present:
@@ -65,7 +65,7 @@ create_{{ ENVIRONMENT }}_public_subnet_3:
     - tags:
         Name: public3-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_vpc_peering_connection_with_operations:
   boto_vpc.vpc_peering_connection_present:
@@ -99,7 +99,7 @@ create_{{ ENVIRONMENT }}_routing_table:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-route_table
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_postgresql_rds_security_group_in_{{ VPC_NAME }}:
   boto_secgroup.present:
@@ -117,7 +117,7 @@ create_postgresql_rds_security_group_in_{{ VPC_NAME }}:
     - tags:
         Name: rds-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_salt_master_security_group:
   boto_secgroup.present:
@@ -134,7 +134,7 @@ create_salt_master_security_group:
     - tags:
         Name: salt_master-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_vault_backend_security_group_in_{{ VPC_NAME }}:
   boto_secgroup.present:
@@ -146,7 +146,7 @@ create_vault_backend_security_group_in_{{ VPC_NAME }}:
     - tags:
         Name: vault-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - rules:
         {# PostGreSQL #}
         - ip_protocol: tcp

--- a/salt/orchestrate/aws/map_templates/edx.yml
+++ b/salt/orchestrate/aws/map_templates/edx.yml
@@ -19,9 +19,9 @@ edx:
         business_unit: {{ business_unit }}
         environment: {{ environment_name }}
         purpose_prefix: {{ purpose_prefix }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
       grains:
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
         business_unit: {{ business_unit }}
         environment: {{ environment_name }}
         {% set modified_purpose = purpose_prefix + '-' + app_type %}
@@ -48,12 +48,12 @@ edx-worker:
               - {{ securitygroupids['consul-agent'] }}
         image: {{ ami_id }}
         tag:
-          created_at: {{ salt.status.time(format=ISO8601) }}
+          created_at: "{{ salt.status.time(format=ISO8601) }}"
           business_unit: {{ business_unit }}
           environment: {{ environment_name }}
           purpose_prefix: {{ purpose_prefix }}
         grains:
-          created_at: {{ salt.status.time(format=ISO8601) }}
+          created_at: "{{ salt.status.time(format=ISO8601) }}"
           business_unit: {{ business_unit }}
           environment: {{ environment_name }}
           {% set modified_purpose = purpose_prefix + '-' + app_type %}

--- a/salt/orchestrate/aws/map_templates/instance_map.yml
+++ b/salt/orchestrate/aws/map_templates/instance_map.yml
@@ -12,12 +12,12 @@
       tag:
         environment: {{ environment_name }}
         role: {{ service_name }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
         {% for tag_name, tag_value in tags.items() %}
         {{ tag_name }}: {{ tag_value }}
         {% endfor %}
       grains:
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
         environment: {{ environment_name }}
         roles: {{ roles }}
         {% for tag_name, tag_value in tags.items() %}

--- a/salt/orchestrate/aws/micromasters/rds.sls
+++ b/salt/orchestrate/aws/micromasters/rds.sls
@@ -12,7 +12,7 @@ create_{{ ENVIRONMENT }}_rds_db_subnet_group:
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_rds_store:
   boto_rds.present:
@@ -36,7 +36,7 @@ create_{{ ENVIRONMENT }}_rds_store:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-rds-mysql
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - require:
         - boto_rds: create_{{ ENVIRONMENT }}_rds_db_subnet_group
 

--- a/salt/orchestrate/aws/micromasters/vpc.sls
+++ b/salt/orchestrate/aws/micromasters/vpc.sls
@@ -15,7 +15,7 @@ create_{{ ENVIRONMENT }}_vpc:
     - tags:
         Name: {{ VPC_NAME }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_internet_gateway:
   boto_vpc.internet_gateway_present:
@@ -26,7 +26,7 @@ create_{{ ENVIRONMENT }}_internet_gateway:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-igw
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_1:
   boto_vpc.subnet_present:
@@ -39,7 +39,7 @@ create_{{ ENVIRONMENT }}_public_subnet_1:
     - tags:
         Name: public1-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_2:
   boto_vpc.subnet_present:
@@ -52,7 +52,7 @@ create_{{ ENVIRONMENT }}_public_subnet_2:
     - tags:
         Name: public2-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_public_subnet_3:
   boto_vpc.subnet_present:
@@ -65,7 +65,7 @@ create_{{ ENVIRONMENT }}_public_subnet_3:
     - tags:
         Name: public3-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ ENVIRONMENT }}_vpc_peering_connection_with_operations:
   boto_vpc.vpc_peering_connection_present:
@@ -99,7 +99,7 @@ create_{{ ENVIRONMENT }}_routing_table:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-route_table
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_elasticsearch_security_group:
   boto_secgroup.present:
@@ -124,7 +124,7 @@ create_elasticsearch_security_group:
     - tags:
         Name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_salt_master_security_group:
   boto_secgroup.present:
@@ -141,4 +141,4 @@ create_salt_master_security_group:
     - tags:
         Name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"

--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -41,7 +41,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc:
     - tags:
         Name: {{ VPC_NAME }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_internet_gateway:
   boto_vpc.internet_gateway_present:
@@ -52,7 +52,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_internet_gateway:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-igw
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_1:
   boto_vpc.subnet_present:
@@ -65,7 +65,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_1:
     - tags:
         Name: public1-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_2:
   boto_vpc.subnet_present:
@@ -78,7 +78,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_2:
     - tags:
         Name: public2-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_3:
   boto_vpc.subnet_present:
@@ -91,7 +91,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_3:
     - tags:
         Name: public3-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc_peering_connection_with_operations:
   boto_vpc.vpc_peering_connection_present:
@@ -125,7 +125,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_routing_table:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-route_table
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_edx_security_group:
   boto_secgroup.present:
@@ -156,7 +156,7 @@ create_edx_security_group:
     - tags:
         Name: edx-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_edx_worker_security_group:
   boto_secgroup.present:
@@ -176,7 +176,7 @@ create_edx_worker_security_group:
     - tags:
         Name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_mongodb_security_group:
   boto_secgroup.present:
@@ -196,7 +196,7 @@ create_mongodb_security_group:
     - tags:
         Name: mongodb-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_mitx_consul_security_group:
   boto_secgroup.present:
@@ -252,7 +252,7 @@ create_mitx_consul_security_group:
     - tags:
         Name: consul-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_mitx_consul_agent_security_group:
   boto_secgroup.present:
@@ -282,7 +282,7 @@ create_mitx_consul_agent_security_group:
     - tags:
         Name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_rabbitmq_security_group:
   boto_secgroup.present:
@@ -312,7 +312,7 @@ create_rabbitmq_security_group:
     - tags:
         Name: rabbitmq-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_elasticsearch_security_group:
   boto_secgroup.present:
@@ -334,7 +334,7 @@ create_elasticsearch_security_group:
     - tags:
         Name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_rds_security_group:
   boto_secgroup.present:
@@ -356,7 +356,7 @@ create_rds_security_group:
     - tags:
         Name: rds-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_salt_master_security_group:
   boto_secgroup.present:
@@ -366,7 +366,7 @@ create_salt_master_security_group:
     - tags:
         Name: salt_master-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - rules:
         - ip_protocol: tcp
           from_port: 22
@@ -386,7 +386,7 @@ create_vault_backend_security_group:
     - tags:
         Name: vault-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - rules:
         {# MongoDB #}
         - ip_protocol: tcp

--- a/salt/orchestrate/aws/mitx_elb.sls
+++ b/salt/orchestrate/aws/mitx_elb.sls
@@ -53,7 +53,7 @@ create_elb_for_edx_{{ purpose_name }}:
     - tags:
         Name: {{ elb_name }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 register_edx_{{ purpose_name }}_nodes_with_elb:
   boto_elb.register_instances:

--- a/salt/orchestrate/aws/operations.sls
+++ b/salt/orchestrate/aws/operations.sls
@@ -18,7 +18,7 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc:
     - tags:
         Name: {{ VPC_NAME }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_1:
   boto_vpc.subnet_present:
@@ -29,7 +29,7 @@ create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_1:
     - tags:
         Name: public1-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_2:
   boto_vpc.subnet_present:
@@ -40,7 +40,7 @@ create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_2:
     - tags:
         Name: public2-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_3:
   boto_vpc.subnet_present:
@@ -51,7 +51,7 @@ create_{{ VPC_RESOURCE_SUFFIX }}_public_subnet_3:
     - tags:
         Name: public3-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 manage_{{ VPC_RESOURCE_SUFFIX }}_routing_table:
   boto_vpc.route_table_present:
@@ -67,7 +67,7 @@ manage_{{ VPC_RESOURCE_SUFFIX }}_routing_table:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-route_table
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_{{ VPC_RESOURCE_SUFFIX }}_consul_security_group:
   boto_secgroup.present:
@@ -143,7 +143,7 @@ create_mitx_consul_agent_security_group:
     - tags:
         Name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_vault_security_group:
   boto_secgroup.present:
@@ -158,4 +158,4 @@ create_vault_security_group:
     - tags:
         Name: vault-{{ VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
-        created_at: {{ salt.status.time(format=ISO8601) }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"

--- a/salt/orchestrate/edx/services/rds.sls
+++ b/salt/orchestrate/edx/services/rds.sls
@@ -1,6 +1,6 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, BUSINESS_UNIT, subnet_ids with context %}
-
+{% set ISO8601 = '%Y-%m-%dT%H:%M:%S' %}
 {% set SIX_MONTHS = '4368h' %}
 {% set master_pass = salt.random.get_str(40) %}
 {% set master_user = salt.pillar.get('rds:master_username', 'odldevops') %}
@@ -13,6 +13,7 @@ create_edx_rds_db_subnet_group:
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
 
 create_edx_rds_store:
   boto_rds.present:
@@ -38,6 +39,7 @@ create_edx_rds_store:
     - tags:
         Name: {{ VPC_RESOURCE_SUFFIX }}-rds-mysql
         business_unit: {{ BUSINESS_UNIT }}
+        created_at: "{{ salt.status.time(format=ISO8601) }}"
     - require:
         - boto_rds: create_edx_rds_db_subnet_group
 


### PR DESCRIPTION
In order to prevent the state execution from trying to parse the
`created_at` tags as timestamps I wrapped the rendered value in quotes