### PR TITLE
Setup vault pki backends and roles to use those backends

### DIFF
--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -1,5 +1,5 @@
 {% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
-{% set ttl = '8760h' %}
+{% set ttl = '8760h' %} # ONE_YEAR
 {% set ou = 'Open Learning' %}
 {% set org = 'Massachusetts Institute of Technology' %}
 {% set country = 'US' %}
@@ -12,7 +12,7 @@ vault:
     {% for env in env_settings.environments %}
     {% for app in env.backends.pki %}
     {{ app }}-{{ env }}-pki:
-      backend: pki_int_{{ env }}
+      backend: pki-int-{{ env }}
       {% for type in ['client', 'server'] %}
       name: pki-{{ env }}-{{ app }}-{{ type }}
       {% endfor %}
@@ -20,7 +20,7 @@ vault:
       max_ttl: {{ ttl }}
       allowed_domains:
         - {{ app }}.service.consul
-        - nearest-{{ app }}.service.consul
+        - nearest-{{ app }}.query.consul
         {% if app == 'mongodb' %}
         - {{ app }}-master.service.consul
         {% endif %}

--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -1,0 +1,46 @@
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set ttl = '8760h' %}
+{% set ou = 'Open Learning' %}
+{% set org = 'Massachusetts Institute of Technology' %}
+{% set country = 'US' %}
+{% set locality = 'Cambridge' %}
+{% set street_address = '77 Massachusetts Ave' %}
+{% set postal_code = '02139' %}
+
+vault:
+  roles:
+    {% for env in env_settings.environments %}
+    {% for app in env.backends.pki %}
+    {{ app }}-{{ env }}-pki:
+      backend: pki_int_{{ env }}
+      {% for type in ['client', 'server'] %}
+      name: pki-{{ env }}-{{ app }}-{{ type }}
+      {% endfor %}
+      ttl: {{ ttl }}
+      max_ttl: {{ ttl }}
+      allowed_domains:
+        - {{ app }}.service.consul
+        - nearest-{{ app }}.service.consul
+        {% if app == 'mongodb' %}
+        - {{ app }}-master.service.consul
+        {% endif %}
+      {% if type == 'server' %}
+      server_flag: true
+      {% else %}
+      client_flag: true
+      {% endif %}
+      key_type: rsa
+      key_bits: 4096
+      key_usage:
+        - DigitalSignature
+        - KeyAgreement
+        - KeyEncipherment
+      ou: {{ ou }}
+      organization: {{ org }}
+      country: {{ country }}
+      locality: {{ locality }}
+      street_address: {{ street_address }}
+      postal_code: {{ postal_code }}
+      require_cn: true
+    {% endfor %}
+    {% endfor %}

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -96,6 +96,12 @@ environments:
     secret_backends:
       <<: *edxapp_secret_backends
     backends:
+      pki:
+        - consul
+        - elasticsearch
+        - fluentd
+        - mongodb
+        - rabbitmq
       rds:
         - name: mitxcas
           multi_az: False
@@ -249,6 +255,12 @@ environments:
     secret_backends:
       <<: *edxapp_secret_backends
     backends:
+      pki:
+        - consul
+        - elasticsearch
+        - fluentd
+        - mongodb
+        - rabbitmq
       rds:
         - name: mitxcas
           multi_az: True
@@ -358,6 +370,10 @@ environments:
         security_groups:
           - webapp
     backends:
+      pki:
+        - consul
+        - elasticsearch
+        - fluentd
       elasticache:
         - engine: redis
           engine_version: 3.2.10
@@ -424,6 +440,12 @@ environments:
         security_groups:
           - webapp
     backends:
+      pki:
+        - cassandra
+        - consul
+        - elasticsearch
+        - fluentd
+        - rabbitmq
       rds:
         - name: reddit
           multi_az: True
@@ -495,6 +517,12 @@ environments:
         security_groups:
           - webapp
     backends:
+      pki:
+        - cassandra
+        - consul
+        - elasticsearch
+        - fluentd
+        - rabbitmq
       rds:
         - name: reddit
           multi_az: False

--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -1,5 +1,5 @@
 {% set SIX_MONTHS = '4368h' %}
-{% set pki_ttl = '8760h' %}
+{% set pki_ttl = '8760h' %} # ONE_YEAR
 {% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
 
 enable_transit_secret_backend:
@@ -20,23 +20,23 @@ enable_mitx_aws_secret_backend:
 enable_pki_intermediate_backend:
   vault.secret_backend_enabled:
     - backend_type: pki
-    - mount_point: pki_int
-    - description: Backend to create self-signed certificates
+    - mount_point: pki-int
+    - description: Backend to create certificates signed by our root CA
     - ttl_default: {{ pki_ttl }}
     - connection_config:
-        issuing_certificates: 'https://vault.service.consul:8200/vi/pki_int/ca'
-        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki_int/crl'
+        issuing_certificates: 'https://vault.service.consul:8200/vi/pki-int/ca'
+        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki-int/crl'
 
 {% for environment in env_settings.environments %}
 enable_pki_intermediate_{{ environment }}_backend:
   vault.secret_backend_enabled:
     - backend_type: pki
-    - mount_point: pki_int_{{ environment }}
-    - description: Backend to create self-signed certificates for {{ environment }}
+    - mount_point: pki-{{ environment }}-int-ca
+    - description: Backend to create certificates for {{ environment }}
     - ttl_default: {{ pki_ttl }}
     - connection_config:
-        issuing_certificates: 'https://vault.service.consul:8200/vi/pki_int_{{ environment }}/ca'
-        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki_int_{{ environment }}/crl'
+        issuing_certificates: 'https://vault.service.consul:8200/vi/pki-{{ environment }}-int/ca'
+        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki-{{ environment }}-int/crl'
 {% endfor %}
 
 {% for unit in salt.pillar.get('business_units', []) %}

--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -1,4 +1,6 @@
 {% set SIX_MONTHS = '4368h' %}
+{% set pki_ttl = '8760h' %}
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
 
 enable_transit_secret_backend:
   vault.secret_backend_enabled:
@@ -14,6 +16,28 @@ enable_mitx_aws_secret_backend:
     - ttl_default: {{ SIX_MONTHS }}
     - lease_max: {{ SIX_MONTHS }}
     - lease_default: {{ SIX_MONTHS }}
+
+enable_pki_intermediate_backend:
+  vault.secret_backend_enabled:
+    - backend_type: pki
+    - mount_point: pki_int
+    - description: Backend to create self-signed certificates
+    - ttl_default: {{ pki_ttl }}
+    - connection_config:
+        issuing_certificates: 'https://vault.service.consul:8200/vi/pki_int/ca'
+        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki_int/crl'
+
+{% for environment in env_settings.environments %}
+enable_pki_intermediate_{{ environment }}_backend:
+  vault.secret_backend_enabled:
+    - backend_type: pki
+    - mount_point: pki_int_{{ environment }}
+    - description: Backend to create self-signed certificates for {{ environment }}
+    - ttl_default: {{ pki_ttl }}
+    - connection_config:
+        issuing_certificates: 'https://vault.service.consul:8200/vi/pki_int_{{ environment }}/ca'
+        crl_distribution_points: 'https://vault.service.consul:8200/v1/pki_int_{{ environment }}/crl'
+{% endfor %}
 
 {% for unit in salt.pillar.get('business_units', []) %}
 enable_generic_backend_for_{{ unit }}:

--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -20,7 +20,7 @@ enable_mitx_aws_secret_backend:
 enable_pki_intermediate_backend:
   vault.secret_backend_enabled:
     - backend_type: pki
-    - mount_point: pki-int
+    - mount_point: pki-intermediate-ca
     - description: Backend to create certificates signed by our root CA
     - ttl_default: {{ pki_ttl }}
     - connection_config:


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#20](https://github.com/mitodl/salt-ops/issues/20)

#### What's this PR do?
Setup vault pki backends and roles to use those backends. Also added new variables to env_settings that specifies what services each environment needs. The roles file needs extra scrutiny as I'm a bit unsure about how the server/client flags will work.
