### PR TITLE
Added the _search route to the allowed paths

### DIFF
--- a/pillar/nginx/micromasters_es.sls
+++ b/pillar/nginx/micromasters_es.sls
@@ -29,6 +29,10 @@ nginx:
                     - proxy_pass: http://127.0.0.1:9200$request_uri
                     - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                     - proxy_pass_header: 'X-Api-Key'
+                - location /_search/scroll:
+                    - proxy_pass: http://127.0.0.1:9200$request_uri
+                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                    - proxy_pass_header: 'X-Api-Key'
                 - location /nginx_status:
                     - stub_status: 'on'
                     - allow: 127.0.0.1


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes the `scroll` api calls in micromasters

#### How should this be manually tested?
Deploy it to the ES cluster and verify micromasters functionality

#### Any background context you want to provide?
Since the `scroll` API requires access to the `_search` path I added it to the location regex for proxying requests to ES from Nginx.