### PR TITLE
Added an nginx app to redirect requests to amps to OVS

### DIFF
--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -1,0 +1,54 @@
+{% set app_name = 'amps-redirect' %}
+
+nginx:
+  ng:
+    install_from_source: True
+    source_version: 1.15.1
+    source_hash: c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460
+    certificates:
+      odl_wildcard:
+        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+    servers:
+      managed:
+        {{ app_name }}:
+          enabled: True
+          config:
+            - server:
+                - server_name: amps.odl.mit.edu
+                - listen:
+                    - 80
+                - listen:
+                    - '[::]:80'
+                - location /:
+                    - return: 301 https://video.odl.mit.edu
+            - server:
+                - server_name: amps.odl.mit.edu
+                - listen:
+                    - 443
+                    - ssl
+                    - default
+                - listen:
+                    - '[::]:443'
+                    - ssl
+                - root: /opt/odl-video-service/
+                - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+                - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+                - ssl_stapling: 'on'
+                - ssl_stapling_verify: 'on'
+                - ssl_session_timeout: 1d
+                - ssl_session_tickets: 'off'
+                - ssl_protocols:
+                    - TLSv1.2
+                    - TLSv1.3
+                - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
+                     :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
+                     :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\
+                     :ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384\
+                     :ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256\
+                     :DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256\
+                     :AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
+                - ssl_prefer_server_ciphers: 'on'
+                - resolver: 1.1.1.1
+                - location /:
+                    - return: 301 https://video.odl.mit.edu

--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -21,7 +21,7 @@ nginx:
                 - listen:
                     - '[::]:80'
                 - location /:
-                    - return: 301 https://video.odl.mit.edu
+                    - return: 301 https://docs.google.com/forms/d/e/1FAIpQLSdvkI2cPG1iMM4gN_KyKem4fNLh4irWzrmjX-JhcFXa51su5g/viewform?fbzx=2658557852628862500
             - server:
                 - server_name: amps.odl.mit.edu
                 - listen:
@@ -31,7 +31,6 @@ nginx:
                 - listen:
                     - '[::]:443'
                     - ssl
-                - root: /opt/odl-video-service/
                 - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
                 - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
                 - ssl_stapling: 'on'
@@ -51,4 +50,4 @@ nginx:
                 - ssl_prefer_server_ciphers: 'on'
                 - resolver: 1.1.1.1
                 - location /:
-                    - return: 301 https://video.odl.mit.edu
+                    - return: 301 https://docs.google.com/forms/d/e/1FAIpQLSdvkI2cPG1iMM4gN_KyKem4fNLh4irWzrmjX-JhcFXa51su5g/viewform?fbzx=2658557852628862500

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -177,6 +177,10 @@ base:
     - match: glob
     - edx.xqwatcher
     - edx.xqwatcher_686
+  'nginx-amps-redirect':
+    - match: glob
+    - nginx
+    - nginx.amps
   'G@roles:backups and P@environment:mitx-(qa|production)':
     - match: compound
     - backups.mitx

--- a/salt/orchestrate/aws/cloud_profiles/nginx-amps-redirect.conf
+++ b/salt/orchestrate/aws/cloud_profiles/nginx-amps-redirect.conf
@@ -1,0 +1,16 @@
+# -*- mode: yaml; coding: utf-8; -*-
+nginx-amps-redirect:
+  provider: mitx
+  size: t2.micro
+  image: ami-628ad918
+  ssh_username: admin
+  ssh_interface: private_ips
+  script_args: -U -Z
+  tag:
+    role: nginx-amps-redirect
+  grains:
+    roles:
+      - nginx-amps-redirect
+  minion:
+    master:
+      - salt.private.odl.mit.edu

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -22,6 +22,10 @@ base:
   'lightsail-xqwatcher-686':
     - match: glob
     - edx.xqwatcher
+  'nginx-amps-redirect':
+    - match: glob
+    - nginx.ng
+    - nginx.ng.certificates
   'roles:backups':
     - match: grain
     - backups.backup


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#628](https://github.com/mitodl/salt-ops/issues/628)

#### What's this PR do?
Once DNS CNAME is configured to point to `amps.odl.mit.edu`, then this should redirect those requests to `video.odl.mit.edu`