### PR TITLE
Added allow_bare_domain param and additional subdomains

### DIFF
--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -14,7 +14,7 @@ vault:
     {% for type in ['client', 'server'] %}
     {{ app }}-{{ env_name }}-{{ type }}-pki:
       backend: pki-intermediate-{{ env_name }}
-      name: pki-{{ env_name }}-{{ app }}-{{ type }}
+      name: {{ app }}-{{ type }}
       options:
         {% if type == 'server' %}
         server_flag: true
@@ -27,6 +27,10 @@ vault:
           {{ app }}.service.consul
           nearest-{{ app }}.query.consul
           {{ app }}-master.service.consul
+          {% for ['consul', 'fluentd'] in app %}
+          {{ app }}.service.operations.consul
+          {% endfor %}
+        allow_bare_domains: true
         key_type: rsa
         key_bits: 4096
         key_usage:

--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -27,9 +27,9 @@ vault:
           {{ app }}.service.consul
           nearest-{{ app }}.query.consul
           {{ app }}-master.service.consul
-          {% for ['consul', 'fluentd'] in app %}
+          {% if app in ['consul', 'fluentd'] %}
           {{ app }}.service.operations.consul
-          {% endfor %}
+          {% endif %}
         allow_bare_domains: true
         key_type: rsa
         key_bits: 4096


### PR DESCRIPTION
#### What's this PR do?
Allows us to generate certs using a common_name specified in allowed_subdomains by adding the `allow_bare_domains` param. Additionally, `consul` and `fluentd` services cross-communicate and thus added a few entries for them. Lastly, changed the path name as it sounded redundant given the name of the backend that already contains the env_name