### PR TITLE
Split fluentd-servers from the logging orchestrate state

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/fluentd.conf
+++ b/salt/orchestrate/aws/cloud_profiles/fluentd.conf
@@ -6,17 +6,14 @@ fluentd:
   ssh_username: admin
   ssh_interface: private_ips
   iam_profile: fluentd-instance-role
-  subnetid: subnet-13305e2e
-  securitygroupid:
-    - sg-0a994772
-    - sg-195cca61
   tag:
     env: prod
-    role: log_agg
+    role: log-aggregator
   grains:
     roles:
       - fluentd
-      - aggregator
+      - fluentd-server
+      - log-aggregator
   minion:
     master:
       - salt.private.odl.mit.edu

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -269,24 +269,3 @@ create_webapp_security_group:
         Department: {{ BUSINESS_UNIT }}
         OU: {{ BUSINESS_UNIT }}
         Environment: {{ ENVIRONMENT }}
-
-create_fluentd_aggregator_security_group:
-  boto_secgroup.present:
-    - name: fluentd-{{ VPC_RESOURCE_SUFFIX }}
-    - vpc_name: {{ VPC_NAME }}
-    - description: ACL for Fluentd aggretators
-    - rules:
-        {% for portnum in [443, 5001] %}
-        - ip_protocol: tcp
-          from_port: {{ portnum }}
-          to_port: {{ portnum }}
-          cidr_ip:
-            - 0.0.0.0/0
-            - '::/0'
-        {% endfor %}
-    - tags:
-        Name: fluentd-{{ VPC_RESOURCE_SUFFIX }}
-        business_unit: {{ BUSINESS_UNIT }}
-        Department: {{ BUSINESS_UNIT }}
-        OU: {{ BUSINESS_UNIT }}
-        Environment: {{ ENVIRONMENT }}

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -269,3 +269,24 @@ create_webapp_security_group:
         Department: {{ BUSINESS_UNIT }}
         OU: {{ BUSINESS_UNIT }}
         Environment: {{ ENVIRONMENT }}
+
+create_fluentd_aggregator_security_group:
+  boto_secgroup.present:
+    - name: fluentd-{{ VPC_RESOURCE_SUFFIX }}
+    - vpc_name: {{ VPC_NAME }}
+    - description: ACL for Fluentd aggretators
+    - rules:
+        {% for portnum in [443, 5001] %}
+        - ip_protocol: tcp
+          from_port: {{ portnum }}
+          to_port: {{ portnum }}
+          cidr_ip:
+            - 0.0.0.0/0
+            - '::/0'
+        {% endfor %}
+    - tags:
+        Name: fluentd-{{ VPC_RESOURCE_SUFFIX }}
+        business_unit: {{ BUSINESS_UNIT }}
+        Department: {{ BUSINESS_UNIT }}
+        OU: {{ BUSINESS_UNIT }}
+        Environment: {{ ENVIRONMENT }}

--- a/salt/orchestrate/operations/services/fluentd.sls
+++ b/salt/orchestrate/operations/services/fluentd.sls
@@ -1,0 +1,102 @@
+{% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
+ ENVIRONMENT, BUSINESS_UNIT, PURPOSE_PREFIX, subnet_ids with context %}
+{% set INSTANCE_COUNT = salt.environ.get('INSTANCE_COUNT', 2) %}
+{% set app_name = 'fluentd' %}
+
+load_{{ app_name }}_cloud_profile:
+  file.managed:
+    - name: /etc/salt/cloud.profiles.d/{{ app_name }}.conf
+    - source: salt://orchestrate/aws/cloud_profiles/{{ app_name }}.conf
+    - template: jinja
+
+generate_{{ app_name }}_cloud_map_file:
+  file.managed:
+    - name: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_{{ app_name }}_map.yml
+    - source: salt://orchestrate/aws/map_templates/instance_map.yml
+    - template: jinja
+    - makedirs: True
+    - context:
+        environment_name: {{ ENVIRONMENT }}
+        num_instances: {{ INSTANCE_COUNT }}
+        service_name: {{ app_name }}
+        roles:
+          - fluentd-server
+          - log-aggregator
+          - {{ app_name }}
+        securitygroupid:
+          - {{ salt.boto_secgroup.get_group_id(
+            'default', vpc_name='mitodl-operations-services') }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'fluentd-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+          - {{ salt.boto_secgroup.get_group_id(
+            'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+        subnetids: {{ subnet_ids }}
+        tags:
+          business_unit: {{ BUSINESS_UNIT }}
+          Department: {{ BUSINESS_UNIT }}
+          OU: {{ BUSINESS_UNIT }}
+          Environment: {{ ENVIRONMENT }}
+    - require:
+        - file: load_{{ app_name }}_cloud_profile
+
+ensure_instance_profile_exists_for_{{ app_name }}:
+  boto_iam_role.present:
+    - name: {{ app_name }}-instance-role
+
+deploy_{{ app_name }}_cloud_map:
+  salt.function:
+    - tgt: 'roles:master'
+    - tgt_type: grain
+    - name: saltutil.runner
+    - arg:
+        - cloud.map_run
+    - kwarg:
+        path: /etc/salt/cloud.maps.d/{{ VPC_RESOURCE_SUFFIX }}_{{ app_name }}_map.yml
+        parallel: True
+        full_return: True
+    - require:
+        - file: generate_{{ app_name }}_cloud_map_file
+
+load_pillar_data_on_{{ app_name }}_nodes:
+  salt.function:
+    - name: saltutil.refresh_pillar
+    - tgt: 'P@roles:{{ app_name }} and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - require:
+        - salt: deploy_{{ app_name }}_cloud_map
+
+populate_mine_with_{{ app_name }}_node_data:
+  salt.function:
+    - name: mine.update
+    - tgt: 'G@roles:{{ app_name }} and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - require:
+        - salt: load_pillar_data_on_{{ app_name }}_nodes
+
+deploy_consul_agent_to_{{ app_name }}_nodes:
+  salt.state:
+    - tgt: 'G@roles:{{ app_name }} and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - sls:
+        - consul
+        - consul.dns_proxy
+
+build_{{ app_name }}_nodes:
+  salt.state:
+    - tgt: 'G@roles:{{ app_name }} and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - highstate: True
+    - require:
+        - salt: deploy_consul_agent_to_{{ app_name }}_nodes
+
+restart_{{ app_name }}_service:
+  salt.function:
+    - tgt: 'G@roles:{{ app_name }} and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+    - name: service.restart
+    - arg:
+        - {{ app_name }}
+    - require:
+        - salt: build_{{ app_name }}_nodes

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -51,7 +51,7 @@ base:
     - fluentd
     - fluentd.plugins
     - fluentd.config
-  'roles:aggregator':
+  'roles:log-aggregator':
     - match: grain
     - fluentd.reverse_proxy
     - datadog.plugins


### PR DESCRIPTION
Split fluentd-servers from the logging orchestrate state which includes elasticsearch and kibana into its own state in order to be able to deploy fluentd-server instances on their own.
