### PR TITLE
Added techtv domain to server name list

### DIFF
--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -36,7 +36,9 @@ nginx:
           enabled: True
           config:
             - server:
-                - server_name: {{ server_domain_name }}
+                - server_name:
+                    - {{ server_domain_name }}
+                    - techtv.mit.edu
                 - listen:
                     - 80
                 - listen:
@@ -44,7 +46,9 @@ nginx:
                 - location /:
                     - return: 301 https://$host$request_uri
             - server:
-                - server_name: {{ server_domain_name }}
+                - server_name:
+                    - {{ server_domain_name }}
+                    - techtv.mit.edu
                 - listen:
                     - 443
                     - ssl


### PR DESCRIPTION
Adding the techtv domain to the nginx config allows the site to respond to requests that are using that domain name.