### PR TITLE
Updated settings for building bucket names to work with xpro

### DIFF
--- a/pillar/edx/ansible_vars/init.sls
+++ b/pillar/edx/ansible_vars/init.sls
@@ -8,7 +8,9 @@
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set purpose_suffix = purpose.replace('-', '_') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
-{% set purpose_data = env_settings.environments[environment].purposes[purpose] %}
+{% set env_data = env_settings.environments[environment] %}
+{% set purpose_data = env_data.purposes[purpose] %}
+{% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
 
 {% set CMS_DOMAIN = purpose_data.domains.cms %}
 {% set EDXAPP_CMS_ISSUER = "https://{}/oauth2".format(CMS_DOMAIN) %}
@@ -141,8 +143,8 @@ edx:
     #####################################################################
     ########### Auth Configs ############################################
     #####################################################################
-    EDXAPP_AWS_ACCESS_KEY_ID: __vault__:cache:aws-mitx/creds/mitx-s3-{{ purpose }}-{{ environment }}>data>access_key
-    EDXAPP_AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/mitx-s3-{{ purpose }}-{{ environment }}>data>secret_key
+    EDXAPP_AWS_ACCESS_KEY_ID: __vault__:cache:aws-mitx/creds/{{ bucket_prefix }}-s3-{{ purpose }}-{{ environment }}>data>access_key
+    EDXAPP_AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/{{ bucket_prefix }}-s3-{{ purpose }}-{{ environment }}>data>secret_key
     EDXAPP_CELERY_BROKER_HOSTNAME: nearest-rabbitmq.query.consul
     EDXAPP_CELERY_BROKER_TRANSPORT: 'amqp'
     EDXAPP_CELERY_PASSWORD: __vault__:cache:rabbitmq-{{ environment }}/creds/celery-{{ purpose }}>data>password

--- a/pillar/vault/roles/mitx.sls
+++ b/pillar/vault/roles/mitx.sls
@@ -54,7 +54,9 @@ vault:
       options:
         db_name: mongodb
         creation_statements: {{ '{"roles": [{"role": "superuser"}, {"role": "root"}], "db": "admin"}'|yaml_dquote }}
-    {% for purpose in env_settings['environments'][env].purposes %}
+    {% set env_data = env_settings['environments'][env] %}
+    {% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
+    {% for purpose in env_data.purposes %}
     {% set purpose_suffix = purpose|replace('-', '_') %}
     {% for role in env_settings.edxapp_secret_backends.mysql.role_prefixes %}
     {% set db_name = role|replace('-', '_') ~ '_' ~ purpose_suffix %}
@@ -85,9 +87,9 @@ vault:
     {% endfor %}{# role loop for MongoDB #}
     read_and_write_iam_bucket_access_for_mitx_{{ purpose }}_in_{{ env }}:
       backend: aws-mitx
-      name: mitx-s3-{{ purpose }}-{{ env }}
+      name: {{ bucket_prefix }}-s3-{{ purpose }}-{{ env }}
       options:
-        policy: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": [\"s3:*Object*\", \"s3:ListAllMyBuckets\", \"s3:ListBucket\"], \"Resource\": [\"arn:aws:s3:::mitx-grades-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::mitx-grades-{{ purpose }}-{{ env }}/*\", \"arn:aws:s3:::mitx-storage-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::mitx-storage-{{ purpose }}-{{ env }}/*\", \"arn:aws:s3:::mitx-etl-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::mitx-etl-{{ purpose }}-{{ env }}/*\"]}]}"
+        policy: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": [\"s3:*Object*\", \"s3:ListAllMyBuckets\", \"s3:ListBucket\"], \"Resource\": [\"arn:aws:s3:::{{ bucket_prefix }}-grades-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::{{ bucket_prefix }}-grades-{{ purpose }}-{{ env }}/*\", \"arn:aws:s3:::{{ bucket_prefix }}-storage-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::{{ bucket_prefix }}-storage-{{ purpose }}-{{ env }}/*\", \"arn:aws:s3:::{{ bucket_prefix }}-etl-{{ purpose }}-{{ env }}\", \"arn:aws:s3:::{{ bucket_prefix }}-etl-{{ purpose }}-{{ env }}/*\"]}]}"
     {% endfor %}{# purpose loop #}
     {% if not 'xpro' in env %}
     {% for app in ['mitxcas'] %}

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -15,10 +15,11 @@ edxapp_secret_backends: &edxapp_secret_backends
       - xqueue
       - celery
   aws:
-    bucket_prefixes:
-      - mitx-etl
-      - mitx-grades
-      - mitx-storage
+    bucket_prefix: mitx
+    bucket_uses:
+      - etl
+      - grades
+      - storage
 
 current_residential_versions_qa: &current_residential_versions_qa
   edx_config_repo: https://github.com/mitodl/configuration
@@ -124,9 +125,10 @@ environments:
           - edxapp
           - ecommerce
       aws:
-        bucket_prefixes:
-          - xpro-grades
-          - xpro-storage
+        bucket_prefix: xpro
+        bucket_uses:
+          - grades
+          - storage
     backends:
       pki:
         - consul

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -27,7 +27,8 @@
 {% set app_image = salt.sdb.get('sdb://consul/xenial_ami_id') %}
 {% set worker_image = salt.sdb.get('sdb://consul/xenial_ami_id') %}
 {% endif %}
-{% set bucket_prefixes = env_settings.secret_backends.aws.bucket_prefixes %}
+{% set bucket_prefix = env_settings.secret_backends.aws.bucket_prefix %}
+{% set bucket_uses = env_settings.secret_backends.aws.bucket_uses %}
 
 update_edxapp_codename_value:
   salt.function:
@@ -116,11 +117,11 @@ ensure_instance_profile_exists_for_edx:
   boto_iam_role.present:
     - name: edx-instance-role
 
-{% for bucket in bucket_prefixes %}
+{% for use in bucket_uses %}
 {% for purpose in purposes %}
 create_edx_s3_bucket_{{ bucket }}_{{ purpose }}_{{ ENVIRONMENT }}:
   boto_s3_bucket.present:
-    - Bucket: {{ bucket }}-{{ purpose }}-{{ ENVIRONMENT }}
+    - Bucket: {{ bucket_prefix }}-{{ use }}-{{ purpose }}-{{ ENVIRONMENT }}
     - region: us-east-1
     - Versioning:
        Status: "Enabled"


### PR DESCRIPTION
The settings and names that we were using for S3 in the edX configs had a lot of assumptions about the residential environment built into them. I updated the settings to be a bit more granular in how they get composed so that we can more easily identify which buckets go with which environments and application stacks.

One question that came out of this is whether we should split out the AWS Vault backend a bit more, similar to how we have the other backends configured?