### PR TITLE
Added tojson filters for rendering data structures in salt templates

### DIFF
--- a/pillar/backups/restore.sls
+++ b/pillar/backups/restore.sls
@@ -65,7 +65,7 @@ restores:
       username: __vault__:cache:mongodb-{{ environment }}/creds/admin>data>username
       duplicity_passphrase: __vault__::secret-operations/global/duplicity-passphrase>data>value
       directory: mongodb-mitx-production
-      db_map: {{ mongo_map }}
+      db_map: {{ mongo_map|tojson }}
 {% endif %}
 {% endfor %}
   - title: live_course_assets

--- a/pillar/cassandra.sls
+++ b/pillar/cassandra.sls
@@ -25,7 +25,7 @@ cassandra:
     seed_provider:
       - class_name: org.apache.cassandra.locator.SimpleSeedProvider
         parameters:
-          - seeds: {{ lan_nodes|join(',') }}
+          - seeds: {{ lan_nodes|join(',')|tojson }}
     # authenticator: PasswordAuthenticator
 
 python_dependencies:

--- a/pillar/consul/init.sls
+++ b/pillar/consul/init.sls
@@ -22,5 +22,5 @@ consul:
         service_ttl:
           "*": 30s
       encrypt: __vault__::secret-operations/global/consul-shared-secret>data>value
-      retry_join: {{ lan_nodes }}
+      retry_join: {{ lan_nodes|tojson }}
       datacenter: {{ ENVIRONMENT }}

--- a/pillar/consul/operations.sls
+++ b/pillar/consul/operations.sls
@@ -19,5 +19,5 @@ consul:
         - 1.1.1.1
         - 8.8.8.8
     {% if 'consul_server' in salt.grains.get('roles', []) %}
-      retry_join_wan: {{ wan_nodes }}
+      retry_join_wan: {{ wan_nodes|tojson }}
     {% endif %}

--- a/pillar/consul/server.sls
+++ b/pillar/consul/server.sls
@@ -30,7 +30,7 @@ consul:
       addresses:
         dns: 0.0.0.0
         http: 0.0.0.0
-      retry_join_wan: {{ wan_nodes }}
+      retry_join_wan: {{ wan_nodes|tojson }}
       acl_datacenter: {{ ENVIRONMENT }}
       acl_master_token: __vault__::secret-operations/{{ ENVIRONMENT }}/consul-acl-master-token>data>value
     aws_services:

--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -81,7 +81,7 @@ edx:
 
   ansible_vars:
     ### EDXAPP ENVIRONMENT ###
-    EDXAPP_LOGIN_REDIRECT_WHITELIST: {{ purpose_data.domains.values() }}
+    EDXAPP_LOGIN_REDIRECT_WHITELIST: {{ purpose_data.domains.values()|tojson }}
     EDXAPP_MEMCACHE:
       {% for cache_config in cache_configs %}
       {% set cache_purpose = cache_config.get('purpose', 'shared') %}

--- a/pillar/environment_settings.sls
+++ b/pillar/environment_settings.sls
@@ -1,4 +1,4 @@
 {# This file is for exposing the data in the YAML file via the Pillar system #}
 {% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
-environments: {{ env_settings.environments }}
-business_units: {{ env_settings.business_units }}
+environments: {{ env_settings.environments|tojson }}
+business_units: {{ env_settings.business_units|tojson }}

--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -19,7 +19,7 @@ nginx:
           enabled: True
           config:
             - server:
-                - server_name: {{ server_domain_names }}
+                - server_name: {{ server_domain_names|tojson }}
                 - listen:
                     - 80
                 - listen:
@@ -29,7 +29,7 @@ nginx:
                 - location /:
                     - return: 301 https://$host$request_uri
             - server:
-                - server_name: {{ server_domain_names }}
+                - server_name: {{ server_domain_names|tojson }}
                 - listen:
                     - 443
                     - ssl

--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -33,7 +33,7 @@ nginx:
           enabled: True
           config:
             - server:
-                - server_name: {{ server_domain_names }}
+                - server_name: {{ server_domain_names|tojson }}
                 - listen:
                     - 80
                 - listen:
@@ -41,7 +41,7 @@ nginx:
                 - location /:
                     - return: 301 https://$host$request_uri
             - server:
-                - server_name: {{ server_domain_names }}
+                - server_name: {{ server_domain_names|tojson }}
                 - listen:
                     - 443
                     - ssl

--- a/salt/apps/redash/datasources.sls
+++ b/salt/apps/redash/datasources.sls
@@ -7,7 +7,7 @@ manage_datasource_settings_for_{{ source.name }}:
     - template: jinja
     - cwd: /opt/redash
     - runas: redash
-    - env: {{ redash_env }}
+    - env: {{ redash_env|tojson }}
     - context:
         ds: {{ source }}
 {% endfor %}

--- a/salt/apps/redash/first_run.sls
+++ b/salt/apps/redash/first_run.sls
@@ -6,11 +6,11 @@ create_redash_database_tables:
     - name: /opt/redash/bin/run ./manage.py database create_tables
     - cwd: /opt/redash
     - runas: redash
-    - env: {{ redash_env }}
+    - env: {{ redash_env|tojson }}
 
 create_redash_root_user:
   cmd.run:
     - name: /opt/redash/bin/run ./manage.py users create_root --password {{ root_user.password }} {{ root_user.email }} {{ root_user.name }}
     - cwd: /opt/redash
     - runas: redash
-    - env: {{ redash_env }}
+    - env: {{ redash_env|tojson }}

--- a/salt/apps/redash/install.sls
+++ b/salt/apps/redash/install.sls
@@ -7,5 +7,5 @@ install_python_requirements_for_all_datasources:
 
 install_additional_python_requirements_for_python_datasource:
   pip.installed:
-    - pkgs: {{ salt.pillar.get('redash:additional_python_pkgs', []) }}
+    - pkgs: {{ salt.pillar.get('redash:additional_python_pkgs', [])|tojson }}
     - bin_env: {{ salt.pillar.get('django:pip_path') }}

--- a/salt/apps/redash/post_deploy.sls
+++ b/salt/apps/redash/post_deploy.sls
@@ -5,7 +5,7 @@ migrate_redash_database:
     - name: /opt/redash/bin/run ./manage.py db upgrade
     - cwd: /opt/redash
     - runas: redash
-    - env: {{ redash_env }}
+    - env: {{ redash_env|tojson }}
     - require:
         - archive: deploy_application_source_to_destination
         - pip: install_python_requirements

--- a/salt/apps/starcellbio/post_deploy.sls
+++ b/salt/apps/starcellbio/post_deploy.sls
@@ -9,7 +9,7 @@ populate_database_with_seed_data:
     - fixtures: auth,backend,courses,assignments,studentassignments
     - bin_env: {{ django.django_admin_path }}
     - runas: deploy
-    - env: {{ django.get('environment', {}) }}
+    - env: {{ django.get('environment', {})|tojson }}
     {% if django.automatic_migrations %}
     - require:
         - module: migrate_database

--- a/salt/backups/backup.sls
+++ b/salt/backups/backup.sls
@@ -16,7 +16,7 @@ install_duplicity_backend_requirements:
 {% if service.get('pkgs') %}
 install_packages_for_{{ service.title }}_backup:
   pkg.installed:
-    - pkgs: {{ service.pkgs }}
+    - pkgs: {{ service.pkgs|tojson }}
 {% endif %}
 {% endfor %}
 
@@ -28,7 +28,7 @@ schedule_backups_for_{{ service.title }}:
     - source: salt://backups/templates/backup_{{ service.name }}.sh
     - template: jinja
     - context:
-        settings: {{ service.settings }}
+        settings: {{ service.settings|tojson }}
         ENVIRONMENT: {{ ENVIRONMENT }}
         title: {{ service.title }}
   cron.present:

--- a/salt/backups/restore.sls
+++ b/salt/backups/restore.sls
@@ -16,7 +16,7 @@ install_duplicity_backend_requirements:
 {% if service.get('pkgs') %}
 install_packages_for_{{ service.title }}_backup:
   pkg.installed:
-    - pkgs: {{ service.pkgs }}
+    - pkgs: {{ service.pkgs|tojson }}
 {% endif %}
 {% endfor %}
 
@@ -27,12 +27,12 @@ run_restore_for_{{ service.title }}:
     - source: salt://backups/templates/restore_{{ service.name }}.sh
     - template: jinja
     - context:
-        settings: {{ service.settings }}
+        settings: {{ service.settings|tojson }}
   cmd.script:
     - name: salt://backups/templates/restore_{{ service.name }}.sh
     - template: jinja
     - context:
-        settings: {{ service.settings }}
+        settings: {{ service.settings|tojson }}
     - fire_event: restore/{{ ENVIRONMENT }}/{{ service.title }}
 {% endfor %}
 

--- a/salt/edx/prod.sls
+++ b/salt/edx/prod.sls
@@ -32,7 +32,7 @@ include:
 
 install_os_packages:
   pkg.installed:
-    - pkgs: {{ os_packages }}
+    - pkgs: {{ os_packages|tojson }}
     - refresh: True
     - refresh_modules: True
     - require_in:

--- a/salt/etl/init.sls
+++ b/salt/etl/init.sls
@@ -2,7 +2,7 @@
 
 install_etl_os_dependencies:
   pkg.installed:
-    - pkgs: {{ salt.pillar.get('etl_dependencies', ['python3', 'python3-pip', 'git']) }}
+    - pkgs: {{ salt.pillar.get('etl_dependencies', ['python3', 'python3-pip', 'git'])|tojson }}
     - refresh: True
 
 create_etl_directory:

--- a/salt/heroku/update_heroku_config.sls
+++ b/salt/heroku/update_heroku_config.sls
@@ -6,4 +6,4 @@ update_heroku_{{ app_name }}_config:
   heroku.update_app_config_vars:
     - name: {{ app_name }}
     - api_key: {{ api_key }}
-    - config_vars: {{ config_vars }}
+    - config_vars: {{ config_vars|tojson }}

--- a/salt/master_utils/libgit.sls
+++ b/salt/master_utils/libgit.sls
@@ -30,7 +30,7 @@
 
 install_libgit_build_tools:
   pkg.installed:
-    - pkgs: {{ libgit.pkgs }}
+    - pkgs: {{ libgit.pkgs|tojson }}
     - reload_modules: True
 
 download_libgit_source:

--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -36,7 +36,7 @@ generate_{{ app_name }}_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             '{}-{}'.format(group_name, ENVIRONMENT), vpc_name=VPC_NAME) }}
           {% endfor %}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           app: {{ app_name }}
           business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/aws/app_elb.sls
+++ b/salt/orchestrate/aws/app_elb.sls
@@ -49,8 +49,8 @@ create_elb_for_{{ app_name }}_{{ ENVIRONMENT }}:
     {% endfor %}
     - health_check:
         target: HTTPS:443{{ purpose.get('healthcheck', '/status/?token={env}'.format(env=ENVIRONMENT)) }}
-    - subnets: {{ subnet_ids }}
-    - security_groups: {{ security_groups }}
+    - subnets: {{ subnet_ids|tojson }}
+    - security_groups: {{ security_groups|tojson }}
     - tags:
         Name: {{ elb_name }}
         business_unit: {{ BUSINESS_UNIT }}
@@ -58,6 +58,6 @@ create_elb_for_{{ app_name }}_{{ ENVIRONMENT }}:
 register_{{ app_name }}_nodes_with_elb:
   boto_elb.register_instances:
     - name: {{ elb_name }}
-    - instances: {{ instance_ids }}
+    - instances: {{ instance_ids|tojson }}
     - require:
         - boto_elb: create_elb_for_{{ app_name }}_{{ ENVIRONMENT }}

--- a/salt/orchestrate/aws/bootcamp-ecommerce/rds.sls
+++ b/salt/orchestrate/aws/bootcamp-ecommerce/rds.sls
@@ -9,7 +9,7 @@ create_{{ ENVIRONMENT }}_rds_db_subnet_group:
   boto_rds.subnet_group_present:
     - name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
     - description: Subnet group for Bootcamp Ecommerce RDS instance
-    - subnet_ids: {{ subnet_ids }}
+    - subnet_ids: {{ subnet_ids|tojson }}
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/aws/minion_dns.sls
+++ b/salt/orchestrate/aws/minion_dns.sls
@@ -11,6 +11,6 @@
 create_dns_entry_for_{{ instance_id }}:
   boto_route53.present:
     - name: {{ domain }}.{{ zone }}
-    - value: {{ ipaddrs }}
+    - value: {{ ipaddrs|tojson }}
     - record_type: A
     - zone: {{ zone }}

--- a/salt/orchestrate/aws/mitx_elb.sls
+++ b/salt/orchestrate/aws/mitx_elb.sls
@@ -56,8 +56,8 @@ create_elb_for_edx_{{ purpose_name }}:
         {% endfor %}
     - health_check:
         target: 'HTTPS:443/heartbeat'
-    - subnets: {{ subnet_ids }}
-    - security_groups: {{ security_groups }}
+    - subnets: {{ subnet_ids|tojson }}
+    - security_groups: {{ security_groups|tojson }}
     - policies:
         - policy_name: {{ elb_name }}-sticky-cookie-policy
           policy_type: LBCookieStickinessPolicyType
@@ -115,8 +115,8 @@ create_elb_for_edx_{{ purpose_name }}_studio:
         {% endfor %}
     - health_check:
         target: 'HTTPS:443/heartbeat'
-    - subnets: {{ subnet_ids }}
-    - security_groups: {{ security_groups }}
+    - subnets: {{ subnet_ids|tojson }}
+    - security_groups: {{ security_groups|tojson }}
     - policies:
         - policy_name: {{ elb_name }}-sticky-cookie-policy
           policy_type: LBCookieStickinessPolicyType

--- a/salt/orchestrate/aws/rds.sls
+++ b/salt/orchestrate/aws/rds.sls
@@ -20,7 +20,7 @@ create_{{ ENVIRONMENT }}_rds_db_subnet_group:
   boto_rds.subnet_group_present:
     - name: db-subnet-group-{{ENVIRONMENT }}
     - description: Subnet group for {{ ENVIRONMENT }} RDS instances
-    - subnet_ids: {{ subnet_ids }}
+    - subnet_ids: {{ subnet_ids|tojson }}
     - tags:
         Name: db-subnet-group-{{ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -60,7 +60,7 @@ generate_edx_cloud_map_file:
             'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           consul-agent: {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           launch-date: '{{ launch_date }}'
           Department: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/edx/services/rds.sls
+++ b/salt/orchestrate/edx/services/rds.sls
@@ -9,7 +9,7 @@ create_edx_rds_db_subnet_group:
   boto_rds.subnet_group_present:
     - name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
     - description: Subnet group for MySQL instance in {{ ENVIRONMENT }}
-    - subnet_ids: {{ subnet_ids }}
+    - subnet_ids: {{ subnet_ids|tojson }}
     - tags:
         Name: db-subnet-group-{{VPC_RESOURCE_SUFFIX }}
         business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/edx/xqwatcher.sls
+++ b/salt/orchestrate/edx/xqwatcher.sls
@@ -46,7 +46,7 @@ generate_xqwatcher_{{ course.name }}_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             '{}-{}'.format(group_name, ENVIRONMENT), vpc_name=VPC_NAME) }}
           {% endfor %}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
     - require:
         - file: load_xqwatcher_cloud_profile
 

--- a/salt/orchestrate/operations/services/fluentd.sls
+++ b/salt/orchestrate/operations/services/fluentd.sls
@@ -55,7 +55,7 @@ generate_{{ app_name }}_cloud_map_file:
             'fluentd-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           business_unit: {{ BUSINESS_UNIT }}
           Department: {{ BUSINESS_UNIT }}
@@ -127,7 +127,7 @@ update_mine_with_{{ app_name }}_node_data:
 register_log_aggregator_dns:
   boto_route53.present:
     - name: log-input.odl.mit.edu
-    - value: {{ hosts }}
+    - value: {{ hosts|tojson }}
     - zone: odl.mit.edu.
     - record_type: A
 #}

--- a/salt/orchestrate/operations/services/kibana.sls
+++ b/salt/orchestrate/operations/services/kibana.sls
@@ -34,7 +34,7 @@ generate_{{ app_name }}_cloud_map_file:
             'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           business_unit: {{ BUSINESS_UNIT }}
           Department: {{ BUSINESS_UNIT }}
@@ -101,6 +101,6 @@ update_mine_with_{{ app_name }}_node_data:
 register_kibana_nodes_with_dns:
   boto_route53.present:
     - name: logs.odl.mit.edu
-    - value: {{ hosts }}
+    - value: {{ hosts|tojson }}
     - zone: odl.mit.edu.
     - record_type: A

--- a/salt/orchestrate/reddit/init.sls
+++ b/salt/orchestrate/reddit/init.sls
@@ -35,7 +35,7 @@ generate_{{ app_name }}_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             '{}-{}'.format(group_name, ENVIRONMENT), vpc_name=VPC_NAME) }}
           {% endfor %}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           app: {{ app_name }}
           business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -41,7 +41,7 @@ generate_cloud_map_file:
             'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
     - require:
         - file: load_consul_cloud_profile
 

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -34,7 +34,7 @@ generate_elasticsearch_cloud_map_file:
             'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         tags:
           escluster: {{ ENVIRONMENT }}
           business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/services/mongodb.sls
+++ b/salt/orchestrate/services/mongodb.sls
@@ -58,7 +58,7 @@ generate_mongodb_cloud_map_file:
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'vault-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
     - require:
         - file: load_mongodb_cloud_profile
 

--- a/salt/orchestrate/services/rabbitmq.sls
+++ b/salt/orchestrate/services/rabbitmq.sls
@@ -59,7 +59,7 @@ generate_rabbitmq_cloud_map_file:
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'vault-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
 
 ensure_instance_profile_exists_for_rabbitmq:
   boto_iam_role.present:

--- a/salt/orchestrate/services/scylladb.sls
+++ b/salt/orchestrate/services/scylladb.sls
@@ -50,7 +50,7 @@ generate_cloud_map_file:
             'scylladb-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-        subnetids: {{ subnet_ids }}
+        subnetids: {{ subnet_ids|tojson }}
         profile_overrides:
           userdata_file: '/etc/salt/cloud.d/edx_userdata.yml'
     - require:

--- a/salt/utils/install_libs.sls
+++ b/salt/utils/install_libs.sls
@@ -13,7 +13,7 @@
 
 prepare_installation_of_pip_executable:
   pkg.installed:
-    - pkgs: {{ python_dependencies.pkgs }}
+    - pkgs: {{ python_dependencies.pkgs|tojson }}
     - reload_modules: True
 
 install_global_pip_executable:
@@ -28,5 +28,5 @@ install_global_pip_executable:
 
 install_python_libraries:
   pip.installed:
-    - names: {{ python_dependencies.python_libs }}
+    - names: {{ python_dependencies.python_libs|tojson }}
     - reload_modules: True

--- a/salt/utils/logrotate.sls
+++ b/salt/utils/logrotate.sls
@@ -8,5 +8,5 @@ generate_{{ name }}_logrotate:
     - template: jinja
     - mode: '0644'
     - context:
-        settings: {{ settings }}
+        settings: {{ settings|tojson }}
 {% endfor %}


### PR DESCRIPTION
The latest version of Salt includes a breaking change for rendering nested data structures directly in YAML from Jinja. This PR adds the `tojson` filter to any locations where we are trying to directly load data structures (lists, dicts, nested objects, etc.) so that we don't have errors trying to render pillar and state data objects.