### PR TITLE
Beacon to check on lmodproxy status

### DIFF
--- a/pillar/beacons/http_status_lmodproxy.sls
+++ b/pillar/beacons/http_status_lmodproxy.sls
@@ -1,0 +1,22 @@
+beacons:
+  http_status:
+    - sites:
+        lmodproxy-qa:
+          url: "https://lmodproxyqa.odl.mit.edu/status"
+          status:
+            - value: 200
+              comp: '=='
+          content:
+            - path: 'status'
+              value: ok
+              comp: '=='
+        lmodproxy-prod:
+          url: "https://lmodproxyprod.odl.mit.edu/status"
+          status:
+            - value: 200
+              comp: '=='
+          content:
+            - path: 'status'
+              value: ok
+              comp: '=='
+    - interval: 1800

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -199,6 +199,7 @@ base:
     - nginx
     - nginx.amps_redirect
     - beacons.http_status_odl_video_service
+    - beacons.http_status_lmodproxy
   'G@roles:backups and P@environment:mitx-(qa|production)':
     - match: compound
     - backups.mitx


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#230](https://github.com/mitodl/salt-ops/issues/230)

#### What's this PR do?
Uses `http_status` beacon to check lmodproxy status endpoint is returning a 200 and also verifies that the app_cert is still valid

#### How should this be manually tested?
Tested locally on vagrant instances and appears to be functional.
