### PR TITLE
Updated rabbit and mongo orchestrate to populate vault password

### DIFF
--- a/salt/orchestrate/services/mongodb.sls
+++ b/salt/orchestrate/services/mongodb.sls
@@ -1,6 +1,10 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, BUSINESS_UNIT, subnet_ids with context %}
+{% set mongo_admin_password = salt.vault.read('secret-{}/{}/mongodb-admin-password'.format(BUSINESS_UNIT, ENVIRONMENT)).data.value %}
+{% if not mongo_admin_password %}
 {% set mongo_admin_password = salt.random.get_str(42) %}
+{% salt.vault.write('secret-{}/{}/mongodb-admin-password'.format(BUSINESS_UNIT, ENVIRONMENT), value=mongo_admin_password) %}
+{% endif %}
 {% set SIX_MONTHS = '4368h' %}
 
 load_mongodb_cloud_profile:

--- a/salt/orchestrate/services/rabbitmq.sls
+++ b/salt/orchestrate/services/rabbitmq.sls
@@ -1,6 +1,10 @@
 {% from "orchestrate/aws_env_macro.jinja" import VPC_NAME, VPC_RESOURCE_SUFFIX,
  ENVIRONMENT, BUSINESS_UNIT, subnet_ids with context %}
+{% set rabbit_admin_password = salt.vault.read('secret-{}/{}/rabbitmq-admin-password'.format(BUSINESS_UNIT, ENVIRONMENT)).data.value %}
+{% if not rabbit_admin_password %}
 {% set rabbit_admin_password = salt.random.get_str(42) %}
+{% salt.vault.write('secret-{}/{}/rabbitmq-admin-password'.format(BUSINESS_UNIT, ENVIRONMENT), value=rabbitmq_admin_password) %}
+{% endif %}
 {% set SIX_MONTHS = '4368h' %}
 
 load_rabbitmq_cloud_profile:


### PR DESCRIPTION
Updated the orchestrate states to make them more re-entrant by storing the generated admin password in vault to be retrieved in pillar data for future runs.