### PR TITLE
Updated to set file type and add dummy snapshot id for root volumes

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/backup_host.conf
+++ b/salt/orchestrate/aws/cloud_profiles/backup_host.conf
@@ -1,7 +1,8 @@
+# -*- mode: yaml; coding: utf-8; -*-
 backup_host:
   provider: mitx
   size: t2.medium
-  image: ami-49e5cb5e
+  image: {{ salt.sdb.get('sdb://consul/debian_ami_id') }}
   availability_zone: us-east-1b
   ssh_username: admin
   ssh_interface: private_ips
@@ -14,8 +15,9 @@ backup_host:
       - backups
   block_device_mappings:
     - DeviceName: /dev/xvda
-      Ebs.VolumeSize: 8
+      Ebs.VolumeSize: 20
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
   minion:
     master:
       - salt.private.odl.mit.edu

--- a/salt/orchestrate/aws/cloud_profiles/consul.conf
+++ b/salt/orchestrate/aws/cloud_profiles/consul.conf
@@ -10,6 +10,7 @@ consul:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 50
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
   iam_profile: consul-instance-role
   tag:
     role: consul_server

--- a/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
@@ -2,7 +2,7 @@
 edx-worker:
   provider: mitx
   size: t2.large
-  image: ami-682dc87e
+  image: {{ salt.sdb.get('sdb://consul/edx_ami_id')|default('ami-973d0681') }}
   ssh_username: ubuntu
   ssh_interface: private_ips
   block_device_mappings:

--- a/salt/orchestrate/aws/cloud_profiles/edx.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx.conf
@@ -9,6 +9,7 @@ edx:
     - DeviceName: /dev/sda1
       Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
   iam_profile: edx-instance-role
   tag:
     role: edx

--- a/salt/orchestrate/aws/cloud_profiles/edx_sandbox.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx_sandbox.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 # This profile is for instances launched for the purpose of
 # building edX sandbox AMIs.
 

--- a/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
+++ b/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 elasticsearch:
   provider: mitx
   size: r4.xlarge
@@ -8,6 +9,7 @@ elasticsearch:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 20
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
     - DeviceName: /dev/xvdb
       Ebs.VolumeSize: 800
       Ebs.VolumeType: gp2

--- a/salt/orchestrate/aws/cloud_profiles/fluentd.conf
+++ b/salt/orchestrate/aws/cloud_profiles/fluentd.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 fluentd:
   provider: mitx
   size: t2.medium

--- a/salt/orchestrate/aws/cloud_profiles/kibana.conf
+++ b/salt/orchestrate/aws/cloud_profiles/kibana.conf
@@ -1,7 +1,8 @@
+# -*- mode: yaml; coding: utf-8; -*-
 kibana:
   provider: mitx
   size: t2.small
-  image: ami-cb4b94dd
+  image: {{ salt.sdb.get('sdb://consul/debian_ami_id') }}
   ssh_username: admin
   iam_profile: kibana-instance-role
   grains:

--- a/salt/orchestrate/aws/cloud_profiles/mongodb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/mongodb.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 mongodb:
   provider: mitx
   size: t2.medium
@@ -9,6 +10,7 @@ mongodb:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 20
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
     - DeviceName: /dev/xvdb
       Ebs.VolumeSize: 250
       Ebs.VolumeType: gp2

--- a/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
+++ b/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 rabbitmq:
   provider: mitx
   size: t2.medium
@@ -9,6 +10,7 @@ rabbitmq:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 50
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
   iam_profile: rabbitmq-instance-role
   tag:
     env: qa

--- a/salt/orchestrate/aws/cloud_profiles/xqwatcher.conf
+++ b/salt/orchestrate/aws/cloud_profiles/xqwatcher.conf
@@ -1,3 +1,4 @@
+# -*- mode: yaml; coding: utf-8; -*-
 xqwatcher:
   provider: mitx
   size: t2.medium
@@ -9,6 +10,7 @@ xqwatcher:
     - DeviceName: /dev/xvda
       Ebs.VolumeSize: 20
       Ebs.VolumeType: gp2
+      Ebs.SnapshotId: dummy0
   iam_profile: xqwatcher-instance-role
   tag:
     role: xqwatcher


### PR DESCRIPTION
When launching new instances with the Debian 9 AMI they were
complaining about duplicate device names. Updated the snapshot ID in
the profiles to point to a dummy snapshot as a means of avoiding that
issue.

Also updated the file metadata to properly identify the fact that the
profiles are YAML