### PR TITLE
Modify sensitivity of elastalert nginx 502 error

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -257,7 +257,7 @@ elasticsearch:
           opsgenie_priority: P1
           type: frequency
           index: logstash-*
-          num_events: 1
+          num_events: 5
           timeframe:
             minutes: 5
           alert:


### PR DESCRIPTION
#### What's this PR do?
Increased the number of events encountered from `1` to `5` to accommodate for service restarts.