### PR TITLE
Added a reactor to notify on Slack when a lease will be expiring.

### DIFF
--- a/salt/reactors/vault/alert_expiring_leases.sls
+++ b/salt/reactors/vault/alert_expiring_leases.sls
@@ -1,0 +1,12 @@
+alert_on_lease_near_expiration:
+  local.slack.post_message:
+    - tgt: 'roles:master'
+    - expr_form: grain
+    - kwarg:
+        channel: "#devops"
+        message: |
+          @channel The Vault lease `{{ data['id'] }}` will be expiring at `{{ data['expire_time'] }}`.
+          ```
+          {{ data|json()|indent(10) }}
+          ```
+        from_name: "saltbot"


### PR DESCRIPTION
#### What are the relevant tickets?
#512 

#### What's this PR do?
Adds a reactor to notify in Slack when an event is fired to signify a lease expiring in Vault

#### Any background context you want to provide?
There have been a handful of occasions where a set of Vault credentials expired and resulted in systems failing without our knowledge. This will provide advance warning of this type of situation.
