### PR TITLE
Restart uwsgi when there is a change to the environment variables

### DIFF
--- a/salt/apps/odlvideo/install.sls
+++ b/salt/apps/odlvideo/install.sls
@@ -17,5 +17,10 @@ create_env_file_for_odlvideo:
         {%- for var, val in salt.pillar.get('django:environment').items() %}
         {{ var }}={{ val }}
         {%- endfor %}
+  service.running:
+    - name: uwsgi
+    - reload: True
+    - watch:
+      - file: create_env_file_for_odlvideo
     - require:
         - deploy_application_source_to_destination


### PR DESCRIPTION
#### What's this PR do?
Anytime environment variables change, uwsgi gets restarted.

#### How should this be manually tested?
Test a deploy to `RC` and verify that the task completes successfully

#### Any background context you want to provide?
Noticed that sometimes after a deploy, uwsgi and celery don't appear to be using the added/modified environment variables. After looking it, it appeared that the uwsgi emperor was still running along with an old uwsgi process that did not get restarted.

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)