### PR TITLE
Added amps-redirect to operations purposes

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -316,6 +316,11 @@ environments:
         domains:
           - bi.odl.mit.edu
         business_unit: operations
+      amps-redirect:
+        num_instances: 1
+        domains:
+          - amps.odl.mit.edu
+          business_unit: operations
     backends:
       elasticache:
         - engine: redis


### PR DESCRIPTION
#### What's this PR do?
Adds an amps-redirect definition to the operations purpose in order to deploy an instance in that VPC