### PR TITLE
Added env data settings for mitx-qa-testing servers

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -65,6 +65,21 @@ next_residential_versions: &next_residential_versions
   codename: ironwood
   ami_id: ami-80861296
 
+edxapp_continuous_delivery_versions: &continuous_delivery_versions
+  edx_config_repo: https://github.com/edx/configuration.git
+  edx_config_version: master
+  edx_platform_repo: 'https://github.com/edx/edx-platform'
+  edxapp: master
+  forum_source_repo: 'https://github.com/edx/cs_comments_service'
+  forum: master
+  xqueue_source_repo: 'https://github.com/edx/xqueue'
+  xqueue: master
+  xqwatcher_courses: master
+  theme_source_repo: 'https://github.com/mitodl/mitx-theme'
+  theme: master
+  codename: tumbleweed
+  ami_id: ami-80861296
+
 sandbox_residential_versions: &sandbox_residential_versions
   edx_config_repo: https://github.com/edx/configuration.git
   edx_config_version: open-release/hawthorn.beta1
@@ -191,10 +206,21 @@ environments:
             number: 1
             type: t2.medium
       continuous-delivery:
-        business_unit: operations
+        business_unit: residential
+        domains:
+          cms: studio-mitx-qa-testing.mitx.mit.edu
+          lms: mitx-qa-testing.mitx.mit.edu
+          preview: preview-mitx-qa-testing.mitx.mit.edu
+          gitreload: prod-gr-qa-testing.mitx.mit.edu
         versions:
-          edxapp: master
-          forum: master
+          <<: *continous_delivery_versions
+        instances:
+          edx:
+            number: 1
+            type: t2.large
+          edx-worker:
+            number: 1
+            type: t2.large
   mitx-production:
     business_unit: residential
     network_prefix: 10.7


### PR DESCRIPTION
This will be used as a ~weekly release platform for keeping track of upstream changes and providing a continous testing environment for ed-techs and DLSs