### PR TITLE
Added ovs prod beacon and interval

### DIFF
--- a/pillar/beacons/http_status_odl_video_service.sls
+++ b/pillar/beacons/http_status_odl_video_service.sls
@@ -10,3 +10,13 @@ beacons:
             - path: 'status_all'
               value: up
               comp: '=='
+        odl-video-production-apps:
+          url: "https://video.odl.mit.edu/status?token=production-apps"
+          json_response:
+            - path: 'certificate:status'
+              value: up
+              comp: '=='
+            - path: 'status_all'
+              value: up
+              comp: '=='
+    - interval: 600

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -146,6 +146,8 @@ salt_master:
         - salt/beacon/reddit-*/memusage/*:
             - salt://reactors/reddit/restart_reddit_service_low_memory.sls
             - salt://reactors/opsgenie/post_notification.sls
+        - salt/beacon/*/http_status/*:
+            - salt://reactors/opsgenie/post_notification.sls
         - vault/lease/expiring/*:
             - salt://reactors/vault/alert_expiring_leases.sls
         - vault/cache/miss/*:


### PR DESCRIPTION
#### What's this PR do?
Uses the new status beacon that we wrote and compares the response from the django-status package to the expected values specified in pillar. This PR adds pillar data to check on OVS RC and prod for valid certificates and whether the overall `status_all` is up. The check runs every 10 min. 

#### How should this be manually tested?
I tested this on my local vagrant master and minion instances and saw the beacons raising an alert.
