### PR TITLE
Restart salt-master serivce when low memory

### DIFF
--- a/pillar/beacons/low_memory.sls
+++ b/pillar/beacons/low_memory.sls
@@ -1,0 +1,3 @@
+beacons:
+  memusage:
+    - percent: 95%

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -142,6 +142,8 @@ salt_master:
       reactor:
         - salt/beacon/*/inotify/*:
             - salt://reactors/edx/inotify_mitx.sls
+        - salt/beacon/master/memusage/*:
+            - salt://reactors/apps/restart_salt_master_service_low_memory.sls
         - salt/beacon/reddit-*/memusage/*:
             - salt://reactors/reddit/restart_reddit_service_low_memory.sls
             - salt://reactors/opsgenie/post_notification.sls

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -27,6 +27,7 @@ base:
     - match: grain
     - salt_master
     - micromasters
+    - beacons.low_memory
   'roles:fluentd':
     - match: grain
     - fluentd

--- a/salt/reactors/apps/restart_salt_master_service_low_memory.sls
+++ b/salt/reactors/apps/restart_salt_master_service_low_memory.sls
@@ -1,0 +1,5 @@
+restart_salt_master_service_low_memory:
+  local.cmd.run:
+    - tgt: {{ data['id'] }}
+    - arg:
+        - systemctl restart salt-master


### PR DESCRIPTION
#### What's this PR do?
Restart `salt-master` service when low memory alert is triggered by adding a beacon to the master. Currently an alert is triggered through Datadog, however we should disable that once this is deployed/