### PR TITLE
Removed unusued XQUEUE_WORKERS_PER_QUEUE var

### DIFF
--- a/pillar/edx/residential_ansible_vars.sls
+++ b/pillar/edx/residential_ansible_vars.sls
@@ -114,7 +114,6 @@ edx:
       {% endif %}
       {% endfor %}
     ### XQUEUE ENVIRONMENT ###
-    XQUEUE_WORKERS_PER_QUEUE: 2
     XQUEUE_QUEUES:
         'MITx-42.01x': 'https://xserver.mitx.mit.edu/fgxserver'
         'MITx-8371': 'https://xqueue.mitx.mit.edu/qis_xserver'


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#590](https://github.com/mitodl/salt-ops/issues/590)

#### What's this PR do?
Removed unusued XQUEUE_WORKERS_PER_QUEUE var.
Devstack var had already been previously removed.
