### PR TITLE
Refactored to use cached_read in pillar for connection strings

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -45,8 +45,9 @@
       }
 } %}
 {% set env_data = env_dict[ENVIRONMENT] %}
-{% set pg_creds = salt.vault.read('postgres-{env}-odlvideo/creds/odlvideo'.format(env=ENVIRONMENT)) %}
-{% set rabbit_creds = salt.vault.read("rabbitmq-{env}/creds/odlvideo".format(env=ENVIRONMENT)) %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set pg_creds = salt.vault.cached_read('postgres-{env}-odlvideo/creds/odlvideo'.format(env=ENVIRONMENT), cache_prefix=minion_id) %}
+{% set rabbit_creds = salt.vault.cached_read("rabbitmq-{env}/creds/odlvideo".format(env=ENVIRONMENT), cache_prefix=minion_id) %}
 
 python:
   versions:

--- a/pillar/apps/redash.sls
+++ b/pillar/apps/redash.sls
@@ -5,7 +5,8 @@
 {% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set purpose_data = env_data.purposes[app_name] %}
-{% set pg_creds = salt.vault.read('postgres-' ~ ENVIRONMENT ~ '-redash/creds/redash') %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set pg_creds = salt.vault.cached_read('postgres-' ~ ENVIRONMENT ~ '-redash/creds/redash', cache_prefix=minion_id) %}
 {% set redash_fluentd_webhook_token = salt.vault.read('secret-operations/global/redash_webhook_token').data.value %}
 
 schedule:

--- a/pillar/datadog/mongodb-integration.sls
+++ b/pillar/datadog/mongodb-integration.sls
@@ -1,4 +1,5 @@
-{% set mongodb_creds = salt.vault.read('mongodb-{env}/creds/datadog'.format(env=salt.grains.get('environment')), ignore_invalid=True) %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set mongodb_creds = salt.vault.cached_read('mongodb-{env}/creds/datadog'.format(env=salt.grains.get('environment')), cache_prefix=minion_id, ignore_invalid=True) %}
 
 {% if mongodb_creds %}
 datadog:

--- a/pillar/datadog/rabbitmq-integration.sls
+++ b/pillar/datadog/rabbitmq-integration.sls
@@ -1,5 +1,5 @@
-#!jinja|yaml|gpg
-{% set rabbitmq_creds = salt.vault.read('rabbitmq-{env}/creds/datadog'.format(env=salt.grains.get('environment')), ignore_invalid=True) %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set rabbitmq_creds = salt.vault.cached_read('rabbitmq-{env}/creds/datadog'.format(env=salt.grains.get('environment')), cache_prefix=minion_id, ignore_invalid=True) %}
 
 {% if rabbitmq_creds %}
 datadog_user: {{ rabbitmq_creds.data.username }}

--- a/pillar/monit/mysql_connection.sls
+++ b/pillar/monit/mysql_connection.sls
@@ -2,7 +2,8 @@
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set edxapp_mysql_host = 'mysql.service.consul' %}
 {% set edxapp_mysql_port = 3306 %}
-{% set edxapp_mysql_creds = salt.vault.read('mysql-{env}/creds/edxapp-{purpose}'.format(env=env, purpose=purpose)) %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set edxapp_mysql_creds = salt.vault.cached_read('mysql-{env}/creds/edxapp-{purpose}'.format(env=env, purpose=purpose), cache_prefix=minion_id) %}
 
 monit_app:
   modules:

--- a/pillar/nginx/reddit.sls
+++ b/pillar/nginx/reddit.sls
@@ -52,7 +52,7 @@ nginx:
                     - proxy_pass: http://127.0.0.1:8001/health
                     - proxy_set_header: Host $http_host
                     - proxy_http_version: 1.1
-                    - proxy_set_header: X-Forwarded-For $remote_addr                    
+                    - proxy_set_header: X-Forwarded-For $remote_addr
                 - location /:
                     - 'if ($http_x_access_token != {{ access_token }})':
                         - return: 403

--- a/pillar/reddit.sls
+++ b/pillar/reddit.sls
@@ -7,7 +7,8 @@
 {% set CASSANDRA_PORT = 9160 %}
 {% set RABBITMQ_HOST = 'nearest-rabbitmq.query.consul' %}
 {% set RABBITMQ_PORT = 5672 %}
-{% set postgresql_creds = salt.vault.read('postgresql-{}-reddit/creds/reddit'.format(ENVIRONMENT)) %}
+{% set minion_id = salt.grains.get('id', '') %}
+{% set postgresql_creds = salt.vault.cached_read('postgresql-{}-reddit/creds/reddit'.format(ENVIRONMENT), cache_prefix=minion_id) %}
 {% set POSTGRESQL_PORT = 5432 %}
 {% set POSTGRESQL_HOST = 'postgresql-reddit.service.consul' %}
 {% set DISCUSSIONS_HOST = 'discussions-reddit-{}.odl.mit.edu'.format(ENVIRONMENT) %}


### PR DESCRIPTION
#### What's this PR do?
Updated pillar rendering to use new `cached_read` execution module function to leverage the lease caching mechanism and elminate churn in dynamic credentials