### PR TITLE
Renamed analytics role to edx-residential-analytics

### DIFF
--- a/pillar/edx/init.sls
+++ b/pillar/edx/init.sls
@@ -36,7 +36,7 @@ schedule:
       pillar:
         edx:
           ansible_flags: '--tags install:configuration'
-  {% if 'analytics' in roles %}
+  {% if 'edx-residential-analytics' in roles %}
   refresh_etl-{{ environment }}_configs:
     days: 5
     function: state.sls

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -109,7 +109,7 @@ base:
     - match: compound
     - rabbitmq.apps
     - consul.apps
-  'G@roles:analytics and G@environment:mitx-production':
+  'G@roles:edx-residential-analytics and G@environment:mitx-production':
     - match: compound
     - data.mitx_etl
   'G@roles:consul_server and G@environment:operations':

--- a/salt/orchestrate/aws/map_templates/analytics_edx.yml
+++ b/salt/orchestrate/aws/map_templates/analytics_edx.yml
@@ -26,4 +26,4 @@ edx:
         roles:
           - edx
           - edx-draft
-          - analytics
+          - edx-residential-analytics

--- a/salt/orchestrate/edx/mitx_analytics.sls
+++ b/salt/orchestrate/edx/mitx_analytics.sls
@@ -57,7 +57,7 @@ sync_external_modules_for_edx_nodes:
 load_pillar_data_on_edx_nodes:
   salt.function:
     - name: saltutil.refresh_pillar
-    - tgt: 'P@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'P@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - require:
         - salt: deploy_analytics_edx_cloud_map
@@ -65,7 +65,7 @@ load_pillar_data_on_edx_nodes:
 populate_mine_with_edx_node_data:
   salt.function:
     - name: mine.update
-    - tgt: 'P@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'P@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - require:
         - salt: load_pillar_data_on_edx_nodes
@@ -74,7 +74,7 @@ populate_mine_with_edx_node_data:
 reload_pillar_data_on_edx_nodes:
   salt.function:
     - name: saltutil.refresh_pillar
-    - tgt: 'P@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'P@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - require:
         - salt: populate_mine_with_edx_node_data
@@ -82,7 +82,7 @@ reload_pillar_data_on_edx_nodes:
 {# Deploy Consul agent first so that the edx deployment can use provided DNS endpoints #}
 deploy_consul_agent_to_analytics_nodes:
   salt.state:
-    - tgt: 'P@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'P@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - sls:
         - consul
@@ -90,7 +90,7 @@ deploy_consul_agent_to_analytics_nodes:
 
 build_analytics_node:
   salt.state:
-    - tgt: 'P@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'P@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - highstate: True
     - require:
@@ -117,7 +117,7 @@ create_user_account:
 {% set enc, key, comment = pubkey.split() %}
 add_{{ comment }}_public_key_to_user:
   salt.function:
-    - tgt: 'G@roles:analytics and G@environment:{{ ENVIRONMENT }}'
+    - tgt: 'G@roles:edx-residential-analytics and G@environment:{{ ENVIRONMENT }}'
     - tgt_type: compound
     - name: ssh.set_auth_key
     - kwarg:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -180,7 +180,7 @@ base:
     - fluentd
     - fluentd.plugins
     - fluentd.config
-  'G@roles:analytics and G@environment:mitx-production':
+  'G@roles:edx-residential-analytics and G@environment:mitx-production':
     - match: compound
     - etl
     - etl.mitx


### PR DESCRIPTION
#### What's this PR do?
Renames `analytics` role to `edx-residential-analytics` in order to clarify that exact type of analytics instance it is since we might have others in the future.
