### PR TITLE
Add no-index rule to allow aliases to be deleted

### DIFF
--- a/pillar/elasticsearch/apps.sls
+++ b/pillar/elasticsearch/apps.sls
@@ -26,6 +26,8 @@ elasticsearch:
           - name: Cluster access within VPC
             type: allow
             accept_x-forwarded-for_header: 'true'
+            indices:
+              - <no-index>
             actions:
               - 'cluster:*'
             hosts:


### PR DESCRIPTION
#### What are the relevant tickets?
https://sentry.io/mit-office-of-digital-learning/discussions/issues/585134656/?environment=production

#### What's this PR do?
Updates the elasticsearch readonlyrest rules to allow aliases to be deleted from within the VPC

#### How should this be manually tested?
N/A
