### PR TITLE
Copy some static files to static subfolder

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -20,4 +20,4 @@ copy_select_static_assets_to_static_subfolder:
   file.copy:
     - src: /edx/var/edxapp/staticfiles/paragon/static/
     - dst: /edx/var/edxapp/staticfiles/paragon/static/static/
-   - recurse: True
+    - recurse: True

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -9,3 +9,15 @@ ensure_system_feedback_template_is_in_expected_location:
     - name: /edx/var/edxapp/staticfiles/studio/common/templates/components/system-feedback.underscore.js
     - source: /edx/var/edxapp/staticfiles/studio/common/templates/components/system-feedback.underscore
     - preserve: True
+
+create_static_assets_subfolder:
+  file.directory:
+    - name: /edx/var/edxapp/staticfiles/paragon/static/static
+    - user: edxapp
+    - group: edxapp
+
+copy_select_static_assets_to_static_subfolder:
+  file.copy:
+    - src: /edx/var/edxapp/staticfiles/paragon/static/
+    - dst: /edx/var/edxapp/staticfiles/paragon/static/static/
+   - recurse: True


### PR DESCRIPTION
#### What's this PR do?
A few residential static assets are timing out when trying to load from cloudfront. It appears that the path being searched includes an additional `static` folder in the path. This hack just adds that subfolder on the instance and copy those static assets to it.