### PR TITLE
Add entry to /etc/hosts to point the lms DNS name

### DIFF
--- a/salt/edx/etc_hosts.sls
+++ b/salt/edx/etc_hosts.sls
@@ -1,0 +1,9 @@
+#!jinja|yaml
+
+{% set lms_site_name = salt.pillar.get('edx:ansible_vars:EDXAPP_LMS_SITE_NAME') %}
+
+add_etc_hosts_entry:
+  host.present:
+    - ip: 127.0.0.1
+    - names:
+      - {{ lms_site_name }}


### PR DESCRIPTION
Add entry to /etc/hosts to point the lms DNS name to localhost to avoid routing traffic intended to the localhost all the way back out to ELB