### PR TITLE
Added beacon and reactor to restart uwsgi service on low memory

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -183,3 +183,7 @@ uwsgi:
 node:
   install_from_binary: True
   version: 8.5.0
+
+beacons:
+  memusage:
+    - percent: 95%

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -146,6 +146,9 @@ salt_master:
         - salt/beacon/reddit-*/memusage/*:
             - salt://reactors/reddit/restart_reddit_service_low_memory.sls
             - salt://reactors/opsgenie/post_notification.sls
+        - salt/beacon/odl-video-service-*/memusage/*:
+            - salt://reactors/apps/restart_uwsgi_service_low_memory.sls
+            - salt://reactors/opsgenie/post_notification.sls
         - salt/beacon/*/http_status/*:
             - salt://reactors/opsgenie/post_notification.sls
         - vault/lease/expiring/*:

--- a/salt/reactors/apps/restart_uwsgi_service_low_memory.sls
+++ b/salt/reactors/apps/restart_uwsgi_service_low_memory.sls
@@ -1,0 +1,5 @@
+restart_uwsgi_service_low_memory:
+  local.cmd.run:
+    - tgt: {{ data['id'] }}
+    - arg:
+        - service uwsgi restart


### PR DESCRIPTION
#### What's this PR do?
Beacon and reactor that restarts the uwsgi service on `odl-video` instances when memory is low and posts a notification in slack. This is similar to the config we have for the reddit service.