### PR TITLE
Added the scroll permission to the _all index

### DIFF
--- a/pillar/elasticsearch/micromasters.sls
+++ b/pillar/elasticsearch/micromasters.sls
@@ -69,6 +69,7 @@ elasticsearch:
               - 'indices:admin/get'
               - 'indices:admin/exists'
               - 'indices:admin/refresh[s]'
+              - 'indices:data/read/scroll'
             auth_key: {{ rc_auth_key }}
           - name: View existence of indices with CI Auth
             type: allow
@@ -85,6 +86,7 @@ elasticsearch:
               - 'indices:admin/get'
               - 'indices:admin/exists'
               - 'indices:admin/refresh[s]'
+              - 'indices:data/read/scroll'
             auth_key: {{ ci_auth_key }}
           - name: View existence of indices with Production Auth
             type: allow
@@ -101,6 +103,7 @@ elasticsearch:
               - 'indices:admin/get'
               - 'indices:admin/exists'
               - 'indices:admin/refresh[s]'
+              - 'indices:data/read/scroll'
             auth_key: {{ production_auth_key }}
     products:
       elasticsearch: '5.x'


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds the `scroll` permission on the `_all` index to allow for using the scroll API when bulk emailing in micromasters.

#### How should this be manually tested?
Deploy the change to elasticsearch and test the code which uses the scroll API

#### Any background context you want to provide?
The `scroll` API was returning a 405 error because of the fact that it is specifying an index as part of the request and does not use the index name as part of the URL. Added the `indices:data/read/scroll` action to the list of allowed operations for the `_all` index.

Refer to https://github.com/beshu-tech/readonlyrest-docs/blob/master/elasticsearch.md#action-rule for the available list of actions for configuring readonlyrest.