### PR TITLE
Pillar file to rotate OCW CMS logs and related changes to top file

### DIFF
--- a/pillar/logrotate/ocw_cms.sls
+++ b/pillar/logrotate/ocw_cms.sls
@@ -1,0 +1,27 @@
+logrotate:
+  zeoclient_event:
+    conf_file: /etc/logrotate.d/zeoclient_event
+    name: /usr/local/Plone/zeocluster/var/client1/event.log
+    options:
+      - rotate 3
+      - monthly
+      - prerotate /usr/local/Plone/zeocluster/var/client1/bin stop
+      - postrotate /usr/local/Plone/zeocluster/var/client1/bin start
+  zeoclient_z2:
+    conf_file: /etc/logrotate.d/zeoclient_z2
+    name: /usr/local/Plone/zeocluster/var/client1/Z2.log
+    options:
+      - rotate 3
+      - monthly
+      - prerotate /usr/local/Plone/zeocluster/var/client1/bin stop
+      - postrotate /usr/local/Plone/zeocluster/var/client1/bin start
+  {% if salt.grains.get('id') == 'ocw-production-cms-2' %}
+  ocw_publishing_logs:
+    conf_file: /etc/logrotate.d/ocw_publishing_logs
+    name: /prod/OCWEngines/logs/*.{log|out}
+    options:
+      - rotate 3
+      - monthly
+      - prerotate /usr/local/Plone/zeocluster/var/client1/bin stop && kill $(ps aux | grep python | awk '{print $2}')
+      - postrotate /usr/local/Plone/zeocluster/var/client1/bin start && nohup python enginescheduler.py PRODUCTION > /prod/OCWEngines/logs/production_nohup.log && nohup python enginescheduler.py CETOOL > /prod/OCWEngines/logs/cetool_nohup.out && nohup python enginescheduler.py MIRRORUPDATE > /prod/OCWEngines/logs/mirror_nohup.out
+  {% endif %}

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -216,3 +216,6 @@ base:
     - fluentd.rabbitmq
     - consul.rabbitmq
     - datadog.rabbitmq-integration
+  'G@roles:ocw-cms and P@environment:ocw-production':
+    - match: compound
+    - logrotate.ocw_cms


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#657](https://github.com/mitodl/salt-ops/issues/657)

#### What's this PR do?
Does the following:
- Stops the zeoclient service, rotates the zeo logs on both cms instances on a monthly basis and keeps 3 months worth of logs
- On publishing instance (`cms2`) stops the python processes and rotates the publishing logs.
