### PR TITLE
Make OCW origin webserver show 404 error page

### DIFF
--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -66,3 +66,6 @@ nginx:
                         - index.htm
                         - index.html
                         - =404
+                    - error_page:
+                        - '404'
+                        - jsp/error.html


### PR DESCRIPTION

#### What are the relevant tickets?
Fixes https://github.com/mitocw/ocwcms/issues/61

#### What's this PR do?

Make the OCW origin server show the custom 404 error page that exists in
/var/www/ocw/jsp/error.html. This is the HTML that's currently being
delivered for https://ocw.mit.edu/mbtest/not_found on the current
production site.

#### How should this be manually tested?

Has to be tested after deployment. See https://github.com/mitocw/ocwcms/issues/61
