### PR TITLE
Salt proxy minion config along with sample app to test with

### DIFF
--- a/pillar/apps/proxy/heroku/flask_app.sls
+++ b/pillar/apps/proxy/heroku/flask_app.sls
@@ -1,10 +1,6 @@
 {% set python_version = '3.7.1' %}
 {% set python_bin_dir = '/usr/local/pyenv/versions/{0}/bin'.format(python_version) %}
 
-proxy:
-  proxytype: rest_sample
-  url: https://amps.odl.mit.edu:8000
-
 django:
   user: flask
   group: flask

--- a/pillar/apps/proxy/heroku/flask_app.sls
+++ b/pillar/apps/proxy/heroku/flask_app.sls
@@ -14,8 +14,8 @@ django:
     type: git
     repository_url: 'https://github.com/mitodl/salt-proxy/flask_app'
     state_params:
-      - overwrite: True
-      - enforce_toplevel: False
+      - force_checkout: True
+      - force_clone: True
   pkgs:
     - flask
   states:

--- a/pillar/apps/proxy/heroku/flask_app.sls
+++ b/pillar/apps/proxy/heroku/flask_app.sls
@@ -1,0 +1,26 @@
+{% set python_version = '3.7.1' %}
+{% set python_bin_dir = '/usr/local/pyenv/versions/{0}/bin'.format(python_version) %}
+
+proxy:
+  proxytype: rest_sample
+  url: https://amps.odl.mit.edu:8000
+
+django:
+  user: flask
+  group: flask
+  pip_path: {{ python_bin_dir }}/pip3
+  app_name: {{ app_name }}
+  app_source:
+    type: git
+    repository_url: 'https://github.com/mitodl/salt-proxy/flask_app'
+    state_params:
+      - overwrite: True
+      - enforce_toplevel: False
+  pkgs:
+    - flask
+  states:
+    deploy:
+      - apps.proxy.heroku.deploy
+      - apps.proxy.flask.post_deploy
+    config:
+      - heroku.update_config

--- a/pillar/apps/proxy/heroku/flask_app.sls
+++ b/pillar/apps/proxy/heroku/flask_app.sls
@@ -8,7 +8,7 @@ django:
   app_name: {{ app_name }}
   app_source:
     type: git
-    repository_url: 'https://github.com/mitodl/salt-proxy/flask_app'
+    repository_url: 'https://github.com/mitodl/salt-proxy'
     state_params:
       - force_checkout: True
       - force_clone: True

--- a/pillar/heroku/init.sls
+++ b/pillar/heroku/init.sls
@@ -1,0 +1,2 @@
+heroku:
+  api_key: __vault__:secret-operations/global/heroku/api_key>data>value

--- a/pillar/heroku/odl_sample_app.sls
+++ b/pillar/heroku/odl_sample_app.sls
@@ -1,0 +1,5 @@
+heroku:
+  app_name: 'odl-sample-app'
+  config_vars:
+    a: 44
+    b: 55

--- a/pillar/heroku/odl_sample_app.sls
+++ b/pillar/heroku/odl_sample_app.sls
@@ -1,3 +1,11 @@
+flask:
+  address: amps.odl.mit.edu
+  port: 8000
+
+proxy:
+  proxytype: rest_sample
+  url: https://{{ flask.address }}:{{ flask.port }}
+
 heroku:
   app_name: 'odl-sample-app'
   config_vars:

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,5 +1,5 @@
 base:
-  '*':
+  '* and not roles:proxy':
     - common
     - environment_settings
     - fluentd
@@ -55,6 +55,10 @@ base:
     - shibboleth
     - shibboleth.odlvideo
     - fluentd.odlvideo
+  heroku_odl_sample_app:
+    - apps.proxy.heroku.odl_sample_app
+    - heroku
+    - heroku.odl_sample_app
   'roles:mitx-cas':
     - match: grain
     - apps.mitx_cas

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,5 +1,6 @@
 base:
-  '* and not roles:proxy':
+  '* and not G@roles:proxy':
+    - type: compound
     - common
     - environment_settings
     - fluentd

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -1,5 +1,5 @@
 base:
-  '* and not G@roles:proxy':
+  'not G@roles:proxy':
     - type: compound
     - common
     - environment_settings

--- a/salt/apps/proxy/flask/post_deploy.sls
+++ b/salt/apps/proxy/flask/post_deploy.sls
@@ -1,0 +1,27 @@
+{% set app_name = salt.pillar.read{'heroku:app_name'} %}
+{% set user = salt.pillar.read('django:user') %}
+{% set group = salt.pillar.read('django:group') %}
+{% set directory = '/opt/{}'.format(app_name) %}
+{% set service = 'flask_{}'.format(app_name) %}
+
+create_{{ service }}_definition:
+  file.managed:
+    - name: /etc/systemd/system/{{ service }}.service
+    - source: salt://apps/templates/flask.service
+    - template: jinja
+    - context:
+        service: {{ service }}
+        directory: {{ directory }}
+        user: {{ user }}
+        group: {{ group }}
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/{{ service }}.service
+
+enable_service_{{ service }}:
+  service.running:
+    - name: {{ service }}
+    - enable: True
+    - require:
+      - file: deploy_systemd_for_{{ service }}

--- a/salt/apps/proxy/heroku/deploy.sls
+++ b/salt/apps/proxy/heroku/deploy.sls
@@ -4,3 +4,10 @@ configure_salt_proxy:
   salt_proxy.configure_proxy:
     - proxyname: {{ app_name }}
     - start: True
+
+set_proxy_grain_role:
+  module.run:
+    - name: grains.set
+    - key: roles
+    - value:
+        - proxy

--- a/salt/apps/proxy/heroku/deploy.sls
+++ b/salt/apps/proxy/heroku/deploy.sls
@@ -1,0 +1,6 @@
+{% set app_name = salt.pillar.get('heroku:app_name') %}
+
+configure_salt_proxy:
+  salt_proxy.configure_proxy:
+    - proxyname: {{ app_name }}
+    - start: True

--- a/salt/apps/templates/flask.service
+++ b/salt/apps/templates/flask.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ user }}
 Group={{ group }}
-ExecStart=/usr/bin/python {{ directory }}/{{ app_name}}.py
+ExecStart=/usr/bin/python {{ directory }}/{{ app_name}}.py --address {{ flask.address }} --port {{ flask.port }}
 Restart=always
 KillSignal=SIGQUIT
 Type=notify

--- a/salt/apps/templates/flask.service
+++ b/salt/apps/templates/flask.service
@@ -1,0 +1,15 @@
+[Unit]
+Description={{ service }} web server
+After=network.target
+
+[Service]
+User={{ user }}
+Group={{ group }}
+ExecStart=/usr/bin/python {{ directory }}/{{ app_name}}.py
+Restart=always
+KillSignal=SIGQUIT
+Type=notify
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/heroku/override_config.sls
+++ b/salt/heroku/override_config.sls
@@ -1,0 +1,9 @@
+{% set app_name = salt.pillar.get('heroku:app_name') %}
+{% set api_key = salt.pillar.get('heroku:api_key') %}
+{% set config_vars = salt.pillar.get('heroku:config_vars') %}
+
+oerride_heroku_{{ app_name }}_config:
+  heroku.override_app_config_vars:
+    - name: {{ app_name }}
+    - api_key: {{ api_key }}
+    - config_vars: {{ config_vars }}

--- a/salt/heroku/update_config.sls
+++ b/salt/heroku/update_config.sls
@@ -1,0 +1,9 @@
+{% set app_name = salt.pillar.get('heroku:app_name') %}
+{% set api_key = salt.pillar.get('heroku:api_key') %}
+{% set config_vars = salt.pillar.get('heroku:config_vars') %}
+
+update_heroku_{{ app_name }}_config:
+  heroku.update_app_config_vars:
+    - name: {{ app_name }}
+    - api_key: {{ api_key }}
+    - config_vars: {{ config_vars }}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#695](https://github.com/mitodl/salt-ops/issues/695)

#### What's this PR do?
- Sets up a salt-proxy for a sample Heroku app
- Sample pillar config vars to test with
- Heroku API key stored in vault
- 2 salt states one to override Heroku config vars and the other to update based on pillar data

*Note: salt-proxy setup will be part of a separate PR. For my testing, I setup it manually on my local vagrant setup.

#### How should this be manually tested?
Setup salt-proxy on the `amps-redirect` minion and test changing config vars and verify that they changes for the Heroku app.
