### PR TITLE
Added log output redirection for gitreload

### DIFF
--- a/salt/edx/gitreload.sls
+++ b/salt/edx/gitreload.sls
@@ -16,7 +16,7 @@
     'UPDATE_LMS': True,
     'REPODIR': '/mnt/data/repos',
     'LOG_LEVEL': 'debug',
-    'NUM_THREADS': 1,
+    'WORKERS': 1,
     'LOGFILE': "/edx/var/log/gr/gitreload.log",
     'VIRTUAL_ENV': '/edx/app/edxapp/venvs/edxapp',
     'EDX_PLATFORM': '/edx/app/edxapp/edx-platform',

--- a/salt/edx/templates/gitreload_systemd.conf.j2
+++ b/salt/edx/templates/gitreload_systemd.conf.j2
@@ -6,10 +6,12 @@ StartLimitInterval=60
 StartLimitBurst=3
 
 [Service]
-Environment=PID=/var/tmp/gitreload.pid
-Environment=WORKERS=1
-Environment=PORT={{ gr_env.PORT }}
+{%- for var, val in gr_env.items() %}
+Environment={{ var }}={{ val }}
+{% endfor -%}
 Environment=LANG=en_US.UTF-8
+Environment=WORKERS=1
+Environment=PID=/var/tmp/gitreload.pid
 WorkingDirectory={{ gr_dir }}
 User=www-data
-ExecStart={{ gr_env.VIRTUAL_ENV }}/bin/gunicorn --preload -b 0.0.0.0:${PORT} -w ${WORKERS} --timeout=10 gitreload.web:application
+ExecStart=/bin/sh -c '${VIRTUAL_ENV}/bin/gunicorn --preload -b 0.0.0.0:${PORT} -w ${WORKERS} --timeout=10 gitreload.web:application 2>&1 | tee -a ${LOGFILE}'


### PR DESCRIPTION
The gitreload process was only writing to the systemd journal and not
the target log file. Updated to redirect stderr and stdout to the
target log file so they will get shipped to Elasticsearch