### PR TITLE
Removed opts arg

### DIFF
--- a/salt/backups/mount_drive.sls
+++ b/salt/backups/mount_drive.sls
@@ -9,7 +9,6 @@ mount_backup_drive:
     - device: /dev/xvdb
     - fstype: ext4
     - mkmnt: True
-    - opts: 'relatime,user'
 
 create_backup_directory:
   file.directory:

--- a/salt/orchestrate/services/cassandra.sls
+++ b/salt/orchestrate/services/cassandra.sls
@@ -82,7 +82,6 @@ mount_data_drive:
         device: /dev/xvdb
         fstype: ext4
         mkmnt: True
-        opts: 'relatime,user'
     - require:
         - salt: format_data_drive
 

--- a/salt/orchestrate/services/mongodb.sls
+++ b/salt/orchestrate/services/mongodb.sls
@@ -111,7 +111,6 @@ mount_data_drive:
         device: /dev/nvme1n1
         fstype: ext4
         mkmnt: True
-        opts: 'relatime,user'
     - require:
         - salt: format_data_drive
 

--- a/salt/orchestrate/services/scylladb.sls
+++ b/salt/orchestrate/services/scylladb.sls
@@ -104,7 +104,6 @@ mount_data_drive:
         device: /dev/md0
         fstype: xfs
         mkmnt: True
-        opts: 'relatime,user'
     - require:
         - salt: format_data_drive
 


### PR DESCRIPTION
#### What's this PR do?
`opts` in mount.mounted throws the following error:
```
Passed invalid arguments to state.single: get_sls_opts() got multiple values for 
keyword argument 'opts'
```
Checking slack, I was told that this is a bug caused by a conflict with the opts keyword that is used with `state.single`. Additionally, [since linux kernel 26.30 the kernel defaults to the `relatime` option behavior](http://man7.org/linux/man-pages/man8/mount.8.html).