### PR TITLE
Use request_uri to pass query parameters to Elasticsearch

### DIFF
--- a/pillar/nginx/micromasters_es.sls
+++ b/pillar/nginx/micromasters_es.sls
@@ -26,7 +26,7 @@ nginx:
                     - '[::]:443'
                     - ssl
                 - location ~ ^/(_alias|_aliases|micromasters|_refresh|_mapping):
-                    - proxy_pass: http://127.0.0.1:9200$uri
+                    - proxy_pass: http://127.0.0.1:9200$request_uri
                     - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                     - proxy_pass_header: 'X-Api-Key'
                 - location /nginx_status:


### PR DESCRIPTION
#### What are the relevant tickets?
Required for https://github.com/mitodl/micromasters/issues/3694

#### What's this PR do?
Uses `$request_uri` which passes query parameters to Elasticsearch

#### How should this be manually tested?
I modified my own instance of micromasters to have elastic use an nginx proxy. My configuration works:

    server {
        listen 9200 default_server;
    
        server_name micromasters.mit.local;
        location ~ ^/(_alias|_aliases|micromasters|_refresh|_mapping) {
            proxy_pass http://172.18.0.1:9300$request_uri;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_pass_header X-Api-Key;
        }
    }
