### PR TITLE
Updated all uses of runners in orchestrate to use saltmod.runner

### DIFF
--- a/salt/orchestrate/edx/init.sls
+++ b/salt/orchestrate/edx/init.sls
@@ -61,15 +61,10 @@ create_edx_s3_bucket_{{ bucket }}_{{ PURPOSE_PREFIX }}-{{ type }}_{{ ENVIRONMENT
 {% endfor %}
 
 deploy_edx_cloud_map:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_edx_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_edx_map.yml
+    - parallel: True
     - require:
         - file: generate_edx_cloud_map_file
 

--- a/salt/orchestrate/edx/services/consul.sls
+++ b/salt/orchestrate/edx/services/consul.sls
@@ -35,15 +35,10 @@ generate_cloud_map_file:
         - file: load_consul_cloud_profile
 
 deploy_consul_nodes:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_consul_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_consul_map.yml
+    - parallel: True
     - require:
         - file: generate_cloud_map_file
 

--- a/salt/orchestrate/edx/services/elasticsearch.sls
+++ b/salt/orchestrate/edx/services/elasticsearch.sls
@@ -44,15 +44,10 @@ generate_elasticsearch_cloud_map_file:
         - file: load_elasticsearch_cloud_profile
 
 deploy_elasticsearch_nodes:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_elasticsearch_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_elasticsearch_map.yml
+    - parallel: True
     - require:
         - file: generate_elasticsearch_cloud_map_file
 

--- a/salt/orchestrate/edx/services/mongodb.sls
+++ b/salt/orchestrate/edx/services/mongodb.sls
@@ -41,15 +41,10 @@ ensure_instance_profile_exists_for_mongodb:
     - name: mongodb-instance-role
 
 deploy_mongodb_cloud_map:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_mongodb_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_mongodb_map.yml
+    - parallel: True
     - require:
         - file: generate_mongodb_cloud_map_file
 

--- a/salt/orchestrate/edx/services/rabbitmq.sls
+++ b/salt/orchestrate/edx/services/rabbitmq.sls
@@ -39,15 +39,10 @@ ensure_instance_profile_exists_for_rabbitmq:
     - name: rabbitmq-instance-role
 
 deploy_rabbitmq_cloud_map:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_rabbitmq_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_rabbitmq_map.yml
+    - parallel: True
     - require:
         - file: generate_rabbitmq_cloud_map_file
 

--- a/salt/orchestrate/edx/xqwatcher.sls
+++ b/salt/orchestrate/edx/xqwatcher.sls
@@ -33,15 +33,10 @@ ensure_instance_profile_exists_for_xqwatcher:
     - name: xqwatcher-instance-role
 
 deploy_xqwatcher_cloud_map:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ ENVIRONMENT}}_xqwatcher_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ ENVIRONMENT}}_xqwatcher_map.yml
+    - parallel: True
     - require:
         - file: generate_xqwatcher_cloud_map_file
 

--- a/salt/orchestrate/logging/init.sls
+++ b/salt/orchestrate/logging/init.sls
@@ -38,15 +38,10 @@ generate_cloud_map_file:
         - file: load_kibana_cloud_profile
 
 deploy_logging_cloud_map:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/logging-map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/logging-map.yml
+    - parallel: True
     - require:
       - file: generate_cloud_map_file
 

--- a/salt/orchestrate/micromasters/elasticsearch.sls
+++ b/salt/orchestrate/micromasters/elasticsearch.sls
@@ -38,15 +38,10 @@ generate_elasticsearch_cloud_map_file:
         - file: load_elasticsearch_cloud_profile
 
 deploy_elasticsearch_nodes:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/{{ ENVIRONMENT }}_elasticsearch_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ ENVIRONMENT }}_elasticsearch_map.yml
+    - parallel: True
     - require:
         - file: generate_elasticsearch_cloud_map_file
 

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -73,15 +73,10 @@ execute_enabled_backup_scripts:
         - salt: deploy_backup_instance_to_{{ ENVIRONMENT }}
 
 terminate_backup_instance_in_{{ ENVIRONMENT }}:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.destroy
-    - kwarg:
-        instances:
-          - backup-{{ ENVIRONMENT }}
+  salt.runner:
+    - name: cloud.destroy
+    - instances:
+        - backup-{{ ENVIRONMENT }}
     - require:
         - salt: execute_enabled_backup_scripts
 

--- a/salt/orchestrate/operations/services/consul.sls
+++ b/salt/orchestrate/operations/services/consul.sls
@@ -26,15 +26,10 @@ generate_cloud_map_file:
         subnetids: {{ subnet_ids }}
 
 deploy_consul_nodes:
-  salt.function:
-    - name: saltutil.runner
-    - tgt: 'roles:master'
-    - tgt_type: grain
-    - arg:
-        - cloud.map_run
-    - kwarg:
-        path: /etc/salt/cloud.maps.d/operations_consul_map.yml
-        parallel: True
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/operations_consul_map.yml
+    - parallel: True
     - require:
         - file: generate_cloud_map_file
 


### PR DESCRIPTION
Rather than using `salt.function` calls to execute runners indirectly
I moved to using the `salt.runner` state during orchestrate runs to
reduce the number of levels of abstraction.