### PR TITLE
Added variables for Hawthorn release

### DIFF
--- a/pillar/edx/ansible_vars.sls
+++ b/pillar/edx/ansible_vars.sls
@@ -150,11 +150,6 @@ edx:
     EDXAPP_MYSQL_PASSWORD: {{ edxapp_mysql_creds.data.password }}
     EDXAPP_MYSQL_PORT: {{ MYSQL_PORT }}
     EDXAPP_MYSQL_USER: {{ edxapp_mysql_creds.data.username }}
-    EDXAPP_MYSQL_CSMH_DB_NAME: edxapp_csmh_{{ purpose_suffix }}
-    EDXAPP_MYSQL_CSMH_USER: {{ edxapp_csmh_mysql_creds.data.username }}
-    EDXAPP_MYSQL_CSMH_PASSWORD: {{ edxapp_csmh_mysql_creds.data.password }}
-    EDXAPP_MYSQL_CSMH_HOST: {{ MYSQL_HOST }}
-    EDXAPP_MYSQL_CSMH_PORT: {{ MYSQL_PORT }}
 
     #####################################################################
     ########### Auth Configs ############################################

--- a/pillar/edx/ansible_vars.sls
+++ b/pillar/edx/ansible_vars.sls
@@ -22,6 +22,10 @@
     'mysql-{env}/creds/edxapp-{purpose}'.format(
         env=environment,
         purpose=purpose)) %}
+{% set edxapp_csmh_mysql_creds = salt.vault.read(
+    'mysql-{env}/creds/edxapp-csmh-{purpose}'.format(
+        env=environment,
+        purpose=purpose)) %}
 {% set edxapp_mongodb_contentstore_creds = salt.vault.read(
     'mongodb-{env}/creds/contentstore-{purpose}'.format(
         env=environment,
@@ -146,6 +150,11 @@ edx:
     EDXAPP_MYSQL_PASSWORD: {{ edxapp_mysql_creds.data.password }}
     EDXAPP_MYSQL_PORT: {{ MYSQL_PORT }}
     EDXAPP_MYSQL_USER: {{ edxapp_mysql_creds.data.username }}
+    EDXAPP_MYSQL_CSMH_DB_NAME: edxapp_csmh_{{ purpose_suffix }}
+    EDXAPP_MYSQL_CSMH_USER: {{ edxapp_csmh_mysql_creds.data.username }}
+    EDXAPP_MYSQL_CSMH_PASSWORD: {{ edxapp_csmh_mysql_creds.data.password }}
+    EDXAPP_MYSQL_CSMH_HOST: {{ MYSQL_HOST }}
+    EDXAPP_MYSQL_CSMH_PORT: {{ MYSQL_PORT }}
 
     #####################################################################
     ########### Auth Configs ############################################
@@ -173,6 +182,7 @@ edx:
     EDXAPP_ANALYTICS_DASHBOARD_URL: !!null
     {# multivariate #}
     EDXAPP_CELERY_BROKER_VHOST: /celery_{{ purpose_suffix }}
+    EDXAPP_CELERY_BROKER_TRANSPORT: 'amqp'
     EDXAPP_CMS_BASE: {{ CMS_DOMAIN }}
     EDXAPP_CMS_MAX_REQ: 1000
     EDXAPP_ENABLE_CSMH_EXTENDED: False

--- a/pillar/edx/init.sls
+++ b/pillar/edx/init.sls
@@ -7,6 +7,9 @@
 {% set mitx_wildcard_cert = salt.vault.read('secret-operations/global/mitx_wildcard_cert') %}
 
 edx:
+  config:
+    repo: {{ purpose_data.versions.edx_config_repo }}
+    branch: {{ purpose_data.versions.edx_config_version }}
   mongodb:
     replset_name: rs0
   ssh_key: |

--- a/pillar/edx/mitx-production.sls
+++ b/pillar/edx/mitx-production.sls
@@ -1,9 +1,6 @@
 #!jinja|yaml|gpg
 
 edx:
-  config:
-    repo: https://github.com/mitodl/configuration.git
-    branch: open-release/ginkgo.master
   gitreload:
     basic_auth:
       username: mitx

--- a/pillar/edx/mitx-qa.sls
+++ b/pillar/edx/mitx-qa.sls
@@ -2,9 +2,6 @@
 {% set SAML_SP_CERT = salt.vault.read('secret-residential/mitx-qa/saml-sp-cert') %}
 
 edx:
-  config:
-    repo: https://github.com/mitodl/configuration.git
-    branch: open-release/ginkgo.master
   gitreload:
     basic_auth:
       username: mitx

--- a/pillar/edx/next_residential.sls
+++ b/pillar/edx/next_residential.sls
@@ -1,10 +1,26 @@
 edx:
-  config:
-    repo: https://github.com/edx/configuration.git
-    branch: master
   ansible_vars:
-    EDXAPP_MONGO_REPLICA_SET: rs0
     EDXAPP_CELERY_BROKER_HOSTNAME: nearest-rabbitmq.query.consul
     EDXAPP_CELERY_BROKER_TRANSPORT: 'amqp'
-    EDXAPP_PLATFORM_DESCRIPTION: 'MITx Residential Online Course Portal'
     EDXAPP_EXTRA_MIDDLEWARE_CLASSES: [] # Worth keeping track of in case we need to take advantage of it
+    EDXAPP_MONGO_REPLICA_SET: rs0
+    EDXAPP_MYSQL_CSMH_DB_NAME: edxapp_csmh_{{ purpose_suffix }}
+    EDXAPP_MYSQL_CSMH_HOST: {{ MYSQL_HOST }}
+    EDXAPP_MYSQL_CSMH_PASSWORD: {{ edxapp_csmh_mysql_creds.data.password }}
+    EDXAPP_MYSQL_CSMH_PORT: {{ MYSQL_PORT }}
+    EDXAPP_MYSQL_CSMH_USER: {{ edxapp_csmh_mysql_creds.data.username }}
+    EDXAPP_PLATFORM_DESCRIPTION: 'MITx Residential Online Course Portal'
+    EDXAPP_PRIVATE_REQUIREMENTS:
+        # For Harvard courses:
+        # Peer instruction XBlock
+        - name: ubcpi-xblock==0.6.4
+        # Vector Drawing and ActiveTable XBlocks (Davidson)
+        - name: git+https://github.com/open-craft/xblock-vectordraw.git@c57df9d98119fd2ca4cb31b9d16c27333cdc65ca#egg=xblock-vectordraw==0.2.1
+          extra_args: -e
+        - name: git+https://github.com/open-craft/xblock-activetable.git@e933d41bb86a8d50fb878787ca680165a092a6d5#egg=xblock-activetable
+          extra_args: -e
+       # MITx Residential XBlocks
+        - name: git+https://github.com/mitodl/edx-sga@5f21fb4900e1cde573a5406572d3f31a0ea7d5dd#egg=edx-sga==0.8.1
+          extra_args: -e
+        - name: git+https://github.com/mitodl/rapid-response-xblock@4251bb15124bdf0b681b431fa1cd67fd094387c4#egg=rapid-response-xblock
+          extra_args: -e

--- a/pillar/edx/residential_ansible_vars.sls
+++ b/pillar/edx/residential_ansible_vars.sls
@@ -272,6 +272,7 @@ edx:
     EDXAPP_GRADE_STORAGE_TYPE: S3
     EDXAPP_GIT_REPO_DIR: "{{ edxapp_git_repo_dir }}"
     EDXAPP_PLATFORM_NAME: MITx Residential
+    # EDXAPP_PLATFORM_DESCRIPTION: 'Your Platform Description Here'
     EDXAPP_TECH_SUPPORT_EMAIL: mitx-support@mit.edu
     EDXAPP_CMS_ISSUER: "{{ EDXAPP_CMS_ISSUER }}"
     EDXAPP_COMMENTS_SERVICE_KEY: {{ COMMENTS_SERVICE_KEY }}

--- a/pillar/edx/residential_ansible_vars.sls
+++ b/pillar/edx/residential_ansible_vars.sls
@@ -170,7 +170,7 @@ edx:
     XQUEUE_RABBITMQ_PASS: {{ xqueue_rabbitmq_creds.data.password }}
     XQUEUE_RABBITMQ_USER: {{ xqueue_rabbitmq_creds.data.username }}
     XQUEUE_RABBITMQ_VHOST: /xqueue_{{ purpose_suffix }}
-    XQUEUE_S3_BUCKET: mitx-grades-{{ purpose }}-{{ environment }}
+    XQUEUE_UPLOAD_BUCKET: mitx-grades-{{ purpose }}-{{ environment }}
     xqueue_source_repo: {{ purpose_data.versions.xqueue_source_repo }}
     xqueue_version: {{ purpose_data.versions.xqueue }}
     ########## END XQUEUE ########################################

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -155,7 +155,7 @@ base:
   'P@purpose:.*-live and P@environment:mitx-(qa|production)':
     - match: compound
     - consul.mitx-live
-  'P@purpose:next-residential.*':
+  'P@purpose:.*residential.* and not G@edx_codename:ginkgo':
     - match: compound
     - edx.next_residential
   'G@roles:sandbox and P@environment:mitx-qa':

--- a/pillar/vault/roles/mitx.sls
+++ b/pillar/vault/roles/mitx.sls
@@ -43,7 +43,7 @@ vault:
       backend: mysql-{{ env }}
       name: {{ role }}-{{ purpose }}
       options:
-        sql: "CREATE USER {% raw %}'{{name}}'@'%'{% endraw %} IDENTIFIED BY {% raw %}'{{password}}'{% endraw %};GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, DROP, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES ON {{ role }}_{{ purpose_suffix }}.* TO {% raw %}'{{name}}'{% endraw %}@'%';"
+        sql: "CREATE USER {% raw %}'{{name}}'@'%'{% endraw %} IDENTIFIED BY {% raw %}'{{password}}'{% endraw %};GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, INDEX, DROP, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES ON {{ role|replace('-', '_') }}_{{ purpose_suffix }}.* TO {% raw %}'{{name}}'{% endraw %}@'%';"
         revocation_sql: {% raw %}"DROP USER '{{name}}';"{% endraw %}
     {% endfor %}{# role loop for mysql #}
     {% for role in env_settings.edxapp_secret_backends.rabbitmq.role_prefixes %}

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -2,6 +2,7 @@ edxapp_secret_backends: &edxapp_secret_backends
   mysql:
     role_prefixes:
       - edxapp
+      - edxapp-csmh
       - xqueue
   mongodb:
     role_prefixes:

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -21,6 +21,8 @@ edxapp_secret_backends: &edxapp_secret_backends
       - mitx-storage
 
 current_residential_versions_qa: &current_residential_versions_qa
+  edx_config_repo: https://github.com/mitodl/configuration
+  edx_config_version: open-release/ginkgo.master
   edx_platform_repo: 'https://github.com/mitodl/edx-platform'
   edxapp: mitx/ginkgo
   forum_source_repo: 'https://github.com/mitodl/cs_comments_service'
@@ -34,6 +36,8 @@ current_residential_versions_qa: &current_residential_versions_qa
   ami_id: ami-80861296
 
 current_residential_versions_rp: &current_residential_versions_rp
+  edx_config_repo: https://github.com/mitodl/configuration
+  edx_config_version: open-release/ginkgo.master
   edx_platform_repo: 'https://github.com/mitodl/edx-platform'
   edxapp: mitx/ginkgo
   forum_source_repo: 'https://github.com/mitodl/cs_comments_service'
@@ -47,6 +51,8 @@ current_residential_versions_rp: &current_residential_versions_rp
   ami_id: ami-80861296
 
 next_residential_versions: &next_residential_versions
+  edx_config_repo: https://github.com/edx/configuration.git
+  edx_config_version: open-release/hawthorn.beta1
   edx_platform_repo: 'https://github.com/mitodl/edx-platform'
   edxapp: mitx/hawthorn
   forum_source_repo: 'https://github.com/mitodl/cs_comments_service'


### PR DESCRIPTION
Added configuration to support the csmh database that was introduced in Ginkgo and appears to be mandatory in Hawthorn

#### What are the relevant tickets?
#581 

#### What's this PR do?
Updates ansible vars to work with the new release of edx platform

#### How should this be manually tested?
Deploy to QA-next servers