### PR TITLE
Added edx-worker as source group for services in env

### DIFF
--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -188,6 +188,7 @@ create_mongodb_security_group:
           to_port: 27017
           source_group_name:
             - edx-{{ VPC_RESOURCE_SUFFIX }}
+            - edx-worker-{{ VPC_RESOURCE_SUFFIX }}
             - mongodb-{{ VPC_RESOURCE_SUFFIX }}
     - require:
         - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
@@ -324,6 +325,10 @@ create_elasticsearch_security_group:
           to_port: 9200
           source_group_name: edx-{{ VPC_RESOURCE_SUFFIX }}
         - ip_protocol: tcp
+          from_port: 9200
+          to_port: 9200
+          source_group_name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+        - ip_protocol: tcp
           from_port: 9300
           to_port: 9400
           source_group_name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
@@ -345,6 +350,10 @@ create_rds_security_group:
           from_port: 3306
           to_port: 3306
           source_group_name: edx-{{ VPC_RESOURCE_SUFFIX }}
+        - ip_protocol: tcp
+          from_port: 3306
+          to_port: 3306
+          source_group_name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
         - ip_protocol: tcp
           from_port: 3306
           to_port: 3306


### PR DESCRIPTION
In order for the edx workers to be able to access some of the other
hosts in the environment we missed adding the edx-worker group as an
allowed source.