### PR TITLE
Reformatted inotify beacon to fix errors in log

### DIFF
--- a/pillar/edx/inotify_mitx.sls
+++ b/pillar/edx/inotify_mitx.sls
@@ -1,52 +1,53 @@
 beacons:
   inotify:
-    /lib:
-      recurse: True
-      auto_add: True
-    /bin:
-      recurse: True
-      auto_add: True
-    /sbin:
-      recurse: True
-      auto_add: True
-    /boot:
-      recurse: True
-      auto_add: True
-    /lib64:
-      recurse: True
-      auto_add: True
-    /usr:
-      recurse: True
-      auto_add: True
-    /edx:
-      exclude:
-        - /edx/var/log
-        - /edx/var/edxapp/export_course_repos
-        - /edx/app/edxapp/venvs/edxapp-sandbox/.config/matplotlib
-      recurse: True
-      auto_add: True
-    /opt:
-      exclude:
-        - /opt/datadog-agent/run
-        - /opt/datadog-agent/agent
-      recurse: True
-      auto_add: True
-    /etc:
-      exclude:
-        - /etc/cas/timestamp
-        - /etc/salt/gpgkeys/random_seed
-      recurse: True
-      auto_add: True
-    /var:
-      exclude:
-        - /var/backups
-        - /var/cache
-        - /var/log
-        - /var/lib
-        - /var/lock
-        - /var/mail
-        - /var/spool
-        - /var/tmp
-      recurse: True
-      auto_add: True
+    - files:
+        /lib:
+          recurse: True
+          auto_add: True
+        /bin:
+          recurse: True
+          auto_add: True
+        /sbin:
+          recurse: True
+          auto_add: True
+        /boot:
+          recurse: True
+          auto_add: True
+        /lib64:
+          recurse: True
+          auto_add: True
+        /usr:
+          recurse: True
+          auto_add: True
+        /edx:
+          exclude:
+            - /edx/var/log
+            - /edx/var/edxapp/export_course_repos
+            - /edx/app/edxapp/venvs/edxapp-sandbox/.config/matplotlib
+          recurse: True
+          auto_add: True
+        /opt:
+          exclude:
+            - /opt/datadog-agent/run
+            - /opt/datadog-agent/agent
+          recurse: True
+          auto_add: True
+        /etc:
+          exclude:
+            - /etc/cas/timestamp
+            - /etc/salt/gpgkeys/random_seed
+          recurse: True
+          auto_add: True
+        /var:
+          exclude:
+            - /var/backups
+            - /var/cache
+            - /var/log
+            - /var/lib
+            - /var/lock
+            - /var/mail
+            - /var/spool
+            - /var/tmp
+          recurse: True
+          auto_add: True
     disable_during_state_run: True


### PR DESCRIPTION
#### What's this PR do?
Continual message in the salt-minion logs caused by an issue with the inotify beacon:
```[salt.beacons     :108 ][INFO    ][19557] Beacon inotify configuration invalid, not running.
Configuration for inotify beacon must be a list.
```
This was introduced in the newer version of salt which we are now running on all the residential minions. This change is based on salt [docs](https://docs.saltstack.com/en/latest/ref/beacons/all/salt.beacons.inotify.html) and should fix the problem.