### PR TITLE
Added dnsutils so that dig is available on instances

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,6 +1,6 @@
 base:
   '*':
-    - utils.install_pip
+    - utils.install_libs
   'not G@roles:devstack':
     - match: compound
     - utils.inotify_watches

--- a/salt/utils/install_libs.sls
+++ b/salt/utils/install_libs.sls
@@ -4,10 +4,10 @@
       'pkgs': ['gcc', 'make']
     },
     'Debian': {
-      'pkgs': ['python-dev', 'python', 'curl'],
+      'pkgs': ['python-dev', 'python', 'curl', 'dnsutils'],
     },
     'RedHat': {
-      'pkgs': ['python', 'python-devel', 'curl'],
+      'pkgs': ['python', 'python-devel', 'curl', 'bind-utils'],
     },
 }, grain='os_family', merge=salt.pillar.get('python_dependencies'), base='default') %}
 


### PR DESCRIPTION
#### What's this PR do?
Dig is usually helpful to have on instances especially when troubleshooting. It's part of dnsuitls (on debian and bind-utils on Redhat). Added it to the list of installed packages on all the instances. Additionally, renamed the state from `install_pip` to `install_libs` as that state files installs more than pip and its dependencies now and it made sense to rename it.
