### PR TITLE
Added additional port range for internode communication

### DIFF
--- a/pillar/rabbitmq/init.sls
+++ b/pillar/rabbitmq/init.sls
@@ -7,9 +7,6 @@ rabbitmq:
   overrides:
     version: '3.7.4-1'
     erlang_version: '1:20.1'
-  environment:
-    RABBITMQ_CTL_DIST_PORT_MIN: 35672
-    RABBITMQ_CTL_DIST_PORT_MAX: 35672
   configuration:
     cluster_partition_handling: autoheal
     cluster_partition_handling.pause_if_all_down.recover: autoheal

--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -3,16 +3,12 @@
 # Make sure that instance profiles exist for node types so that
 # they can be granted access via permissions attached to those
 # profiles because it's easier than managing IAM keys
-{% set VPC_NAME = salt.environ.get('VPC_NAME', 'MITx QA') %}
-{% set VPC_RESOURCE_SUFFIX = salt.environ.get(
-    'VPC_RESOURCE_SUFFIX',
-    VPC_NAME.lower().replace(' ', '-')) %}
-{% set ENVIRONMENT = salt.environ.get(
-    'ENVIRONMENT',
-    VPC_NAME.lower().replace(' ', '-')) %}
-{% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', 'residential') %}
-
-{% set env_settings = salt.pillar.get('environments:{}'.format(ENVIRONMENT)) %}
+{% set env_data = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
+{% set env_settings = env_settings.environments[ENVIRONMENT] %}
+{% set PURPOSE_PREFIX = salt.environ.get('PURPOSE_PREFIX', 'current-residential') %}
+{% set VPC_NAME = env_data.vpc_name %}
+{% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_data.business_unit) %}
 
 {% for profile in ['consul', 'mongodb', 'rabbitmq', 'edx'] %}
 ensure_instance_profile_exists_for_{{ profile }}:
@@ -27,9 +23,7 @@ ensure_instance_profile_exists_for_{{ profile }}:
 {% set cidr_ip = '{}.0.0/22'.format(network_prefix) %}
 {% set cidr_block = '{}.0.0/16'.format(network_prefix) %}
 
-{% set VPC_RESOURCE_SUFFIX_UNDERSCORE = VPC_RESOURCE_SUFFIX.replace('-', '_') %}
-
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc:
+create_{{ ENVIRONMENT }}_vpc:
   boto_vpc.present:
     - name: {{ VPC_NAME }}
     - cidr_block: {{ cidr_block }}
@@ -40,88 +34,88 @@ create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc:
         Name: {{ VPC_NAME }}
         business_unit: {{ BUSINESS_UNIT }}
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_internet_gateway:
+create_{{ ENVIRONMENT }}_internet_gateway:
   boto_vpc.internet_gateway_present:
-    - name: {{ VPC_RESOURCE_SUFFIX }}-igw
+    - name: {{ ENVIRONMENT }}-igw
     - vpc_name: {{ VPC_NAME }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: {{ VPC_RESOURCE_SUFFIX }}-igw
+        Name: {{ ENVIRONMENT }}-igw
         business_unit: {{ BUSINESS_UNIT }}
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_1:
+create_{{ ENVIRONMENT }}_public_subnet_1:
   boto_vpc.subnet_present:
-    - name: public1-{{ VPC_RESOURCE_SUFFIX }}
+    - name: public1-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - cidr_block: {{ cidr_block_public_subnet_1 }}
     - availability_zone: us-east-1d
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: public1-{{ VPC_RESOURCE_SUFFIX }}
+        Name: public1-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_2:
+create_{{ ENVIRONMENT }}_public_subnet_2:
   boto_vpc.subnet_present:
-    - name: public2-{{ VPC_RESOURCE_SUFFIX }}
+    - name: public2-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - cidr_block: {{ cidr_block_public_subnet_2 }}
     - availability_zone: us-east-1b
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: public2-{{ VPC_RESOURCE_SUFFIX }}
+        Name: public2-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_3:
+create_{{ ENVIRONMENT }}_public_subnet_3:
   boto_vpc.subnet_present:
-    - name: public3-{{ VPC_RESOURCE_SUFFIX }}
+    - name: public3-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - cidr_block: {{ cidr_block_public_subnet_3 }}
     - availability_zone: us-east-1c
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: public3-{{ VPC_RESOURCE_SUFFIX }}
+        Name: public3-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc_peering_connection_with_operations:
+create_{{ ENVIRONMENT }}_vpc_peering_connection_with_operations:
   boto_vpc.vpc_peering_connection_present:
-    - conn_name: {{ VPC_RESOURCE_SUFFIX }}-operations-peer
+    - conn_name: {{ ENVIRONMENT }}-operations-peer
     - requester_vpc_name: {{ VPC_NAME }}
     - peer_vpc_name: mitodl-operations-services
 
-accept_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc_peering_connection_with_operations:
+accept_{{ ENVIRONMENT }}_vpc_peering_connection_with_operations:
   boto_vpc.accept_vpc_peering_connection:
-    - conn_name: {{ VPC_RESOURCE_SUFFIX }}-operations-peer
+    - conn_name: {{ ENVIRONMENT }}-operations-peer
 
-create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_routing_table:
+create_{{ ENVIRONMENT }}_routing_table:
   boto_vpc.route_table_present:
-    - name: {{ VPC_RESOURCE_SUFFIX }}-route_table
+    - name: {{ ENVIRONMENT }}-route_table
     - vpc_name: {{ VPC_NAME }}
     - subnet_names:
-        - public1-{{ VPC_RESOURCE_SUFFIX }}
-        - public2-{{ VPC_RESOURCE_SUFFIX }}
-        - public3-{{ VPC_RESOURCE_SUFFIX }}
+        - public1-{{ ENVIRONMENT }}
+        - public2-{{ ENVIRONMENT }}
+        - public3-{{ ENVIRONMENT }}
     - routes:
         - destination_cidr_block: 0.0.0.0/0
-          internet_gateway_name: {{ VPC_RESOURCE_SUFFIX }}-igw
+          internet_gateway_name: {{ ENVIRONMENT }}-igw
         - destination_cidr_block: 10.0.0.0/22
-          vpc_peering_connection_name: {{ VPC_RESOURCE_SUFFIX }}-operations-peer
+          vpc_peering_connection_name: {{ ENVIRONMENT }}-operations-peer
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_1
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_2
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_public_subnet_3
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc_peering_connection_with_operations
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_public_subnet_1
+        - boto_vpc: create_{{ ENVIRONMENT }}_public_subnet_2
+        - boto_vpc: create_{{ ENVIRONMENT }}_public_subnet_3
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc_peering_connection_with_operations
     - tags:
-        Name: {{ VPC_RESOURCE_SUFFIX }}-route_table
+        Name: {{ ENVIRONMENT }}-route_table
         business_unit: {{ BUSINESS_UNIT }}
 
 create_edx_security_group:
   boto_secgroup.present:
-    - name: edx-{{ VPC_RESOURCE_SUFFIX }}
+    - name: edx-{{ ENVIRONMENT }}
     - description: Access rules for EdX instances
     - vpc_name: {{ VPC_NAME }}
     - rules:
@@ -144,14 +138,14 @@ create_edx_security_group:
           to_port: 18040
           cidr_ip: {{ cidr_ip }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: edx-{{ VPC_RESOURCE_SUFFIX }}
+        Name: edx-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_edx_worker_security_group:
   boto_secgroup.present:
-    - name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+    - name: edx-worker-{{ ENVIRONMENT }}
     - description: Grant access to edx-worker from EdX instances
     - vpc_name: {{ VPC_NAME }}
     - rules:
@@ -159,18 +153,18 @@ create_edx_worker_security_group:
           from_port: 18040
           to_port: 18040
           source_group_name:
-            - edx-{{ VPC_RESOURCE_SUFFIX }}
-            - edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+            - edx-{{ ENVIRONMENT }}
+            - edx-worker-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_edx_security_group
     - tags:
-        Name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+        Name: edx-worker-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_mongodb_security_group:
   boto_secgroup.present:
-    - name: mongodb-{{ VPC_RESOURCE_SUFFIX }}
+    - name: mongodb-{{ ENVIRONMENT }}
     - description: Grant access to Mongo from EdX instances
     - vpc_name: {{ VPC_NAME }}
     - rules:
@@ -178,19 +172,19 @@ create_mongodb_security_group:
           from_port: 27017
           to_port: 27017
           source_group_name:
-            - edx-{{ VPC_RESOURCE_SUFFIX }}
-            - edx-worker-{{ VPC_RESOURCE_SUFFIX }}
-            - mongodb-{{ VPC_RESOURCE_SUFFIX }}
+            - edx-{{ ENVIRONMENT }}
+            - edx-worker-{{ ENVIRONMENT }}
+            - mongodb-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_edx_security_group
     - tags:
-        Name: mongodb-{{ VPC_RESOURCE_SUFFIX }}
+        Name: mongodb-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_mitx_consul_security_group:
   boto_secgroup.present:
-    - name: consul-{{ VPC_RESOURCE_SUFFIX }}
+    - name: consul-{{ ENVIRONMENT }}
     - description: Access rules for Consul cluster in {{ VPC_NAME }} stack
     - vpc_name: {{ VPC_NAME }}
     - rules:
@@ -238,126 +232,130 @@ create_mitx_consul_security_group:
             - {{ cidr_ip }}
           {# WAN cluster interface #}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
     - tags:
-        Name: consul-{{ VPC_RESOURCE_SUFFIX }}
+        Name: consul-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_mitx_consul_agent_security_group:
   boto_secgroup.present:
-    - name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
+    - name: consul-agent-{{ ENVIRONMENT }}
     - description: Access rules for Consul agent in {{ VPC_NAME }} stack
     - vpc_name: {{ VPC_NAME }}
     - rules:
         - ip_protocol: tcp
           from_port: 8301
           to_port: 8301
-          source_group_name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: consul-agent-{{ ENVIRONMENT }}
         - ip_protocol: udp
           from_port: 8301
           to_port: 8301
-          source_group_name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: consul-agent-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 8301
           to_port: 8301
-          source_group_name: consul-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: consul-{{ ENVIRONMENT }}
         - ip_protocol: udp
           from_port: 8301
           to_port: 8301
-          source_group_name: consul-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: consul-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_mitx_consul_security_group
     - tags:
-        Name: consul-agent-{{ VPC_RESOURCE_SUFFIX }}
+        Name: consul-agent-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_rabbitmq_security_group:
   boto_secgroup.present:
-    - name: rabbitmq-{{ VPC_RESOURCE_SUFFIX }}
+    - name: rabbitmq-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for RabbitMQ servers
     - rules:
         - ip_protocol: tcp
           from_port: 5672
           to_port: 5672
-          source_group_name: edx-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 5672
           to_port: 5672
-          source_group_name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-worker-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 4369
           to_port: 4369
-          source_group_name: rabbitmq-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: rabbitmq-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 25672
           to_port: 25672
-          source_group_name: rabbitmq-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: rabbitmq-{{ ENVIRONMENT }}
+        - ip_protocol: tcp
+          from_port: 35672
+          to_port: 35682
+          source_group_name: rabbitmq-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_edx_security_group
     - tags:
-        Name: rabbitmq-{{ VPC_RESOURCE_SUFFIX }}
+        Name: rabbitmq-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_elasticsearch_security_group:
   boto_secgroup.present:
-    - name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
+    - name: elasticsearch-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for elasticsearch servers
     - rules:
         - ip_protocol: tcp
           from_port: 9200
           to_port: 9200
-          source_group_name: edx-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 9200
           to_port: 9200
-          source_group_name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-worker-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 9300
           to_port: 9400
-          source_group_name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: elasticsearch-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_edx_security_group
     - tags:
-        Name: elasticsearch-{{ VPC_RESOURCE_SUFFIX }}
+        Name: elasticsearch-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_rds_security_group:
   boto_secgroup.present:
-    - name: rds-{{ VPC_RESOURCE_SUFFIX }}
+    - name: rds-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for RDS access
     - rules:
         - ip_protocol: tcp
           from_port: 3306
           to_port: 3306
-          source_group_name: edx-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 3306
           to_port: 3306
-          source_group_name: edx-worker-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: edx-worker-{{ ENVIRONMENT }}
         - ip_protocol: tcp
           from_port: 3306
           to_port: 3306
-          source_group_name: consul-{{ VPC_RESOURCE_SUFFIX }}
+          source_group_name: consul-{{ ENVIRONMENT }}
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
         - boto_secgroup: create_edx_security_group
     - tags:
-        Name: rds-{{ VPC_RESOURCE_SUFFIX }}
+        Name: rds-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
 
 create_salt_master_security_group:
   boto_secgroup.present:
-    - name: salt_master-{{ VPC_RESOURCE_SUFFIX }}
+    - name: salt_master-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for allowing access to hosts from Salt Master
     - tags:
-        Name: salt_master-{{ VPC_RESOURCE_SUFFIX }}
+        Name: salt_master-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
     - rules:
         - ip_protocol: tcp
@@ -366,15 +364,15 @@ create_salt_master_security_group:
           cidr_ip:
             - 10.0.0.0/22
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
 
 create_public_ssh_security_group:
   boto_secgroup.present:
-    - name: public-ssh-{{ VPC_RESOURCE_SUFFIX }}
+    - name: public-ssh-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for allowing access to hosts from the open internet
     - tags:
-        Name: publich-ssh-{{ VPC_RESOURCE_SUFFIX }}
+        Name: publich-ssh-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
     - rules:
         - ip_protocol: tcp
@@ -383,17 +381,17 @@ create_public_ssh_security_group:
           cidr_ip:
             - 0.0.0.0/0
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc
 
 create_vault_backend_security_group:
   boto_secgroup.present:
-    - name: vault-{{ VPC_RESOURCE_SUFFIX }}
+    - name: vault-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: >-
         ACL to allow Vault to access data stores so that it
         can create dynamic credentials
     - tags:
-        Name: vault-{{ VPC_RESOURCE_SUFFIX }}
+        Name: vault-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
     - rules:
         {# MongoDB #}
@@ -415,4 +413,4 @@ create_vault_backend_security_group:
           cidr_ip:
             - 10.0.0.0/22
     - require:
-        - boto_vpc: create_{{ VPC_RESOURCE_SUFFIX_UNDERSCORE }}_vpc
+        - boto_vpc: create_{{ ENVIRONMENT }}_vpc

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -163,6 +163,10 @@ create_rabbitmq_security_group:
           from_port: 25672
           to_port: 25672
           source_group_name: rabbitmq-{{ ENVIRONMENT }}
+        - ip_protocol: tcp
+          from_port: 35672
+          to_port: 35682
+          source_group_name: rabbitmq-{{ ENVIRONMENT }}
     - tags:
         Name: rabbitmq-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}


### PR DESCRIPTION
RabbitMQ 3.7.x adds another set of ports for inter-node communication that gets used by commands such as list-queues. Added these ports to the rabbit security groups to resolve timeouts when executing queries.

Also updated the mitx vpc orchestration to use env settings data in the new pattern.

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds additional ports to the rabbitmq security groups for inter-node communication in 3.7

#### How should this be manually tested?
Apply the security group changes to an existing security group and verify proper operation of the `rabbitmq.list_queues_vhost` command.