### PR TITLE
Cleaning up after fixing AMI build errors

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -162,6 +162,8 @@ salt_master:
             - salt://reactors/slack/post_event.sls
     misc:
       worker_threads: 25
+      {# this is to avoid timeouts waiting for edx asset compilation during AMI build (TMM 2019-04-01) #}
+      gather_job_timeout: 30
       master_job_cache: pgjsonb
       event_return: pgjsonb
       returner.pgjsonb.host: postgres-saltmaster.service.consul

--- a/salt/orchestrate/aws/cloud_profiles/edx_base.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx_base.conf
@@ -1,13 +1,13 @@
 # -*- mode: yaml; coding: utf-8; -*-
 edx_base:
   provider: mitx
-  size: m5.large
+  size: t3.large
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id')|default('ami-020a9a7369c26052b') }}
   ssh_username: ubuntu
   ssh_interface: private_ips
   block_device_mappings:
     - DeviceName: /dev/sda1
-      Ebs.VolumeSize: 15
+      Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
   iam_profile: edx-instance-role
   tag:
@@ -20,13 +20,13 @@ edx_base:
 
 edx_worker_base:
   provider: mitx
-  size: m5.large
+  size: t3.large
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id') }}
   ssh_username: ubuntu
   ssh_interface: private_ips
   block_device_mappings:
     - DeviceName: /dev/sda1
-      Ebs.VolumeSize: 15
+      Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
   iam_profile: edx-instance-role
   tag:

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -215,9 +215,6 @@ compile_assets_for_edx_{{ PURPOSE }}:
     - name: cmd.run
     - arg:
         - /edx/bin/edxapp-update-assets
-    - kwarg:
-        use_vt: True
-        timeout: 900
     - require:
         - salt: build_edx_base_nodes
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -170,9 +170,9 @@ base:
   'G@roles:edx and P@environment:mitx-(qa|production)':
     - match: compound
     - edx.gitreload
-    - edx.tests.test_gitreload
     - edx.edxapp_global_pre_commit
     - edx.etc_hosts
+    - edx.tests.test_gitreload
   'G@roles:edx and G@environment:mitx-production':
     - match: compound
     - monit


### PR DESCRIPTION
Removing code that was added while debugging AMI build failures for residential production that was a result of the asset compilation step causing the master to timeout waiting for a response from the minion