### PR TITLE
Add stacktrace format for OCW fluentd

### DIFF
--- a/pillar/fluentd/ocw_cms.sls
+++ b/pillar/fluentd/ocw_cms.sls
@@ -47,6 +47,19 @@ fluentd:
                   - format1: '/------\n/'
                   - format2: '/(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}) /'
                   - format3: '/(?<level_name>[A-Z]+) (?<message>.*)/'
+              # Zope stacktrace format. This regex allows the message to be
+              # picked up by fluentd if it is the last message in the logfile,
+              # because otherwise looking for '------' as the beginning of the
+              # next message will fail.
+              - directive: parse
+                attrs:
+                  - '@type': multiline
+                  - format_firstline: '/\A------'
+                  - format1: '/\A------\n/'
+                  - format2: '/(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}) /'
+                  - format3: '/(?<level_name>[A-Z]+) /'
+                  - format4: '/(?<message>.*?\nTraceback \(innermost last\):'
+                  - format5: '/(?:\n^\s+.*?$)+\n\S.*)\Z/'
         - directive: source
           attrs:
             - '@id': ocwcms_zope_access_log


### PR DESCRIPTION
Add a `parse` clause for the `ocw_cms` fluentd configuration that allows a stacktrace message to be shipped if it is the last message in the logfile.

I've tested the regex with https://rubular.com/

Example log:
```
------
2019-04-17T13:47:04 INFO getNewTags:ERROR 0.111x
------
2019-04-17T13:47:04 INFO getNewTags:ERROR global name 'any' is not defined
------
2019-04-17T13:47:04 ERROR Zope.SiteErrorLog 1555508824.720.576809600157 https://ocw-qa.odl.mit.edu/view_new_mitx_tags
Traceback (innermost last):
  Module ZPublisher.Publish, line 119, in publish
  Module ZPublisher.mapply, line 88, in mapply
  Module ZPublisher.Publish, line 42, in call_object
  Module Shared.DC.Scripts.Bindings, line 313, in __call__
  Module Shared.DC.Scripts.Bindings, line 350, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 129, in _exec
  Module Products.PageTemplates.PageTemplate, line 98, in pt_render
  Module zope.pagetemplate.pagetemplate, line 117, in pt_render
  Module zope.tal.talinterpreter, line 271, in __call__
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 891, in do_useMacro
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 536, in do_optTag_tal
  Module zope.tal.talinterpreter, line 521, in do_optTag
  Module zope.tal.talinterpreter, line 516, in no_tag
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 949, in do_defineSlot
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 536, in do_optTag_tal
  Module zope.tal.talinterpreter, line 521, in do_optTag
  Module zope.tal.talinterpreter, line 516, in no_tag
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 861, in do_defineMacro
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 536, in do_optTag_tal
  Module zope.tal.talinterpreter, line 521, in do_optTag
  Module zope.tal.talinterpreter, line 516, in no_tag
  Module zope.tal.talinterpreter, line 346, in interpret
  Module zope.tal.talinterpreter, line 822, in do_loop_tal
  Module zope.tales.tales, line 682, in setRepeat
  Module zope.tales.tales, line 696, in evaluate
   - URL: view_new_mitx_tags
   - Line 30, Column 10
   - Expression: <PathExpr standard:'view/getNewTags'>
   - Names:
      {'container': <PloneSite at /Plone>,
       'context': <PloneSite at /Plone>,
       'default': <object object at 0x7f36ed19f200>,
       'here': <PloneSite at /Plone>,
       'loop': {},
       'nothing': None,
       'options': {'args': ()},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0xa5b0cf8>,
       'request': <HTTPRequest, URL=https://ocw-qa.odl.mit.edu/view_new_mitx_tags>,
       'root': <Application at >,
       'template': <ImplicitAcquirerWrapper object at 0xa3e4450>,
       'traverse_subpath': [],
       'user': <PloneUser 'mbrdlove'>,
       'view': <Products.Five.metaclass.ViewNewMITxTags object at 0xa3e0d10>,
       'views': <zope.app.pagetemplate.viewpagetemplatefile.ViewMapper object at 0xa3e4350>}
  Module zope.tales.expressions, line 217, in __call__
  Module Products.PageTemplates.Expressions, line 163, in _eval
  Module Products.PageTemplates.Expressions, line 125, in render
  Module ocw.publishing.browser.viewnewmitxtags, line 24, in getNewTags
NameError: global name 'any' is not defined
```