### PR TITLE
Added explicit symlink override for edx DATA_DIR

### DIFF
--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -101,6 +101,17 @@ create_course_asset_symlink:
     - user: edxapp
     - group: www-data
 
+create_edxapp_data_dir_symlink:
+  file.symlink:
+    - name: /edx/app/edxapp/data
+    - target: {{ salt.pillar.get('edx:edxapp:GIT_REPO_DIR', '/mnt/data/prod_repos') }}
+    - makedirs: True
+    - force: True
+    - user: edxapp
+    - group: www-data
+    - require:
+        - cmd: run_ansible
+
 {# Steps to enable git export for courses #}
 make_git_export_directory:
   file.directory:

--- a/salt/edx/tests/test_server_state.sls
+++ b/salt/edx/tests/test_server_state.sls
@@ -1,0 +1,15 @@
+{% from "shared/edx/mitx.jinja" import edx with context %}
+
+ensure_data_dir_symlink_has_proper_target:
+  testinfra.file:
+    - name: /edx/app/edxapp/data
+    - is_symlink: True
+    - linked_to:
+        expected: {{ edx.edxapp_git_repo_dir }}
+        comparison: eq
+    - user:
+        expected: edxapp
+        comparison: eq
+    - group:
+        expected: www-data
+        comparison: eq


### PR DESCRIPTION
The DATA_DIR value is hardcoded to the /edx/app/edxapp/data directory so the configuration repository currently relies on creating a symlink to the `edxapp_course_data_dir` location which we are overriding. Unfortunately, Ansible doesn't actually bother updating the symlink if it is already present on disk so we need to enforce the correct value at deploy time since we are pre-baking the AMIs to increase deployment speed.