### PR TITLE
Monit checks for nginx cert expiration and latex2edx connection

### DIFF
--- a/pillar/monit/latex2edx.sls
+++ b/pillar/monit/latex2edx.sls
@@ -1,0 +1,12 @@
+monit_app:
+  notification: 'slack'
+  modules:
+    latex2edx:
+      host:
+        custom:
+          name: studio-input-filter.mitx.mit.edu
+        with:
+          address: studio-input-filter.mitx.mit.edu
+        if:
+          failed: port 443 protocol https request "/latex2edx?raw=1" status = 200
+          action: exec "/bin/sh -c /usr/local/bin/slack.sh"

--- a/pillar/monit/nginx_cert_expiration.sls
+++ b/pillar/monit/nginx_cert_expiration.sls
@@ -1,0 +1,16 @@
+monit_app:
+  notification: 'slack'
+  modules:
+    nginx_cert_expiration:
+      process:
+        custom:
+          name: nginx
+        with:
+          pidfile: /var/run/nginx.pid
+        config:
+          group: www
+          start: "/etc/init.d/nginx start"
+          stop: "/etc/init.d/nginx stop"
+        if:
+          failed: port 443 protocol https and certificate valid > 30 days
+          action: exec "/bin/sh -c /usr/local/bin/slack.sh"


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#526](https://github.com/mitodl/salt-ops/issues/526)

#### What's this PR do?
Sent slack notifications when:
- nginx cert is about to expire in 30 days or less
- check latex2edx connection and alert if response is not 200