### PR TITLE
Updated xqwatcher deployment to be per course

### DIFF
--- a/pillar/edx/xqwatcher_600.sls
+++ b/pillar/edx/xqwatcher_600.sls
@@ -37,55 +37,6 @@ edx:
           - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>username
           - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>password
     {% endfor %}
-    - COURSE: mit-686x-{{ purpose }}
-      GIT_REPO: git@github.mit.edu:mitx/graders-mit-686x
-      GIT_REF: master
-      PYTHON_REQUIREMENTS:
-        - name: numpy
-          version: 1.14.0
-        - name: pandas
-          version: 0.22.0
-        - name: scikit-image
-          version: 0.13.1
-        - name: scikit-learn
-          version: 0.19.1
-        - name: scipy
-          version: 1.0.0
-        - name: matplotlib
-          version: 2.1.2
-        - name: pytz
-          version: 2018.4
-        - name: networkx
-          version: 2.1
-        - name: cycler
-          version: 0.10.0
-        - name: decorator
-          version: 4.3.0
-        - name: Pillow
-          version: 5.1.0
-        - name: pyparsing
-          version: 2.2.0
-        - name: PyWavelets
-          version: 0.5.2
-        - name: six
-          version: 1.11.0
-      PYTHON_EXECUTABLE: /usr/bin/python3
-      QUEUE_NAME: mitx-686xgrader
-      QUEUE_CONFIG:
-        SERVER: 'http://xqueue-{{ purpose }}.service.consul:18040'
-        CONNECTIONS: 5
-        HANDLERS:
-          - HANDLER: 'xqueue_watcher.jailedgrader.JailedGrader'
-            CODEJAIL:
-              name: mit-686x
-              user: mit-686x
-              lang: python3
-              bin_path: '{% raw %}{{ xqwatcher_venv_base }}{% endraw %}/mit-686x/bin/python'
-            KWARGS:
-              grader_root: ../data/mit-686x-{{ purpose }}/graders/
-        AUTH:
-         - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>username
-         - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>password
     {% endif %}
     {% endfor %}
 
@@ -102,12 +53,5 @@ schedule:
     kwargs:
       identity: /edx/app/xqwatcher/.ssh/xqwatcher-courses
   {% endfor %}
-  update_live_686_grader_for_{{ purpose }}:
-    function: git.pull
-    minutes: 5
-    args:
-      - /edx/app/xqwatcher/data/mit-686x-{{ purpose }}/
-    kwargs:
-      identity: /edx/app/xqwatcher/.ssh/xqwatcher-courses
   {% endif %}
   {% endfor %}

--- a/pillar/edx/xqwatcher_686_residential.sls
+++ b/pillar/edx/xqwatcher_686_residential.sls
@@ -1,0 +1,75 @@
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set environment = salt.grains.get('environment', 'mitx-qa') %}
+{% set env_data = env_settings.environments[environment] %}
+{% set xqwatcher_venv_base = '/edx/app/xqwatcher/venvs' %}
+
+edx:
+  ansible_vars:
+   XQWATCHER_COURSES:
+    {% for purpose, purpose_data in env_data.purposes.items() %}
+    {% if 'residential' in purpose %}
+    - COURSE: mit-686x-{{ purpose }}
+      GIT_REPO: git@github.mit.edu:mitx/graders-mit-686x
+      GIT_REF: master
+      PYTHON_REQUIREMENTS:
+        - name: numpy
+          version: 1.14.0
+        - name: pandas
+          version: 0.22.0
+        - name: scikit-image
+          version: 0.13.1
+        - name: scikit-learn
+          version: 0.19.1
+        - name: scipy
+          version: 1.0.0
+        - name: matplotlib
+          version: 2.1.2
+        - name: pytz
+          version: 2018.4
+        - name: networkx
+          version: 2.1
+        - name: cycler
+          version: 0.10.0
+        - name: decorator
+          version: 4.3.0
+        - name: Pillow
+          version: 5.1.0
+        - name: pyparsing
+          version: 2.2.0
+        - name: PyWavelets
+          version: 0.5.2
+        - name: six
+          version: 1.11.0
+      PYTHON_EXECUTABLE: /usr/bin/python3
+      QUEUE_NAME: mitx-686xgrader
+      QUEUE_CONFIG:
+        SERVER: 'http://xqueue-{{ purpose }}.service.consul:18040'
+        CONNECTIONS: 5
+        HANDLERS:
+          - HANDLER: 'xqueue_watcher.jailedgrader.JailedGrader'
+            CODEJAIL:
+              name: mit-686x
+              user: mit-686x
+              lang: python3
+              bin_path: '{% raw %}{{ xqwatcher_venv_base }}{% endraw %}/mit-686x/bin/python'
+            KWARGS:
+              grader_root: ../data/mit-686x-{{ purpose }}/graders/
+        AUTH:
+         - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>username
+         - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>password
+    {% endif %}
+    {% endfor %}
+
+
+schedule:
+  {% for purpose, purpose_data in env_data.purposes.items() %}
+  {% if purpose_data.business_unit == 'residential' %}
+  update_live_686_grader_for_{{ purpose }}:
+    function: git.pull
+    minutes: 5
+    args:
+      - /edx/app/xqwatcher/data/mit-686x-{{ purpose }}/
+    kwargs:
+      identity: /edx/app/xqwatcher/.ssh/xqwatcher-courses
+  {% endif %}
+  {% endfor %}

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -189,12 +189,17 @@ base:
   'roles:xqwatcher':
     - match: grain
     - edx.xqwatcher
-    - edx.xqwatcher_600
     - fluentd.xqwatcher
   'lightsail-xqwatcher-686':
     - match: glob
     - edx.xqwatcher
     - edx.xqwatcher_686
+  'xqwatcher-600x*':
+    - match: glob
+    - edx.xqwatcher_600
+  'xqwatcher-686*':
+    - match: glob
+    - edx.xqwatcher_686_residential
   'roles:amps-redirect':
     - match: grain
     - nginx

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -380,7 +380,11 @@ environments:
           xqwatcher: 20ab9e6d645b0b8850f14db558499e62e554d8a2
           edx_config_repo: https://github.com/edx/configuration
           edx_config_version: open-release/hawthorn.beta1
-        num_instances: 3
+        courses:
+          - 600x:
+              num_instances: 3
+          - 686:
+              num_instances: 1
       residential-draft:
         business_unit: residential
         domains:


### PR DESCRIPTION
In order to be able to grant access to the course team for a given grader I split out the xqueue-watcher deployment to be per course instead of shared instances. The deployment now iterates over a mapping of courses to build separate groups of instances which allows for independent scaling needs as well.