### PR TITLE
Modify environment_settings.yml, correct OCW environments

### DIFF
--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -1,8 +1,21 @@
+# Example Grains:
+#   environment: ocw
+#   roles: ocw-origin
+#   ocw-environment: production
+#   ocw-deployment: staging
+#
+
 {% set app_name = 'ocw-origin' %}
 {% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'ocw') %}
+#
+# FIXME: The ocw-environment and ocw-deployment grains are not created by Salt
+# Cloud configuration. They have to be added after instances are created.
+{% set OCW_ENVIRONMENT = salt.grains.get('ocw-environment') %}
+{% set OCW_DEPLOYMENT = salt.grains.get('ocw-deployment') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
-{% set server_domain_names = env_data.purposes[app_name].domains %}
+{% set server_domain_names = env_data.purposes[app_name].domains[OCW_ENVIRONMENT][OCW_DEPLOYMENT] %}
+
 
 nginx:
   ng:

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -253,10 +253,10 @@ base:
     - logrotate.ocw_cms
     - fluentd.ocw_cms
     - apps.ocw
-  'G@roles:ocw-cms and G@environment:ocw-production':
+  'G@roles:ocw-cms and G@ocw-environment:production':
     - match: compound
     - apps.ocw-production
-  'G@roles:ocw-cms and G@environment:ocw-qa':
+  'G@roles:ocw-cms and G@ocw-environment:qa':
     - match: compound
     - apps.ocw-qa
   'roles:ocw-db':

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -879,8 +879,17 @@ environments:
         app: nginx
         business_unit: open-courseware
         domains:
-          - ocw-origin.odl.mit.edu
-        num_instances: 1
+          production:
+            production:
+              - ocw-origin.odl.mit.edu
+            staging:
+              - ocw-production-ocw2.odl.mit.edu
+          qa:
+            production:
+              - ocw-qa-origin.odl.mit.edu
+            staging:
+              - ocw-qa-ocw2.odl.mit.edu
+        num_instances: 4
         security_groups:
           - webapp
           - ssh


### PR DESCRIPTION
Modify environment_settings.yml to have the correct environment names for OCW. They are currently "ocw-production" and "ocw-qa".

This fits the convention in place already for mitxpro and mitx.

We've discussed possibly having QA and Production share the same environment but having some other grain that distinguishes the two, but haven't done that yet.

#### What are the relevant tickets?

I ran into an error from Salt master when trying to run the `nginx.ng` state, per https://github.com/mitocw/ocwcms/issues/61#issuecomment-484937988

`SaltRenderError: Jinja variable 'dict object' has no attribute 'ocw-qa'`

#### What's this PR do?

Fixes the Salt render error by having the environments in `environment_settings.yml` that match the OCW origin servers' `environment` grains.
