### PR TITLE
Change fluentd pillar for new version

### DIFF
--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -1,6 +1,6 @@
 fluentd:
   overrides:
-    version: "1.1.1"
+    version: "1.7.4"
     user: root
     group: root
   plugins:


### PR DESCRIPTION
#### What's this PR do?
- Updated fluentd version to 1.1.0
- Removed fluent-plugin-heroku-syslog as we are using the built-in syslog plugin
- Removed fluent-plugin-secure-forward as it has been deprecated
- Removed the directive using secure_foward
- Modified heroku logs to listen on localhost since we will be using stunnel to first receive the logs from heroku drains
- Modified buffering directives since the formatting changes with new fluentd release

#### How should this be manually tested?
I ran it on my local test-minion and was able to start the service with no errors or warnings
