### PR TITLE
add env vars for settings needed for analytics

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -11,6 +11,7 @@
       'log_level': 'DEBUG',
       'use_shibboleth': False,
       'ga_id': 'UA-108097284-1',
+      'ga_view_id': '163329706',
       'transcode_pipeline_id': '1506027488410-93oya5',
       'youtube_project_id': 'ovs-youtube-qa',
       'release_branch': 'master',
@@ -23,6 +24,7 @@
       'log_level': 'INFO',
       'use_shibboleth': True,
       'ga_id': 'UA-5145472-27',
+      'ga_view_id': '163330947',
       'transcode_pipeline_id': '1506081628031-bepkel',
       'youtube_project_id': 'ovs-youtube-qa',
       'release_branch': 'release-candidate',
@@ -35,6 +37,7 @@
       'log_level': 'WARN',
       'use_shibboleth': True,
       'ga_id': 'UA-5145472-27',
+      'ga_view_id': '163330947',
       'transcode_pipeline_id': '1497541042228-8mpenl',
       'youtube_project_id': 'ovs-youtube-production',
       'release_branch': 'release',
@@ -89,7 +92,7 @@ django:
     ET_PRESET_IDS: 1504127981769-6cnqhq,1504127981819-v44xlx,1504127981867-06dkm6,1504127981921-c2jlwt
     GA_DIMENSION_CAMERA: dimension1
     GA_KEYFILE_JSON: {{ salt.vault.read('secret-odl-video/{env}/ga-keyfile-json'.format(env=ENVIRONMENT)).data.value }}
-    GA_VIEW_ID: {{ salt.vault.read('secret-odl-video/{env}/ga-view-id'.format(env=ENVIRONMENT)).data.value }}
+    GA_VIEW_ID: {{ env_data.ga_view_id }}
     GA_TRACKING_ID: {{ env_data.ga_id }}
     LECTURE_CAPTURE_USER: {{ salt.sdb.get('sdb://consul/odl-video-service/lecture-capture-user') }}
     MAILGUN_KEY: {{ salt.vault.read('secret-operations/global/mailgun-api-key').data.value }}

--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -88,6 +88,8 @@ django:
     ET_PIPELINE_ID: {{ env_data.transcode_pipeline_id }}
     ET_PRESET_IDS: 1504127981769-6cnqhq,1504127981819-v44xlx,1504127981867-06dkm6,1504127981921-c2jlwt
     GA_DIMENSION_CAMERA: dimension1
+    GA_KEYFILE_JSON: {{ salt.vault.read('secret-odl-video/{env}/ga-keyfile-json'.format(env=ENVIRONMENT)).data.value }}
+    GA_VIEW_ID: {{ salt.vault.read('secret-odl-video/{env}/ga-view-id'.format(env=ENVIRONMENT)).data.value }}
     GA_TRACKING_ID: {{ env_data.ga_id }}
     LECTURE_CAPTURE_USER: {{ salt.sdb.get('sdb://consul/odl-video-service/lecture-capture-user') }}
     MAILGUN_KEY: {{ salt.vault.read('secret-operations/global/mailgun-api-key').data.value }}


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/issues/402

#### What's this PR do?
Adds variables for settings related to video analytics queries:
1. GA_KEYFILE_JSON: a json string representing a keyfile for a Google Analytics service account.
2. GA_VIEW_ID: a string representing the ID of a Google Analytics view.

#### Any background context you want to provide?
Need to add the following to vault:

1. secrets for production:
  - `secret-odl-video/production/ga-keyfile-json`
  - `secret-odl-video/production/ga-view-id`
2. secrets for ci:
  - `secret-odl-video/ci/ga-keyfile-json`
  - `secret-odl-video/ci/ga-view-id`
