### PR TITLE
Added hearbeat endpoint to check for status

### DIFF
--- a/pillar/monit/lms_503.sls
+++ b/pillar/monit/lms_503.sls
@@ -7,5 +7,5 @@ monit_app:
         with:
           address: lms.mitx.mit.edu
         if:
-          failed: port 443 protocol https status = 503
+          failed: port 443 protocol https request "/heartbeat" status = 200
           action: exec "/bin/sh -c /usr/local/bin/slack.sh"


### PR DESCRIPTION
#### What's this PR do?
Added hearbeat endpoint to check for status so that monit logs don't appear in the edx tracking logs file.