### PR TITLE
Added mounting of additional vault endpoints per schema

### DIFF
--- a/salt/orchestrate/aws/postgres_rds.sls
+++ b/salt/orchestrate/aws/postgres_rds.sls
@@ -61,15 +61,17 @@ create_{{ ENVIRONMENT }}_rds_store:
     - require:
         - boto_rds: create_{{ ENVIRONMENT }}_rds_db_subnet_group
 
-configure_vault_postgresql_backend:
+{% for dbname in pg_configs.get('schemas', []).append(pg_configs.get('db_name', 'odldevops') %}
+configure_vault_postgresql_{{ dbname }}_backend:
   vault.secret_backend_enabled:
     - backend_type: postgresql
     - description: Backend to create dynamic PostGreSQL credentials for {{ ENVIRONMENT }}
-    - mount_point: postgresql-{{ ENVIRONMENT }}
+    - mount_point: postgresql-{{ ENVIRONMENT }}-{{ dbname }}
     - ttl_max: {{ SIX_MONTHS }}
     - ttl_default: {{ SIX_MONTHS }}
     - lease_max: {{ SIX_MONTHS }}
     - lease_default: {{ SIX_MONTHS }}
     - connection_config:
-        connection_url: "postgresql://{{ master_user }}:{{ master_pass }}@postgresql.service.{{ ENVIRONMENT }}.consul:5432/{{ pg_configs.get('db_name', 'odldevops') }}"
+        connection_url: "postgresql://{{ master_user }}:{{ master_pass }}@postgresql.service.{{ ENVIRONMENT }}.consul:5432/{{ dbname }}"
         verify_connection: False
+{% endfor %}

--- a/salt/orchestrate/aws/reddit_elb.sls
+++ b/salt/orchestrate/aws/reddit_elb.sls
@@ -34,7 +34,7 @@ create_elb_for_{{ app_name }}_{{ ENVIRONMENT }}:
           zone: odl.mit.edu.
           ttl: 60
     - health_check:
-        target: 'HTTPS:443/heartbeat'
+        target: 'HTTPS:443/'
     - subnets: {{ subnet_ids }}
     - security_groups: {{ security_groups }}
     - tags:


### PR DESCRIPTION
In order to support creation of credentials in a given PostGres DB object the connection URL needs to target that DB.