### PR TITLE
Changed celery worker concurrency numbers

### DIFF
--- a/pillar/edx/ansible_vars.sls
+++ b/pillar/edx/ansible_vars.sls
@@ -178,27 +178,27 @@ edx:
     EDXAPP_CELERY_WORKERS:
       - queue: low
         service_variant: cms
-        concurrency: 1
+        concurrency: 5
         monitor: True
       - queue: default
         service_variant: cms
-        concurrency: 1
+        concurrency: 4
         monitor: True
       - queue: high
         service_variant: cms
-        concurrency: 1
+        concurrency: 3
         monitor: True
       - queue: low
         service_variant: lms
-        concurrency: 1
+        concurrency: 5
         monitor: True
       - queue: default
         service_variant: lms
-        concurrency: 2
+        concurrency: 4
         monitor: True
       - queue: high
         service_variant: lms
-        concurrency: 2
+        concurrency: 3
         monitor: True
       - queue: high_mem
         service_variant: lms


### PR DESCRIPTION
Changed celery worker concurrency numbers since after looking at the load on the worker instances, it appears that we can run more tasks on them and thus speed things up a bit

#### What's this PR do?
It should help speed things up as far as task processing since the workers would be able to handle more tasks concurrently.