### PR TITLE
Updated settings and hacks to resolve SAML login

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -9,3 +9,22 @@ edx:
     EDXAPP_SESSION_COOKIE_NAME: {{ environment }}-{{ purpose }}-session
     EDXAPP_CMS_AUTH_EXTRA:
       SECRET_KEY: __vault__:gen_if_missing:secret-residential/global/edxapp-lms-django-secret-key>data>value
+    EDXAPP_REGISTRATION_EXTRA_FIELDS:
+      confirm_email: "hidden"
+      level_of_education: "optional"
+      gender: "optional"
+      year_of_birth: "optional"
+      mailing_address: "hidden"
+      goals: "optional"
+      honor_code: "required"
+      terms_of_service: "hidden"
+      city: "hidden"
+      country: "hidden"
+    EDXAPP_LMS_ENV_EXTRA:
+      FEATURES:
+        AUTH_USE_CAS: false
+        ALLOW_PUBLIC_ACCOUNT_CREATION: True
+        SKIP_EMAIL_VALIDATION: True
+    EDXAPP_CMS_ENV_EXTRA:
+      FEATURES:
+        AUTH_USE_CAS: false

--- a/salt/edx/files/nginx_static_assets.j2
+++ b/salt/edx/files/nginx_static_assets.j2
@@ -25,10 +25,3 @@
         # Expire other static files immediately (there should be very few / none of these)
         expires epoch;
     }
-
-{% if salt.grains.get('business_unit') == 'residential' %}
-    # Redirect registration page to authentication page
-    location /register {
-        return 301 https://$host/login;
-    }
-{% endif %}


### PR DESCRIPTION
In order for us to be able to create new accounts for users using SAML they need to be able to self-register as part of the auth flow. This requires us to remove our forced redirect of the `/register` endpoint and set the feature flag to allow account creation. This will likely require further efforts to prevent creation of accounts by any means other than SAML.

#### What are the relevant tickets?
#610 

#### What's this PR do?
Fixes account creation for edX residential