### PR TITLE
Added residential-live suffix to sandbox purpose

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -149,7 +149,7 @@ environments:
           edx-worker:
             number: 1
             type: t2.medium
-      sandbox:
+      sandbox-residential-live:
         business_unit: operations
         domains:
           cms: studio-mitx-qa-sandbox.mitx.mit.edu


### PR DESCRIPTION
#### What's this PR do?
`build_ami` state fails because Jinja variable dict object has no attribute `sandbox-live`. After looking at the build_ami state file, it looks like it fails at setting the value for `edx_codename` since we hardcode the `live` suffix in that value. 
This PR changes the `sandbox` purpose to be aligned with the other existing purposes by appending a `residential-live` suffix to the purpose name.