### PR TITLE
Readonlyrest plugin conflicts with xpack.security

### DIFF
--- a/pillar/elasticsearch/apps.sls
+++ b/pillar/elasticsearch/apps.sls
@@ -10,6 +10,7 @@ elasticsearch:
       gateway.expected_nodes: 3
       gateway.recover_after_time: 5m
       rest.action.multi.allow_explicit_index: 'false'
+      xpack.security.enabled: false
   plugins:
     - name: discovery-ec2
       config:


### PR DESCRIPTION
#### What are the relevant tickets?
(Required)

#### What's this PR do?
This change adds a single line to disable xpack.security, as the ES service starts but does not bind to any port. The readonlyrest plugin offers the same features as xpack.security and thus xpack needs to be disabled for the ES service to bind to a port. Came across the solution [here](https://forum.readonlyrest.com/t/how-to-make-readonlyrest-compatible-with-x-pack-plugin/24)
