### PR TITLE
Added salt beacon & reactor to restart reddit service and notify slack

### DIFF
--- a/pillar/reddit.sls
+++ b/pillar/reddit.sls
@@ -250,3 +250,7 @@ pgbouncer:
         server_tls_sslmode: require
         server_tls_protocols: tlsv1.2
         auth_type: any
+
+beacons:
+  memusage:
+    - percent: 95%

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -137,10 +137,10 @@ salt_master:
         version: 1
     reactors:
       reactor:
-        - salt/beacon/edx-*/diskusage/*:
-            - salt://reactors/edx/draft_disk_cleanup.sls
         - salt/beacon/*/inotify/*:
             - salt://reactors/edx/inotify_mitx.sls
+        - salt/beacon/reddit-*/memusage/*:
+            - salt://reactors/reddit/restart_reddit_service_low_memory.sls
         - vault/lease/expiring/*:
             - salt://reactors/vault/alert_expiring_leases.sls
         - salt/state_result/*/restore/*/result:

--- a/salt/reactors/edx/draft_disk_cleanup.sls
+++ b/salt/reactors/edx/draft_disk_cleanup.sls
@@ -1,5 +1,0 @@
-remove_exported_courses_from_disk:
-  local.cmd.run:
-    - tgt: {{ data['id'] }}
-    - arg:
-        - rm -rf /edx/var/edxapp/export_course_repos/*

--- a/salt/reactors/reddit/restart_reddit_service_low_memory.sls
+++ b/salt/reactors/reddit/restart_reddit_service_low_memory.sls
@@ -1,0 +1,14 @@
+restart_reddit_service_low_memory:
+  local.cmd.run:
+    - tgt: {{ data['id'] }}
+    - arg:
+        - /usr/local/bin/reddit-restart
+
+post_event_to_slack:
+  local.slack.post_message:
+    - tgt: 'roles:master'
+    - tgt_type: grain
+    - kwarg:
+        channel: "#devops"
+        message: "SaltStack Event {{ tag }}:`{{ data }}`"
+        from_name: "saltbot"


### PR DESCRIPTION
Added salt beacon & reactor to restart reddit service and notify slack when memory runs low on the instance. Additionally, removed the `draft_disk_cleanup` state file and its corresponding reactor as it is no longer being used.
