### PR TITLE
Added logic to purge unwanted EFS mount configs from the fstab

### DIFF
--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -83,6 +83,18 @@ place_tls_{{ ext }}_file:
 {% endif %}
 
 {% if 'devstack' not in salt.grains.get('roles') %}
+{% set device_name = '{}.{}.efs.us-east-1.amazonaws.com:/'.format(salt.grains.get('ec2:availability_zone', 'us-east-1b'), salt.pillar.get('edx:efs_id')) %}
+{% fstab_contents = salt.mount.fstab() %}
+{% for fmount, settings in fstab_contents.items() %}
+{% if fmount == '/mnt/data' and settings.fstype == 'nfs4' and settings.device != device_name %}
+remove_{{ settings.device }}_mount_config_from_fstab:
+  mount.unmounted:
+    - name: {{ fmount }}
+    - device: {{ settings.device }}
+    - persist: True
+{% endif %}
+{% endfor %}
+
 mount_efs_filesystem_for_course_assets:
   mount.mounted:
     - name: /mnt/data


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Addresses the case where an edX AMI is built in QA with one EFS mount point and then gets deployed to production, where a second mount point for the same directory with a different EFS destination is appended, instead of replacing the original. This has resulted in non-deterministic behavior that causes the course assets to not be mounted on the instance.

#### How should this be manually tested?
Take a production instance out of rotation and apply the state to it to ensure there is only one mount configuration specified for /mnt/data/

#### Where should the reviewer start?
salt/edx/prod.sls