### PR TITLE
Added edx codename as grain and conditional for static assets

### DIFF
--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -152,6 +152,16 @@ install_edxapp_theme:
     - require_in:
       - cmd: run_ansible
 
+{# TODO Remove this conditional once we release Hawthorn (TMM 2018-04-05) #}
+{% if salt.grains.get('edx_codename') == 'hawthorn' %}
+compile_assets_for_edx:
+  cmd.run:
+    - name: /edx/bin/edxapp-update-assets
+    - onchanges:
+        - git: install_edxapp_theme
+    - require:
+        - cmd: run_ansible
+{% else %}
 compile_assets_for_lms:
   cmd.run:
     - name: /edx/bin/edxapp-update-assets-lms
@@ -167,6 +177,7 @@ compile_assets_for_cms:
         - git: install_edxapp_theme
     - require:
         - cmd: run_ansible
+{% endif %}
 {% endif %}
 
 {% for host in git_servers %}

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -71,6 +71,7 @@ generate_edx_cloud_map_file:
           Department: {{ BUSINESS_UNIT }}
           OU: {{ BUSINESS_UNIT }}
           Environment: {{ ENVIRONMENT }}
+          edx_codename: {{ codename }}
         profile_overrides:
           userdata_file: '/etc/salt/cloud.d/edx_userdata.yml'
         app_types:


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
The path for the script(s) to recompile static assets on edX has changed in master/Hawthorn so I added the codename grain to deployed instances for future reference, and a conditional for specifying which command to use for building assets.