### PR TITLE
Added explicit passing of flags to ansible runs

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -80,6 +80,7 @@ run_ansible:
         repo_path: {{ repo_path }}
         conf_file: {{ conf_file }}
         playbooks: {{ playbooks }}
+        extra_flags: {{ salt.pillar.get('edx:ansible_flags', '') }}
     - require:
       - virtualenv: create_ansible_virtualenv
     - unless: {{ salt.pillar.get('edx:skip_ansible', False) }}

--- a/salt/edx/templates/run_ansible.sh.j2
+++ b/salt/edx/templates/run_ansible.sh.j2
@@ -17,6 +17,6 @@ source {{ venv_path }}/src/ansible/hacking/env-setup
 rm {{ data_path }}/ansible-log.txt
 cd {{ repo_path }}/playbooks
 {% for playbook in playbooks %}
-ansible-playbook -c local -i localhost, {{ playbook }} --extra-vars @{{ conf_file }} 2>&1 | \
+ansible-playbook -c local -i localhost, {{ playbook }} --extra-vars @{{ conf_file }} {{ extra_flags }} 2>&1 | \
     tee -a {{ data_path }}/ansible-log.txt
 {% endfor %}

--- a/salt/orchestrate/edx/init.sls
+++ b/salt/orchestrate/edx/init.sls
@@ -1,6 +1,7 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, BUSINESS_UNIT, PURPOSE_PREFIX, subnet_ids with context %}
 
+{% set ANSIBLE_FLAGS = salt.environ.get('ANSIBLE_FLAGS') %}
 {% set env_settings = salt.pillar.get('environments:{}'.format(ENVIRONMENT)) %}
 {% set purposes = env_settings.purposes %}
 {% set bucket_prefixes = env_settings.secret_backends.aws.bucket_prefixes %}
@@ -118,6 +119,11 @@ build_edx_nodes:
     - highstate: True
     - require:
         - salt: deploy_consul_agent_to_edx_nodes
+    {% if ANSIBLE_FLAGS %}
+    - pillar:
+        edx:
+          ansible_flags: {{ ANSIBLE_FLAGS }}
+    {% endif %}
 
 {% for service in ['edxapp:', 'forum', 'xqueue', 'xqueue_consumer'] %}
 stop_non_edx_worker_services_{{ service }}:


### PR DESCRIPTION
In order to make it easier to only update configuration values during blue/green deploys I added the ability to pass
flags to ansible playbook runs via pillar data and then exposed that as an env var for orchestrate routines. This lets
us specify `ANSIBLE_FLAGS=--tags install:configure` when deploying.