### PR TITLE
Added mitx to use old elasticsearch formula

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -133,7 +133,7 @@ base:
     - match: grain
     - datadog
     - datadog.plugins
-  'G@roles:elasticsearch and P@environment:(micromasters|rc-apps|production-apps)':
+  'G@roles:elasticsearch and P@environment:(micromasters|rc-apps|production-apps|mitx(pro)?-(qa|production))':
     - match: compound
     - elasticsearch
     - elasticsearch.plugins


### PR DESCRIPTION
#### What's this PR do?
MITx environments were configured to use the new elastic-stack formula which is geared towards >=5.x ES releases. However MITx, requires an older version which forces us to use the old elasticsearch-formula we have in place as opposed to the new elastic-stack one.