### PR TITLE
Adding support for ScyllaDB clusters in AWS

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/scylladb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/scylladb.conf
@@ -1,0 +1,25 @@
+# -*- mode: yaml; coding: utf-8; -*-
+consul:
+  provider: mitx
+  size: t2.medium
+  image: ami-4567933f
+  ssh_username: centos
+  ssh_interface: private_ips
+  script_args: -U -A salt.private.odl.mit.edu
+  block_device_mappings:
+    - DeviceName: /dev/xvda
+      Ebs.VolumeSize: 50
+      Ebs.VolumeType: gp2
+    - DeviceName: /dev/xvdb
+      Ebs.VolumeSize: 100
+      Ebs.VolumeType: gp2
+  iam_profile: scylladb-instance-role
+  tag:
+    role: scylladb
+  grains:
+    roles:
+      - scylladb
+  minion:
+    master:
+      - salt.private.odl.mit.edu
+  sync_after_install: all

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -171,6 +171,26 @@ create_postgres_rds_security_group:
         OU: {{ BUSINESS_UNIT }}
         Environment: {{ ENVIRONMENT }}
 
+create_scylladb_rds_security_group:
+  boto_secgroup.present:
+    - name: scylladb-{{ VPC_RESOURCE_SUFFIX }}
+    - vpc_name: {{ VPC_NAME }}
+    - description: ACL for Scylladb servers
+    - rules:
+        {% for portnum in [7000, 7001, 7199, 9042, 9100, 9160, 9180, 10000] %}
+        - ip_protocol: tcp
+          from_port: {{ portnum }}
+          to_port: {{ portnum }}
+          cidr_ip:
+            - {{ VPC_CIDR }}
+        {% endfor %}
+    - tags:
+        Name: scylladb-{{ VPC_RESOURCE_SUFFIX }}
+        business_unit: {{ BUSINESS_UNIT }}
+        Department: {{ BUSINESS_UNIT }}
+        OU: {{ BUSINESS_UNIT }}
+        Environment: {{ ENVIRONMENT }}
+
 create_webapp_security_group:
   boto_secgroup.present:
     - name: webapp-{{ VPC_RESOURCE_SUFFIX }}

--- a/salt/orchestrate/services/scylladb.sls
+++ b/salt/orchestrate/services/scylladb.sls
@@ -1,0 +1,153 @@
+{% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
+ ENVIRONMENT, BUSINESS_UNIT, subnet_ids with context %}
+{% set INSTANCE_COUNT = salt.environ.get('INSTANCE_COUNT', 3) %}
+{% set scylla_admin_password = salt.random.get_str(42) %}
+
+load_scylladb_cloud_profile:
+  file.managed:
+    - name: /etc/salt/cloud.profiles.d/scylladb.conf
+    - source: salt://orchestrate/aws/cloud_profiles/scylladb.conf
+    - template: jinja
+
+generate_cloud_map_file:
+  file.managed:
+    - name: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_scylladb_map.yml
+    - source: salt://orchestrate/aws/map_templates/instance_map.yml
+    - template: jinja
+    - makedirs: True
+    - context:
+        num_instances: {{ INSTANCE_COUNT }}
+        service_name: scylladb
+        tags:
+          business_unit: {{ BUSINESS_UNIT }}
+        environment_name: {{ ENVIRONMENT }}
+        roles:
+          - scylladb
+        securitygroupid:
+          - {{ salt.boto_secgroup.get_group_id(
+            'scylladb-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+        subnetids: {{ subnet_ids }}
+    - require:
+        - file: load_scylladb_cloud_profile
+
+deploy_scylladb_nodes:
+  salt.runner:
+    - name: cloud.map_run
+    - path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_scylladb_map.yml
+    - kwargs:
+        parallel: True
+    - require:
+        - file: generate_cloud_map_file
+
+format_data_drive:
+  salt.function:
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - blockdev.formatted
+    - kwarg:
+        name: /dev/xvdb
+        fs_type: xfs
+    - require:
+        - salt: deploy_elasticsearch_nodes
+
+mount_data_drive:
+  salt.function:
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: state.single
+    - arg:
+        - mount.mounted
+    - kwarg:
+        name: /var/lib/scylla
+        device: /dev/xvdb
+        fstype: xfs
+        mkmnt: True
+        opts: 'relatime,user'
+    - require:
+        - salt: format_data_drive
+
+sync_external_modules_for_scylladb_nodes:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+
+load_pillar_data_on_{{ ENVIRONMENT }}_scylladb_nodes:
+  salt.function:
+    - name: saltutil.refresh_pillar
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - require:
+        - salt: deploy_scylladb_nodes
+
+populate_mine_with_{{ ENVIRONMENT }}_scylladb_data:
+  salt.function:
+    - name: mine.update
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - require:
+        - salt: load_pillar_data_on_{{ ENVIRONMENT }}_scylladb_nodes
+
+{# Reload the pillar data to update values from the salt mine #}
+reload_pillar_data_on_{{ ENVIRONMENT }}_scylladb_nodes:
+  salt.function:
+    - name: saltutil.refresh_pillar
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - require:
+        - salt: populate_mine_with_{{ ENVIRONMENT }}_scylladb_data
+
+build_{{ ENVIRONMENT }}_scylladb_nodes:
+  salt.state:
+    - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - highstate: True
+    - require:
+        - salt: reload_pillar_data_on_{{ ENVIRONMENT }}_scylladb_nodes
+
+# set_authentication_data_replication_factor:
+#   salt.function:
+#     - name: cassandra_cql.cql_query_with_prepare
+#     - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+#     - tgt_type: compound
+#     - subset: 1
+#     - kwarg:
+#         statement_name: password_replication
+#         query: >-
+#            ALTER KEYSPACE system_auth WITH REPLICATION =
+#            { 'class' : 'SimpleStrategy', 'replication_factor' : ? };
+#         statement_arguments: {{ INSTANCE_COUNT }}
+#         cql_user: cassandra
+#         cql_pass: cassandra
+
+# create_scylla_admin_user:
+#   salt.function:
+#     - name: cassandra_cql.cql_query_with_prepare
+#     - tgt: 'G@roles:scylladb and G@environment:{{ ENVIRONMENT }}'
+#     - tgt_type: compound
+#     - subset: 1
+#     - kwarg:
+#         statement_name: password_replication
+#         query: >-
+#            CREATE ROLE odldevops WITH SUPERUSER = true AND LOGIN = true
+#            AND PASSWORD = '?';
+#         statement_arguments: {{ INSTANCE_COUNT }}
+#         cql_user: cassandra
+#         cql_pass: cassandra
+
+# configure_vault_cassandra_backend:
+#   vault.secret_backend_enabled:
+#     - backend_type: cassandra
+#     - description: Backend to create dynamic Cassandra/Scylla credentials for {{ ENVIRONMENT }}
+#     - mount_point: scylladb-{{ ENVIRONMENT }}
+#     - ttl_max: {{ SIX_MONTHS }}
+#     - ttl_default: {{ SIX_MONTHS }}
+#     - lease_max: {{ SIX_MONTHS }}
+#     - lease_default: {{ SIX_MONTHS }}
+#     - connection_config:
+#         uri: 
+#         verify_connection: False

--- a/salt/scylladb/configure.sls
+++ b/salt/scylladb/configure.sls
@@ -1,0 +1,12 @@
+create_scylladb_server_config_file:
+  file.managed:
+    - name: /etc/scylla/scylla.yaml
+    - contents: |
+        {{ salt.pillar.get('scylladb:configuration')|yaml(False)|indent(8) }}
+
+scylladb_service_enabled:
+  service.running:
+    - name: scylla
+    - enable: True
+    - onchanges:
+        - file: create_scylladb_server_config_file

--- a/salt/scylladb/tests/init.sls
+++ b/salt/scylladb/tests/init.sls
@@ -1,0 +1,4 @@
+include:
+  - .test_configure
+  - .test_service
+  - .test_server

--- a/salt/scylladb/tests/test_configure.sls
+++ b/salt/scylladb/tests/test_configure.sls
@@ -1,0 +1,5 @@
+ensure_configuration_file_exists:
+  testinfra.file:
+    - name: /etc/scylla/scylla.yaml
+    - exists: True
+    - is_file: True

--- a/salt/scylladb/tests/test_server.sls
+++ b/salt/scylladb/tests/test_server.sls
@@ -1,0 +1,7 @@
+verify_data_drive_is_present:
+  testinfra.mount_point:
+    - name: /var/lib/scylla
+    - exists: True
+    - filesystem:
+        expected: xfs
+        comparison: eq

--- a/salt/scylladb/tests/test_service.sls
+++ b/salt/scylladb/tests/test_service.sls
@@ -1,0 +1,12 @@
+ensure_service_is_running:
+  testinfra.service:
+    - name: scylla
+    - is_running: True
+    - is_enabled: True
+
+{% for portnum in [7000, 7001, 7199, 9042, 9100, 9160, 9180, 10000] %}
+ensure_service_is_listening:
+  testinfra.socket:
+    - name: {{ salt.pillar.get('scylladb:configuration:listen_address') }}:{{ portnum }}
+    - is_listening: True
+{% endfor %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -125,3 +125,7 @@ base:
     - edx.prod
     - rabbitmq.configure
     - edx.django_user
+  'roles:scylladb':
+    - match: grain
+    - scylladb.configure
+    - scylladb.tests


### PR DESCRIPTION
Added a cloud profile and orchestrate state, along with configuration deployment and tests for ScyllaDB