### PR TITLE
Fixes for xpro

### DIFF
--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -115,7 +115,7 @@ edx:
     ################################################################################
     #################### Forum Settings ############################################
     ################################################################################
-    FORUM_API_KEY: __vault__:gen_if_missing:secret-residential/global/forum-api-key>data>value
+    FORUM_API_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/global/forum-api-key>data>value
     FORUM_ELASTICSEARCH_HOST: "nearest-elasticsearch.query.consul"
     FORUM_MONGO_USER: __vault__:cache:mongodb-{{ environment }}/creds/forum-{{ purpose }}>data>username
     FORUM_MONGO_PASSWORD: __vault__:cache:mongodb-{{ environment }}/creds/forum-{{ purpose }}>data>password

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -32,6 +32,7 @@ edx:
         ENABLE_OAUTH2_PROVIDER: True
         ENABLE_THIRD_PARTY_AUTH: True
         ALLOW_PUBLIC_ACCOUNT_CREATION: True
+        SKIP_EMAIL_VALIDATION: True
     EDXAPP_LMS_AUTH_EXTRA:
       SOCIAL_AUTH_OAUTH_SECRETS:
         mitxpro-oauth2: __vault__::secret-{{ business_unit }}/{{ environment }}/xpro-app-oauth2-client-secret>data>value


### PR DESCRIPTION

#### What's this PR do?
- Adds the `SKIP_EMAIL_VALIDATION` feature given that enabling that on the oauth provider level didn't provide the expected result
- Used the `business_unit` value to replace the hard-coded residential value since those pillar values are applied to xpro as well