### PR TITLE
Remove outdated elasticsearch.yml config for plugins

### DIFF
--- a/pillar/elastic_stack/elasticsearch/logging.sls
+++ b/pillar/elastic_stack/elasticsearch/logging.sls
@@ -8,19 +8,12 @@ elastic_stack:
       gateway.recover_after_nodes: 3
       gateway.expected_nodes: 5
       gateway.recover_after_time: 5m
-      repositories:
-        s3:
-          bucket: mitx-elasticsearch-backups
-          region: us-east-1
       discovery:
         zen.hosts_provider: ec2
       cloud.node.auto_attributes: true
       network.host: [_eth0_, _lo_]
     plugins:
       - name: discovery-ec2
-        config:
-          aws:
-            region: us-east-1
       - name: repository-s3
 
     # There seems to be a bug in


### PR DESCRIPTION
#### What are the relevant tickets?

#761 

#### What's this PR do?

Under elastic_stack.elasticsearch.configuration_settings ...

* Remove `repositories` property
* Remove `config` property for `discovery-ec2` element

As of version 6.7, Elasticsearch throws IllegalArgumentExceptions
for `aws.region` and `repositories.s3` in `elasticsearch.yml`.

The ec2-discovery plugin continues to recognize `discovery.ec2.tag`
and `discovery.zen.host.provider`. These settings remain in our
generated `elasticsearch.yml`.

The repository-s3 plugin is supposed to be configured with the REST
`/_snapshot` API.
