### PR TITLE
In Nginx OCW origin pillar, allow http download of edx_courses.json

### DIFF
--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -39,6 +39,9 @@ nginx:
                     - '[::]:80'
                 - location ~ /.well-known:
                     - allow: all
+                - location /courses/edx_courses.json:
+                    - root: /var/www/ocw
+                    - allow: all
                 - location /:
                     - return: 301 https://$host$request_uri
             - server:


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitocw/ocwcms/issues/34
https://github.com/mitocw/ocwcms/pull/35

#### What's this PR do?

This allows an account on our legacy "current production" origin server to pull this file on cron every day. It seems like the neatest way of doing it to work around being stuck with TLSv1 on the old server, and to avoid hassles with ssh.

#### How should this be manually tested?

It's been "manually staged" ... try running `curl -I http://ocw-origin.odl.mit.edu/courses/edx_courses.json`
