### PR TITLE
Added elastalert to send notification when rapid response is enabled or disabled

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -144,6 +144,34 @@ elasticsearch:
                       environment.raw: mitx-production
                   - term:
                       fluentd_tag.raw: edx.lms
+      - name: rapid_response_xblock_status
+        settings:
+          name: Rapid Response XBlock status changed
+          description: >-
+            Send a message anytime a rapid response xblock is
+            enabled or disabled.
+          type: frequency
+          index: logstash-*
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - slack
+          alert_text: "Rapid Response XBlock status changed"
+          slack_webhook_url: {{ slack_webhook_url }}
+          slack_channel_override: "#mitx-tech-notifs"
+          slack_username_override: "Elastalert"
+          slack_msg_color: "good"
+          filter:
+            - bool:
+                must:
+                  - match:
+                      #Request is the same whether xblock is enabled or disabled
+                      message.raw: rapid_response_xblock/handler/toggle_block_enabled
+                  - term:
+                      environment.raw: mitx-production
+                  - term:
+                      fluentd_tag.raw: edx.nginx.access
       - name: rabbitmq_creds_expired
         settings:
           name: Rabbitmq AMQPLAIN login refused

--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -12,6 +12,24 @@ fluentd:
   configs:
     - name: edx
       settings:
+       - directive: source
+          attrs:
+            - '@id': edx_nginx_access_log
+            - '@type': tail
+            - enable_watch_timer: 'false'
+            - tag: edx.nginx.access
+            - path: /edx/var/log/nginx/access.log
+            - pos_file: /edx/var/log/nginx/access.log.pos
+            - nested_directives:
+                - directive: parse
+                  attrs:
+                    - '@type': ltsv
+                    - null_value_pattern: '-'
+                    - keep_time_key: 'true'
+                    - label_delimiter: '='
+                    - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'
+                    - time_key: time
+                    - types: time:time
         - directive: source
           attrs:
             - '@id': edx_cms_log


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#669](https://github.com/mitodl/salt-ops/issues/669)

#### What's this PR do?
Added elastalert to use nginx access logs and notify slack channel when rapid response xblock is enabled or disabled