### PR TITLE
Added delay to fluentd beacon service check

### DIFF
--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -6,6 +6,9 @@ fluentd:
 
 beacons:
   service:
-    fluentd:
-      onchangeonly: True
-    disable_during_state_run: True
+    - services:
+        fluentd:
+          onchangeonly: True
+          delay: 60
+          disable_during_state_run: True
+    - interval: 60


### PR DESCRIPTION
#### What's this PR do?
Salt-minion logs for newer versions of the client are full of this message in the log:
```
[salt.beacons     :108 ][INFO    ][18036] Beacon service configuration invalid, not running.
Configuration for service beacon must be a list.
```
Now that most of our minions are running the newer version, this should address that issue in addition to changing the check interval from one second to one minute.
