### PR TITLE
Updated the ELB orchestration to directly use the DNS entries

### DIFF
--- a/salt/orchestrate/aws/mitx_elb.sls
+++ b/salt/orchestrate/aws/mitx_elb.sls
@@ -43,8 +43,6 @@ create_elb_for_edx_{{ purpose_name }}:
           timeout: 300
     - cnames:
         {% for domain_key, domain in purpose.domains.items()  %}
-        {% if (edx_type == 'live' and domain_key in ['lms', 'gitreload', 'preview'])
-           or edx_type == 'draft' %}
         - name: {{ domain }}.
           zone: mitx.mit.edu.
           ttl: 60


### PR DESCRIPTION
Now that we are exposing the studio service on the LMS servers we need to ensure that the DNS entries are applied
properly, which means that we no longer need to special case the logic when provisioning the ELBs.