### PR TITLE
Added IDA_LOGOUT_URI_LIST to xpro ansible_vars

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -4,10 +4,10 @@
 {% set environment = salt.grains.get('environment', 'mitxpro-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
-{% set env_mapping_dict = {
-    'sandbox': 'ci',
-    'xpro-qa': 'rc',
-    'xpro-production': ''
+{% set heroku_xpro_env_logout_mapping = {
+    'sandbox': 'https://xpro-ci.odl.mit.edu/logout'
+    'xpro-qa': 'https://xpro-rc.odl.mit.edu/logout'
+    'xpro-production': 'https://xpro.odl.mit.edu/logout'
   } %}
 {% set heroku_env = env_mapping_dict[purpose] %}
 
@@ -23,11 +23,7 @@ edx:
     #   ROOT_PATH: 'ingest/'
     # EDXAPP_VIDEO_CDN_URLS:
     #   EXAMPLE_COUNTRY_CODE: "http://example.com/edx/video?s3_url="
-    {% if 'sandbox' or 'qa' in purpose %}
-    EDXAPP_IDA_LOGOUT_URI_LIST: ['https://xpro-{{ heroku_env }}.odl.mit.edu/logout']
-    {% elif 'production' in purpose %}
-    EDXAPP_IDA_LOGOUT_URI_LIST: ['https://xpro.odl.mit.edu/logout']
-    {% endif %}
+    EDXAPP_IDA_LOGOUT_URI_LIST: [{{ heroku_xpro_env_logout_mapping[purpose] }}]
     EDXAPP_PRIVATE_REQUIREMENTS:
       - name: mitxpro-openedx-extensions==0.1.0
       - name: social-auth-mitxpro==0.2

--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -8,7 +8,7 @@
       'ga_id': '',
       'release_branch': 'master',
       'log_level': 'DEBUG',
-      'logout_redirect_url': 'https://xpro-ci.odl.mit.edu',
+      'logout_redirect_url': 'https://xpro-qa-sandbox.mitx.mit.edu/logout',
       'OPENEDX_API_BASE_URL': 'https://xpro-qa-sandbox.mitx.mit.edu',
       'CYBERSOURCE_SECURE_ACCEPTANCE_URL': 'https://testsecureacceptance.cybersource.com/pay'
       },
@@ -17,7 +17,7 @@
       'ga_id': '',
       'release_branch': 'release-candidate',
       'log_level': 'INFO',
-      'logout_redirect_url': 'https://xpro-ci.odl.mit.edu',
+      'logout_redirect_url': 'https://xpro-qa.mitx.mit.edu/logout',
       'OPENEDX_API_BASE_URL': 'https://xpro-qa.mitx.mit.edu',
       'CYBERSOURCE_SECURE_ACCEPTANCE_URL': 'https://testsecureacceptance.cybersource.com/pay'
       },
@@ -26,7 +26,7 @@
       'ga_id': '',
       'release_branch': 'release',
       'log_level': 'WARN',
-      'logout_redirect_url': 'https://xpro.odl.mit.edu',
+      'logout_redirect_url': 'https://xpro.mitx.mit.edu/logout',
       'OPENEDX_API_BASE_URL': 'https://xpro.mitx.mit.edu',
       'CYBERSOURCE_SECURE_ACCEPTANCE_URL': 'https://secureacceptance.cybersource.com/pay'
       }


### PR DESCRIPTION
#### What's this PR do?
- This is a bit of an ugly hack but because of the naming discrepancy between our Heroku envs and AWS, I couldn't think of another way of dealing with it. This add the `IDA_LOGOUT_URI_LIST` value to xpro ansible_vars based on this [doc](https://github.com/mitodl/mitxpro/blob/master/docs/configure_open_edx.md).
- Updated `logout_redirect_url` based on above linked doc
- Renamed a few of the default values to reflect xpro.