### PR TITLE
Added micromasters to list of envs for datadog

### DIFF
--- a/pillar/datadog/init.sls
+++ b/pillar/datadog/init.sls
@@ -1,9 +1,7 @@
 #!jinja|yaml|gpg
 
-include:
-  - datadog.secrets
-
 datadog:
+  api_key: __vault__::secret-operations/global/datadog-api-key>data>value
   overrides:
     config:
       tags: roles:{{ salt.grains.get('roles', ['not_set']) | join(', ') }}, environment:{{ salt.grains.get('environment', 'not_set') }}

--- a/pillar/datadog/secrets.sls
+++ b/pillar/datadog/secrets.sls
@@ -1,4 +1,0 @@
-#!jinja|yaml|gpg
-
-datadog:
-  api_key: __vault__::secret-operations/global/datadog-api-key>data>value

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -78,7 +78,7 @@ base:
     - shibboleth.redash
     - apps.redash
     - apps.redash_data_sources
-  'P@environment:(mitx-qa|mitx-production|operations|rc-apps|production-apps)':
+  'P@environment:(mitx-qa|mitx-production|operations|rc-apps|production-apps|micromasters)':
     - match: compound
     - datadog
     - consul


### PR DESCRIPTION
The MM ES cluster didn't have the datadog API key applied due to an oversight in top file targeting.