### PR TITLE
Added way to customize Consul service name for RDS

### DIFF
--- a/pillar/consul/mitx.sls
+++ b/pillar/consul/mitx.sls
@@ -10,6 +10,7 @@ consul:
         - 8.8.8.8
     {% if 'consul_server' in salt.grains.get('roles', []) %}
     {% set mysql_endpoint = salt.boto_rds.get_endpoint('{env}-rds-mysql'.format(env=ENVIRONMENT)) %}
+    {% if mysql_endpoint %}
     hosted_services:
       services:
         - name: mysql
@@ -18,4 +19,5 @@ consul:
           check:
             tcp: '{{ mysql_endpoint }}'
             interval: 10s
+    {% endif %}
     {% endif %}

--- a/pillar/consul/server.sls
+++ b/pillar/consul/server.sls
@@ -38,7 +38,8 @@ consul:
         {% for dbconfig in env_data.backends.get('rds', []) %}
         {% set rds_endpoint = salt.boto_rds.get_endpoint('{env}-rds-{engine}-{db}'.format(env=ENVIRONMENT, engine=dbconfig.engine, db=dbconfig.name)) %}
         {% if rds_endpoint %}
-        - name: {{ dbconfig.engine }}-{{ dbconfig.name }}
+        {% set service_name = dbconfig.pop('service_name', dbconfig.engine ~ '-' ~ dbconfig.name) %}
+        - name: {{ service_name }}
           port: {{ rds_endpoint.split(':')[1] }}
           address: {{ rds_endpoint.split(':')[0] }}
           check:

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -124,6 +124,7 @@ environments:
           public_access: False
           engine_version: '10.3'
           purpose: xpro-qa
+          service_name: mysql
       elasticache:
         - engine: memcached
           engine_version: '1.4.34'

--- a/salt/orchestrate/aws/rds.sls
+++ b/salt/orchestrate/aws/rds.sls
@@ -35,6 +35,7 @@ create_{{ ENVIRONMENT }}_rds_db_subnet_group:
 {% set dbpurpose = dbconfig.pop('purpose', 'shared') %}
 {% set vault_plugin = dbconfig.pop('vault_plugin') %}
 {% set pw_length = dbconfig.pop('password_length', 42) %}
+{% set service_name = dbconfig.pop('service_name', engine ~ '-' ~ name) %}
 
 {% set vault_master_pass_path = 'secret-' ~ BUSINESS_UNIT ~ '/' ~ ENVIRONMENT ~ '/' ~ engine ~ '-' ~ dbpurpose ~ '-master-password' %}
 {% set master_pass = salt.vault.read(vault_master_pass_path ) %}
@@ -105,9 +106,9 @@ configure_vault_{{ engine }}_{{ name }}_backend:
     - connection_config:
         plugin_name: {{ vault_plugin }}
         {% if engine == 'postgres' %}
-        connection_url: "postgresql://{{ master_user }}:{{ master_pass }}@{{ engine }}-{{ name }}.service.{{ ENVIRONMENT }}.consul:5432/{{ name }}"
+        connection_url: "postgresql://{{ master_user }}:{{ master_pass }}@{{ service_name }}.service.{{ ENVIRONMENT }}.consul:5432/{{ name }}"
         {% else %}
-        connection_url: "{{ master_user }}:{{ master_pass }}@tcp({{ engine }}-{{ name }}.service.{{ ENVIRONMENT }}.consul:3306)/"
+        connection_url: "{{ master_user }}:{{ master_pass }}@tcp({{ service_name }}.service.{{ ENVIRONMENT }}.consul:3306)/"
         {% endif %}
         verify_connection: False
         allowed_roles: '*'


### PR DESCRIPTION
In order to allow for mapping the new pattern for building RDS instances to the old Consul service name I added a way to explicitly set the service name as part of the db configuration. This allows for preserving the Ansible configuration of edX while still using current deployment tooling.