### PR TITLE
Increased OVS default disk size to 20GB

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/odl-video-service.conf
+++ b/salt/orchestrate/aws/cloud_profiles/odl-video-service.conf
@@ -5,6 +5,10 @@ odl-video-service:
   image: ami-628ad918
   ssh_username: admin
   ssh_interface: private_ips
+  block_device_mappings:
+    - DeviceName: {{ salt.sdb.get('sdb://consul/debian_root_device')|default('/dev/xvda', True) }}
+      Ebs.VolumeSize: 20
+      Ebs.VolumeType: gp2
   script_args: -U -Z
   iam_profile: odl-video-service-instance-role
   tag:


### PR DESCRIPTION
Increased OVS default disk size to 20GB since the instance performs some local processing and requires a larger disk.