### PR TITLE
Add scheduled state to pull edX courses JSON for OCW

### DIFF
--- a/pillar/apps/ocw.sls
+++ b/pillar/apps/ocw.sls
@@ -1,4 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
+{% set ROLES = salt.grains.get('roles') %}
 
 ocw:
   db_username: __vault__::secret-ocw/{{ ENVIRONMENT }}/db>data>username
@@ -8,3 +9,12 @@ ocw:
   dspace_connection_user: __vault__::secret-ocw/{{ ENVIRONMENT }}/dspace/test>data>username
   dspace_connection_password: __vault__::secret-ocw/{{ ENVIRONMENT }}/dspace/test>data>password
   github_ssh_key: __vault__::secret-ocw/global/github/ssh-deploy-key>data>value
+
+{% if 'ocw-origin' in ROLES %}
+schedule:
+  pull_edx_courses_json:
+    days: 1
+    function: state.sls
+    args:
+      - apps.ocw.pull_edx_courses_json
+{% endif %}

--- a/salt/apps/ocw/pull_edx_courses_json.sls
+++ b/salt/apps/ocw/pull_edx_courses_json.sls
@@ -1,0 +1,14 @@
+
+pull_edx_courses_json:
+  module.run:
+    - name: s3.get
+    - bucket: open-learning-course-data
+    - path: edx_courses.json
+    - local_file: /var/www/ocw/courses/edx_courses.json
+
+ensure_ownership_and_perms_of_edx_courses_json:
+  file.managed:
+    - name: /var/www/ocw/courses/edx_courses.json
+    - user: fsuser
+    - group: fsuser
+    - mode: 0644


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitocw/ocwcms/issues/34

See also https://github.com/mitocw/ocwcms/pull/35

#### What's this PR do?

Automates the download of `edx_courses.json` to the origin server

#### How should this be manually tested?

We'll need to deploy it and see how it goes.

