### PR TITLE
Added uwsgi option to disable OSErrors from being sent to sentry when…

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -149,6 +149,7 @@ uwsgi:
         - buffer-size: 65535
         - chdir: /opt/{{ app_name }}
         - chown-socket: 'www-data:deploy'
+        - disable-write-exception: 'true'
         - enable-threads: 'true'
         - gid: deploy
         - logto: /var/log/uwsgi/apps/%n.log


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#651](https://github.com/mitodl/odl-video-service/issues/651)

#### What's this PR do?
Added uwsgi option to disable OSErrors from being sent to sentry when someone cancels downloads before completion