### PR TITLE
Added conditional to only apply sticky sessions to draft instances

### DIFF
--- a/salt/orchestrate/aws/mitx_elb.sls
+++ b/salt/orchestrate/aws/mitx_elb.sls
@@ -21,13 +21,17 @@ create_elb_for_edx_{{ purpose_name }}:
           instance_protocol: HTTPS
           certificate: arn:aws:acm:us-east-1:610119931565:certificate/31cbdb62-7553-472b-979a-3063c3e1fddc
           policies:
+            {% if edx_type == 'draft' %}
             - {{ elb_name }}-sticky-cookie-policy
+            {% endif %}
         - elb_port: 80
           instance_port: 80
           elb_protocol: HTTP
           instance_protocol: HTTP
           policies:
+            {% if edx_type == 'draft' %}
             - {{ elb_name }}-sticky-cookie-policy
+            {% endif %}
     - attributes:
         cross_zone_load_balancing:
           enabled: True


### PR DESCRIPTION
Added conditional to only apply sticky sessions to draft instances and skip live ones since we're now using a memcached cluster