### PR TITLE
Added elastalert check for 502 status in nginx logs

### DIFF
--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -46,11 +46,16 @@ fluentd:
             - tag: reddit.nginx.access
             - path: /var/log/nginx/access.log
             - pos_file: /var/log/nginx/access.log.pos
-            - format: keyvalue
-            - key_value_seperator: '='
-            - pair_delimiter: '" "'
-            - time_key: time
-            - types: time:time
+            - nested_directives:
+                - directive: parse
+                  attrs:
+                    - '@type': ltsv
+                    - null_value_pattern: '-'
+                    - keep_time_key: 'true'
+                    - label_delimiter: '='
+                    - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'
+                    - time_key: time
+                    - types: time:time
         - directive: source
           attrs:
             - '@id': reddit_nginx_error_log

--- a/pillar/kibana.sls
+++ b/pillar/kibana.sls
@@ -236,6 +236,34 @@ elasticsearch:
           slack_channel_override: "#devops"
           slack_username_override: "Elastalert"
           slack_msg_color: "warning"
+      - name: nginx_bad_gateway
+        settings:
+          name: Alert on bad gateway errors from Nginx
+          description: >-
+            Notify for occurrences of 502 errors on applications that use Nginx to proxy requests to an upstream
+            process
+          type: frequency
+          index: logstash-*
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - slack
+          alert_text: >-
+            <@devopseng> The upstream service on {minion} is not responding to Nginx
+          alert_text_kw:
+            minion: minion_id
+          slack_webhook_url: {{ slack_webhook_url_devops }}
+          slack_channel_override: "#devops"
+          slack_username_override: Elastalert
+          slack_msg_color: warning
+          filter:
+            - bool:
+                must:
+                  - match:
+                      fluentd_tag: '*.nginx.*'
+                  - term:
+                      status: 502
 
 kibana:
   lookup:


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds an elastalert check for 502 errors from Nginx logs to alert us of errors in upstream services (e.g. uWSGI)

#### How should this be manually tested?
Deploy to kibana and run `salt kibana* cmd.run 'elastalert-test-rule rules/nginx_bad_gateway.yaml --alert' cwd=/etc/elastalert`

#### Where should the reviewer start?
`pillar/kibana.sls`