### PR TITLE
Changes to complete devstack setup

### DIFF
--- a/pillar/devstack.sls
+++ b/pillar/devstack.sls
@@ -6,9 +6,9 @@
 {% set purpose_suffix = 'devstack' %}
 {% set edx_platform_branch = 'mitx/ficus-1' %}
 
-{% set xqueue_rabbitmq_username = 'xqueue_rabbitmq_user' %}
+{% set xqueue_rabbitmq_username = 'admin' %}
 {% set xqueue_rabbitmq_password = 'changeme' %}
-{% set edxapp_rabbitmq_username = 'edxapp_rabbitmq_user' %}
+{% set edxapp_rabbitmq_username = 'admin' %}
 {% set edxapp_rabbitmq_password = 'changeme' %}
 {% set admin_mysql_username = 'root' %}
 {% set admin_mysql_password = 'changeme' %}
@@ -28,7 +28,7 @@
 {% set xqwatcher_xqueue_password = 'changeme' %}
 
 {% set CELERY_BROKER_PASSWORD = 'changeme' %}
-{% set CELERY_BROKER_USER = 'edxapp' %}
+{% set CELERY_BROKER_USER = 'admin' %}
 {% set DEFAULT_FEEDBACK_EMAIL = 'mitodl-devstack@example.com' %}
 {% set DEFAULT_FROM_EMAIL = 'mitodl-devstack@example.com' %}
 {% set GIT_REPO_DIR = '/repo' %}
@@ -45,6 +45,7 @@
 {% set XQUEUE_USER = 'lms' %}
 {% set edxapp_log_env = 'sandbox' %}
 {% set TLS_KEY_NAME = 'mitodl_devstack' %}
+{% set HOST_IP = '192.168.33.10' %}
 
 edx:
   generate_tls_certificate: True
@@ -68,6 +69,9 @@ edx:
       - memcached
   playbooks:
     - 'edx-stateless.yml'
+  django:
+    django_superuser: 'devstack'
+    django_superuser_password: 'changeme'
 
   ansible_vars:
     ### COMMON VARS ###
@@ -92,7 +96,7 @@ edx:
     XQUEUE_RABBITMQ_HOSTNAME: rabbitmq.service.consul
     XQUEUE_RABBITMQ_PASS: {{ xqueue_rabbitmq_password }}
     XQUEUE_RABBITMQ_USER: {{ xqueue_rabbitmq_username }}
-    XQUEUE_RABBITMQ_VHOST: /xqueue_{{ purpose_suffix }}
+    XQUEUE_RABBITMQ_VHOST: /xqueue
     XQUEUE_WORKERS_PER_QUEUE: 2
 
     common_debian_pkgs:
@@ -203,7 +207,7 @@ edx:
     ########### Environment Configs #####################################
     #####################################################################
     EDXAPP_BUGS_EMAIL: {{ DEFAULT_FEEDBACK_EMAIL }}
-    EDXAPP_CELERY_BROKER_VHOST: /celery_{{ purpose_suffix }}
+    EDXAPP_CELERY_BROKER_VHOST: /celery
     EDXAPP_CODE_JAIL_LIMITS:
       REALTIME: 3
       CPU: 3
@@ -272,6 +276,7 @@ edx:
       - ['Devstack Stacktrace Recipients', {{ DEFAULT_FEEDBACK_EMAIL }}]
       SERVER_EMAIL: {{ DEFAULT_FEEDBACK_EMAIL }}
       TIME_ZONE_DISPLAYED_FOR_DEADLINES: "{{ TIME_ZONE }}"
+      SITE_NAME: {{ HOST_IP }}
 
     EDXAPP_LMS_ENV_EXTRA:
       <<: *common_env_config

--- a/pillar/rabbitmq_devstack.sls
+++ b/pillar/rabbitmq_devstack.sls
@@ -7,6 +7,8 @@ rabbitmq:
     version: '3.6.10-1'
   configuration:
     rabbit:
+      disk_free_limit:
+        mem_relative: 0.2
       auth_backends:
         - '@rabbit_auth_backend_internal'
   env:

--- a/salt/edx/django_user.sls
+++ b/salt/edx/django_user.sls
@@ -1,0 +1,9 @@
+{% set django_superuser = salt.pillar.get('devstack:edx:django:django_superuser', 'devstack') %}
+{% set django_superuser_password = salt.pillar.get('devstack:edx:django:django_superuser_password', 'changeme') %}
+
+create_django_staff_account:
+  cmd.run:
+    - name: python manage.py lms create_user -u {{ django_superuser }} -e {{ django_superuser }}@example.com -p {{ django_superuser_password }} --staff --settings=aws
+    - cwd: /edx/app/edxapp/edx-platform/
+    - env: /edx/app/edxapp/edxapp_env
+    - runas: edxapp

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -119,5 +119,6 @@ base:
     - rabbitmq
     - elasticsearch
     - edx.prod
-    - edx.migration
+    - rabbitmq.configure
+    - edx.django_user
     - edx.tests


### PR DESCRIPTION
- Added configuration value to rabbitmq to set the disk limit to override the existing calculation as the service was failing to start
- Creating a staff django user account so that someone using devstack already has an account that can be used
- Added new django_user state to top file and also reordered list so that rabbitmq.config runs after edxapp gets installed so that the disk space calculation is accurate
- Changed some values in devstack pillar