### PR TITLE
Added pgbouncer to list of states for running on a schedule

### DIFF
--- a/pillar/reddit.sls
+++ b/pillar/reddit.sls
@@ -31,6 +31,7 @@ schedule:
     function: state.sls
     args:
       - reddit.config
+      - pgbouncer
 
 reddit:
   environment:


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds the pgbouncer state to the list of states applied on a schedule for Reddit servers

#### Any background context you want to provide?
The pgbouncer state controls the connection of Reddit to the RDS instances. Added it to the list of states to be run on a scheduled basis for refreshing credentials.