### PR TITLE
Added event triggers to backup/restore states and slack messages

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -140,6 +140,12 @@ salt_master:
             - salt://reactors/edx/inotify_mitx.sls
         - vault/lease/expiring/*:
             - salt://reactors/vault/alert_expiring_leases.sls
+        - salt/state_result/*/restore/*/result:
+            - salt://reactors/slack/post_event.sls
+        - salt/state_result/*/backup/*/result:
+            - salt://reactors/slack/post_event.sls
+    misc:
+      cache: consul
     sdb:
       consul:
         driver: consul

--- a/salt/backups/backup.sls
+++ b/salt/backups/backup.sls
@@ -1,3 +1,5 @@
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+
 install_duplicity:
   pkg.installed:
     - pkgs:
@@ -34,7 +36,8 @@ run_backup_for_{{ service.title }}:
         settings: {{ service.settings }}
     - parallel: True
     - require_in:
-        - event: wait_for_backups_to_complete
+        - file: wait_for_backups_to_complete
+    - fire_event: backup/{{ ENVIRONMENT }}/{{ service.title }}/result
 {% endfor %}
 
 wait_for_backups_to_complete:

--- a/salt/backups/restore.sls
+++ b/salt/backups/restore.sls
@@ -1,3 +1,5 @@
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+
 install_duplicity:
   pkg.installed:
     - pkgs:
@@ -34,7 +36,8 @@ run_restore_for_{{ service.title }}:
         settings: {{ service.settings }}
     - parallel: True
     - require_in:
-        - event: wait_for_restores_to_complete
+        - file: wait_for_restores_to_complete
+    - fire_event: restore/{{ ENVIRONMENT }}/{{ service.title }}
 {% endfor %}
 
 wait_for_restores_to_complete:

--- a/salt/reactors/slack/post_event.sls
+++ b/salt/reactors/slack/post_event.sls
@@ -1,0 +1,8 @@
+post_event_to_slack:
+  local.slack.post_message:
+    - tgt: 'roles:master'
+    - tgt_type: grain
+    - kwarg:
+        channel: "#devops"
+        message: "SaltStack Event {{ tag }}:`{{ data }}`"
+        from_name: "saltbot"


### PR DESCRIPTION
In order to get more visibility into the overall execution of our backup/restore jobs I added event triggers to the state runs for each script and set up a slack message to post the results of those events