### PR TITLE
Changed CacheClusterId to only be purpose name

### DIFF
--- a/salt/orchestrate/aws/elasticache.sls
+++ b/salt/orchestrate/aws/elasticache.sls
@@ -62,7 +62,7 @@ create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_replication_group
 {% else %}
 create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_cluster_{{ cache_purpose }}:
   boto3_elasticache.cache_cluster_present:
-    - CacheClusterId: {{ '{}-{}'.format(cache_purpose, cache_config.engine)[:20].strip('-') }}
+    - CacheClusterId: {{ '{}'.format(cache_purpose)[:20].strip('-') }}
     - NumCacheNodes: {{ cache_config.get('num_cache_nodes', 2) }}
     - AZMode: {{ 'cross-az' if cache_config.get('num_cache_nodes', 2) > 1 else 'single-az' }}
 {% endif %}


### PR DESCRIPTION
Changed CacheClusterId to only be purpose name to better match with the edx build ami elasticache query. The 20 character restriction on the name is causing some complications where if purpose name is too long, we would have a mistmatch between the two and the build would fail.