### PR TITLE
Removing override of static url to eliminate cloudfront

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -2,9 +2,7 @@
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
-{% set purpose_prefix = purpose.rsplit('-', 1)[0] %}
 {% set purpose_suffix = purpose.replace('-', '_') %}
-{% set cloudfront_domain = salt.sdb.get('sdb://consul/cloudfront/' ~ purpose_prefix ~ '-' ~ environment ~ '-cdn') %}
 {% set purpose_data = env_settings.environments[environment].purposes[purpose] %}
 
 {% set DEFAULT_FEEDBACK_EMAIL = 'mitx-support@mit.edu' %}
@@ -269,11 +267,7 @@ edx:
        # MITx Residential XBlocks
         - name: edx-sga==0.8.2
         - name: rapid-response-xblock==0.0.2
-    {% if cloudfront_domain %}
-    EDXAPP_STATIC_URL_BASE: "https://{{ cloudfront_domain }}/static/"
-    {% else %}
     EDXAPP_STATIC_URL_BASE: /static/
-    {% endif %}
     EDXAPP_TECH_SUPPORT_EMAIL: mitx-support@mit.edu
     EDXAPP_CMS_ISSUER: "{{ EDXAPP_CMS_ISSUER }}"
 


### PR DESCRIPTION
The `static_url` attribute gets compiled into the static assets for loading font files. This means that when we build our AMIs for edX (which happens in QA) the cloudfront domain gets set at that point. When we deploy to production, the production instances then try to resolve font files from QA hosts and the only option to override the value is to use `sed` or recompile the assets. The alternative is to remove cloudfront from the equation and just load the assets from disk per instance. This commit implements that strategy to remove complexity from our deployments.

#### How should this be manually tested?
Build a new set of AMIs and verify that they aren't attempting to load assets from cloudfront