### PR TITLE
Added missing port setting for edxapp outgoing mail

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -255,6 +255,8 @@ edx:
     EDXAPP_DEFAULT_FEEDBACK_EMAIL: "{{ DEFAULT_FEEDBACK_EMAIL }}"
     EDXAPP_DEFAULT_FROM_EMAIL: "{{ DEFAULT_FROM_EMAIL }}"
     EDXAPP_EMAIL_HOST: __vault__::secret-operations/global/mit-smtp>data>relay_host
+    EDXAPP_EMAIL_PORT: __vault__::secret-operations/global/mit-smtp>data>relay_port
+    EDXAPP_EMAIL_USE_TLS: True
     EDXAPP_EMAIL_HOST_USER: __vault__::secret-operations/global/mit-smtp>data>relay_username
     EDXAPP_EMAIL_HOST_PASSWORD: __vault__::secret-operations/global/mit-smtp>data>relay_password
     EDXAPP_EMAIL_USE_TLS: True


### PR DESCRIPTION
The outgoing SMTP connection times out due to the fact that it is defaulting to port 25, whereas outgoing.mit.edu is expecting connections on port 587