### PR TITLE
Added states needed to run to build devstack instance using top file

### DIFF
--- a/pillar/mysql_devstack.sls
+++ b/pillar/mysql_devstack.sls
@@ -1,0 +1,35 @@
+{% from 'pillar/devstack.sls' import COMMON_MYSQL_ADMIN_USER, COMMON_MYSQL_ADMIN_PASS, MYSQL_HOST,
+XQUEUE_MYSQL_DB_NAME, EDXAPP_MYSQL_DB_NAME, COMMON_MYSQL_MIGRATE_USER, COMMON_MYSQL_MIGRATE_PASS,
+XQUEUE_MYSQL_USER, XQUEUE_MYSQL_PASSWORD, EDXAPP_MYSQL_USER, EDXAPP_MYSQL_PASSWORD with context %}
+
+mysql:
+  server:
+    root_user: {{ COMMON_MYSQL_ADMIN_USER }}
+    root_password: {{ COMMON_MYSQL_ADMIN_PASS }}
+    mysql_host: {{ MYSQL_HOST }}
+
+  database:
+    - {{ XQUEUE_MYSQL_DB_NAME }}
+    - {{ EDXAPP_MYSQL_DB_NAME }}
+
+  user:
+    {{ COMMON_MYSQL_MIGRATE_USER }}:
+      password: {{ COMMON_MYSQL_MIGRATE_PASS }}
+      host: {{ MYSQL_HOST }}
+      databases:
+        - database: {{ XQUEUE_MYSQL_DB_NAME }}
+          grants: ['all privileges']
+        - database: {{ EDXAPP_MYSQL_DB_NAME }}
+          grants: ['all privileges']
+    {{ XQUEUE_MYSQL_USER }}:
+      password: {{ XQUEUE_MYSQL_PASSWORD }}
+      host: {{ MYSQL_HOST }}
+      databases:
+        - database: {{ XQUEUE_MYSQL_DB_NAME }}
+          grants: ['all privileges']
+    {{ EDXAPP_MYSQL_USER }}:
+      password: {{ EDXAPP_MYSQL_PASSWORD }}
+      host: {{ MYSQL_HOST }}
+      databases:
+        - database: {{ EDXAPP_MYSQL_DB_NAME }}
+          grants: ['all privileges']

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -102,7 +102,8 @@ base:
     - consul.dns_proxy
     - consul.tests
     - consul.tests.test_dns_setup
-    - mysql.server
+    - mysql
+    - mysql.remove_test_database
     - mongodb
     - mongodb.consul_check
     - rabbitmq

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -96,3 +96,17 @@ base:
   'roles:restores':
     - match: grain
     - backups.restore
+  'G@roles:devstack and P@environment:dev':
+    - match: compound
+    - consul
+    - consul.dns_proxy
+    - consul.tests
+    - consul.tests.test_dns_setup
+    - mysql.server
+    - mongodb
+    - mongodb.consul_check
+    - rabbitmq
+    - elasticsearch
+    - edx.prod
+    - edx.run_ansible
+    - edx.tests


### PR DESCRIPTION
Devstack runs all services on one host and we're planning on using our existing formulas and configs to build out the devstack instance. Made the following changes:
- In order to minimize the changes needed between a production deployment and devstack, we will be using consul and masterless-salt to orchestrate the devstack instance which necessitates the use of the top file.
- Created a pillar file to override some settings in the mysql formula to get the variables from one source of truth and that being the devstack file.