### PR TITLE
Exclude devstack from top file

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,5 +1,5 @@
 base:
-  '* and not G@roles:devstack':
+  'not G@roles:devstack':
     - match: compound
     - utils.install_pip
     - utils.inotify_watches

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,5 +1,6 @@
 base:
-  '*':
+  '* and not G@roles:devstack':
+    - match: compound
     - utils.install_pip
     - utils.inotify_watches
     - fluentd


### PR DESCRIPTION
There's no need to include fluentd in devstack but even if we do want to include it, we'd also have to include the fluentd pillar data. In an effort of trying to keep things simple, it might be best to simply exclude devstack.