### PR TITLE
Added hacks state to manage platform workarounds

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -1,0 +1,13 @@
+ensure_license_selector_template_is_in_expected_location:
+  file.copy:
+    - name: /edx/var/edxapp/staticfiles/studio/templates/license-selector.underscore.js
+    - source: /edx/var/edxapp/staticfiles/studio/templates/license-selector.underscore
+    - user: edxapp
+    - group: www-data
+
+ensure_system_feedback_template_is_in_expected_location:
+  file.copy:
+    - name:/edx/var/edxapp/staticfiles/studio/common/templates/components/system-feedback.underscore.js
+    - source: /edx/var/edxapp/staticfiles/studio/common/templates/components/system-feedback.underscore
+    - user: edxapp
+    - group: www-data

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -155,6 +155,7 @@ base:
     - edx.patch_nginx
     - edx.edxapp_global_pre_commit
     - edx.etc_hosts
+    - edx.hacks
     - edx.tests
     - fluentd
     - fluentd.plugins


### PR DESCRIPTION
In this instance there are underscore template files that are being loaded with a `.js` extension in the UI, despite not existing on disk at that location. The easiest fix (other than fixing the webpack/requirejs build configs) is to copy those files to the expected location.

#### What are the relevant tickets?
Zendesk #24351

#### What's this PR do?
Fixes the video editor UI in studio that is broken by the platform trying to load underscore templates with a `.js` extension