### PR TITLE
Improve Elasticsearch cloud map and profile generation

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -539,6 +539,10 @@ environments:
         business_unit: operations
         security_groups:
           - webapp-odl-vpn
+      elasticsearch:
+        num_instances: 5
+        size: r4.xlarge
+        data_volume_size: 1536
     backends:
       pki:
         - consul


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/761

#### What's this PR do?

* Create a service-per-environment cloud map file instead of one
  "elasticsearch" cloud map file.

* Remove profile_overrides from orchestrate/services/elasticsearch.sls
  and set environment-specific data from environment_settings.yml

This should fix the issues we were having with trying to create the operations logging Elasticsearch cluster and having settings like instance type and volume size get overridden by the hardcoded `profile_overrides` in `salt/orchestrate/services/elasticsearch.sls`. In addition I'm attempting to do the refactoring that I _think_ we three were talking about yesterday to make the Elasticsearch Salt Cloud files more flexible and easier to override per-environment.

