### PR TITLE
Updated vault refresh schedules to be more frequent

### DIFF
--- a/pillar/apps/mitx_cas.sls
+++ b/pillar/apps/mitx_cas.sls
@@ -21,7 +21,7 @@
 
 schedule:
   refresh_{{ app_name }}_credentials:
-    days: 21
+    days: 5
     function: state.sls
     args:
       - django.config

--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -52,7 +52,7 @@
 
 schedule:
   refresh_{{ app_name }}_credentials:
-    days: 14
+    days: 5
     function: state.sls
     args:
       - django.config

--- a/pillar/apps/redash.sls
+++ b/pillar/apps/redash.sls
@@ -11,7 +11,7 @@
 
 schedule:
   refresh_{{ app_name }}_credentials:
-    days: 14
+    days: 5
     function: state.sls
     args:
       - django.config

--- a/pillar/apps/starcellbio.sls
+++ b/pillar/apps/starcellbio.sls
@@ -18,7 +18,7 @@
 
 schedule:
   refresh_{{ app_name }}_credentials:
-    days: 14
+    days: 5
     function: state.sls
     args:
       - django.config

--- a/pillar/edx/init.sls
+++ b/pillar/edx/init.sls
@@ -27,7 +27,7 @@ edx:
 
 schedule:
   refresh_mitx-{{ environment }}_configs:
-    days: 21
+    days: 5
     function: state.sls
     args:
       - edx.run_ansible

--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -7,7 +7,7 @@
 schedule:
   refresh_{{ app_name }}_configs:
     # Needed to ensure that S3 credentials remain valid
-    days: 21
+    days: 5
     function: state.sls
     args:
       - fluentd.config

--- a/pillar/mongodb/init.sls
+++ b/pillar/mongodb/init.sls
@@ -35,7 +35,7 @@ mongodb:
 {% if 'production' in environment %}
 schedule:
 refresh_datadog_mongodb-{{ environment }}_credentials:
-  days: 21
+  days: 5
   function: state.sls
   args:
     - datadog.plugins

--- a/pillar/rabbitmq/init.sls
+++ b/pillar/rabbitmq/init.sls
@@ -34,7 +34,7 @@ rabbitmq:
 {% if 'production' in ENVIRONMENT %}
 schedule:
 refresh_datadog_rabbitmq-{{ ENVIRONMENT }}_credentials:
-  days: 21
+  days: 5
   function: state.sls
   args:
     - datadog.plugins

--- a/pillar/reddit.sls
+++ b/pillar/reddit.sls
@@ -25,7 +25,7 @@
 
 schedule:
   refresh_{{ app_name }}_configs:
-    days: 14
+    days: 5
     function: state.sls
     args:
       - reddit.config


### PR DESCRIPTION
In order to ensure that the scheduled refresh will always fall within the expiration window of the Vault cache I updated the schedule to be fewer than the 7 day window. The current schedules couldd easily fall outside of that 7 day window and end up resulting in invalid credentials for several days.