### PR TITLE
Overriding the DATA_DIR to fix course imports

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -308,6 +308,7 @@ edx:
       ADMINS:
       - ['MITx Stacktrace Recipients', 'cuddle-bunnies@mit.edu']
       BOOK_URL: ""
+      DATA_DIR: {{ edxapp_git_repo_dir }}
       SERVER_EMAIL: mitxmail@mit.edu
       TIME_ZONE_DISPLAYED_FOR_DEADLINES: "{{ TIME_ZONE }}"
 


### PR DESCRIPTION
With the Hawthorn release the DATA_DIR setting is distinct from the COURSE_DATA_DIR which results in errors when trying tom import course archives. In order to resolve this issue we need to set the DATA_DIR back to the course_data_dir/github_repo_dir

#### What are the relevant tickets?
https://github.mit.edu/mitx/Spring-2019/issues/6

#### What's this PR do?
Fixes course imports