### PR TITLE
Monit notifications for mysql and mongodb

### DIFF
--- a/pillar/monit/mongodb_connection.sls
+++ b/pillar/monit/mongodb_connection.sls
@@ -1,0 +1,20 @@
+#!jinja|yaml
+
+{% set env = salt.grains.get('environment', 'mitx-qa') %}
+{% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
+{% set mongodb_host = 'mongodb-master.service.consul' %}
+{% set mongodb_port = 27017 %}
+{% set mongodb_contentstore_creds = salt.vault.read('mongodb-{env}/creds/contentstore-{purpose}'.format(env=env, purpose=purpose)) %}
+
+monit_app:
+  notification: 'slack'
+  modules:
+    edx2mysql:
+      host:
+        custom:
+          name: {{ mongodb_host }}
+        with:
+          address: {{ mongodb_host }}
+        if:
+          failed: port {{ mongodb_port }} protocol mongodb username "{{ mongodb_contentstore_creds.data.username }}" password "{{ mongodb_contentstore_creds.data.password }}"
+          action: exec "/bin/sh -c /usr/local/bin/slack.sh"

--- a/pillar/monit/mysql_connection.sls
+++ b/pillar/monit/mysql_connection.sls
@@ -1,0 +1,20 @@
+#!jinja|yaml
+
+{% set env = salt.grains.get('environment', 'mitx-qa') %}
+{% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
+{% set edxapp_mysql_host = 'mysql.service.consul' %}
+{% set edxapp_mysql_port = 3306 %}
+{% set edxapp_mysql_creds = salt.vault.read('mysql-{env}/creds/edxapp-{purpose}'.format(env=env, purpose=purpose)) %}
+
+monit_app:
+  notification: 'slack'
+  modules:
+    edx2mysql:
+      host:
+        custom:
+          name: {{ edxapp_mysql_host }}
+        with:
+          address: {{ edxapp_mysql_host }}
+        if:
+          failed: port {{ edxapp_mysql_port }} protocol mysql username "{{ edxapp_mysql_creds.data.username }}" password "{{ edxapp_mysql_creds.data.password }}"
+          action: exec "/bin/sh -c /usr/local/bin/slack.sh"


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#526](https://github.com/mitodl/salt-ops/issues/526)

#### What's this PR do?
Configures the following monit alerts:
- check mysql connection and send slack notification on failure
- check mongodb connection and send slack notification on failure

#### How should this be manually tested?
Easiest would be to merge it and then test it on QA  and tweaked accordingly
