### PR TITLE
Added quotes around 'env' as it was failing

### DIFF
--- a/pillar/devstack.sls
+++ b/pillar/devstack.sls
@@ -70,8 +70,8 @@ edx:
   playbooks:
     - 'edx-stateless.yml'
   django:
-    django_superuser: 'devstack'
-    django_superuser_password: 'changeme'
+    django_staff_user: 'devstack'
+    django_staff_password: 'changeme'
 
   ansible_vars:
     ### COMMON VARS ###

--- a/salt/edx/django_user.sls
+++ b/salt/edx/django_user.sls
@@ -1,9 +1,9 @@
-{% set django_superuser = salt.pillar.get('devstack:edx:django:django_superuser', 'devstack') %}
-{% set django_superuser_password = salt.pillar.get('devstack:edx:django:django_superuser_password', 'changeme') %}
+{% set django_superuser = salt.pillar.get('devstack:edx:django:django_staff_user', 'devstack') %}
+{% set django_superuser_password = salt.pillar.get('devstack:edx:django:django_staff_password', 'changeme') %}
 
 create_django_staff_account:
   cmd.run:
-    - name: python manage.py lms create_user -u {{ django_superuser }} -e {{ django_superuser }}@example.com -p {{ django_superuser_password }} --staff --settings=aws
+    - name: python manage.py lms create_user -u {{ django_staff_user }} -e {{ django_staff_user }}@example.com -p {{ django_staff_password }} --staff --settings=aws
     - cwd: /edx/app/edxapp/edx-platform/
-    - env: /edx/app/edxapp/edxapp_env
+    - env: '/edx/app/edxapp/edxapp_env'
     - runas: edxapp


### PR DESCRIPTION
Added quotes around 'env' as it was failing. Renamed django devstack pillar to match with what's being created.