### PR TITLE
Modified restore state due to db naming mismatch

### DIFF
--- a/salt/backups/restore.sls
+++ b/salt/backups/restore.sls
@@ -8,7 +8,7 @@ install_duplicity_backend_requirements:
   pip.installed:
     - name: boto
 
-{% for service in salt.pillar.get('backups:enabled', []) %}
+{% for service in salt.pillar.get('restores', []) %}
 {% if service.get('pkgs') %}
 install_packages_for_{{ service.title }}_backup:
   pkg.installed:

--- a/salt/backups/templates/restore_mongodb.sh
+++ b/salt/backups/templates/restore_mongodb.sh
@@ -15,5 +15,5 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore\
                       --port {{ settings.get('port', 27017) }} \
                       --password {{ settings.password }} --username admin \
                       --authenticationDatabase admin \
-                      --db {{ settings.database }} \
-                      --drop {{ backupdir }}/{{ settings.database }}
+                      --db {{ settings.restore_to }} \
+                      --drop {{ backupdir }}/{{ settings.restore_from }}

--- a/salt/backups/templates/restore_mongodb.sh
+++ b/salt/backups/templates/restore_mongodb.sh
@@ -11,9 +11,12 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore\
           --archive-dir {{ cachedir }} \
           --force --tempdir /backups/tmp/ {{ backupdir }}
 
+{% for key, value in mongodb.items() %}
 /usr/bin/mongorestore --host {{ settings.host }} \
                       --port {{ settings.get('port', 27017) }} \
                       --password {{ settings.password }} --username admin \
                       --authenticationDatabase admin \
-                      --db {{ settings.restore_to }} \
-                      --drop {{ backupdir }}/{{ settings.restore_from }}
+                      --db {{ value }} \
+                      --drop {{ backupdir }}/{{ key }}
+{% endfor %}
+rm -rf {{ backupdir }}

--- a/salt/backups/templates/restore_mysql.sh
+++ b/salt/backups/templates/restore_mysql.sh
@@ -15,5 +15,5 @@ PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity restore \
                --port {{ settings.get('port', 3306) }} \
                --user {{ settings.username }} \
                --password={{ settings.password }} \
-               --database={{ settings.database }} \
-               < {{ backupdir }}/{{ settings.database }}.dump
+               --database={{ settings.restore_to }} \
+               < {{ backupdir }}/{{ settings.restore_from }}.dump


### PR DESCRIPTION
Current dogwood environment that we're upgrading uses a non-standard naming convention for mongodb and mysql. This change (including PR for pillar data) maps old name to new name.