### PR TITLE
Added condition to edx.prod to check for devstack

### DIFF
--- a/pillar/devstack.sls
+++ b/pillar/devstack.sls
@@ -310,3 +310,5 @@ edx:
 
     edx_platform_repo: 'https://github.com/mitodl/edx-platform.git'
     edx_platform_version: 'mitx/ficus-1'
+
+    COMMON_ENABLE_AWS_ROLE: False

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -116,5 +116,5 @@ base:
     - mongodb.consul_check
     - rabbitmq
     - elasticsearch
-    - edx.run_ansible
+    - edx.prod
     - edx.tests

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -116,6 +116,5 @@ base:
     - mongodb.consul_check
     - rabbitmq
     - elasticsearch
-    - edx.prod
     - edx.run_ansible
     - edx.tests


### PR DESCRIPTION
Some of the functionality in edx.prod only applies to aws instances, so added a condition to check whether the instance has the devstack role and skip some of the calls if that's the case.
Removed edx.run_ansible call since it's redundant given that edx.prod includes it and added a variable to pillar devstack in order not to install the aws role.