### PR TITLE
Redirect rule to throw a 404 when collection is not available

### DIFF
--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -84,6 +84,9 @@ nginx:
                     - include: fastcgi_params
                     - include: includes/shib_fastcgi_params
                     - fastcgi_pass: 'unix:/run/shibresponder.sock'
+                - location ~* /{{ ovs_login_path }}/([^?]+):
+                    - include: uwsgi_params
+                    - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
                 - location /{{ ovs_login_path }}:
                     - include: includes/shib_clear_headers
                     - shib_request: /shibauthorizer


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#604](https://github.com/mitodl/odl-video-service/issues/604)

#### What's this PR do?
Added redirect rule to throw a 404 error when collection is not available

#### How should this be manually tested?
Applied and tested it on `RC`
