### PR TITLE
Secure MITxPro /register with token

### DIFF
--- a/pillar/edx/mitxpro.sls
+++ b/pillar/edx/mitxpro.sls
@@ -1,0 +1,6 @@
+{% set business_unit = salt.grains.get('business_unit') %}
+{% set environment = salt.grains.get('environment') %}
+
+edx:
+  mitxpro:
+    registration_access_token: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/xpro-registration-access-token>data>value

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -167,6 +167,7 @@ base:
     - datadog.supervisord-integration
   'P@roles:(edx|edx-worker|sandbox) and P@environment:mitxpro.*':
     - match: compound
+    - edx.mitxpro
     - edx.ansible_vars.xpro
   'P@roles:(edx|edx-worker) and G@environment:mitx-qa':
     - match: compound

--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -32,6 +32,14 @@ replace_nginx_static_asset_template_fragment:
     - require:
         - git: clone_edx_configuration
 
+manage_extra_locations_lms_config:
+  file.managed:
+    - name: {{ repo_path }}/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/extra_locations_lms.j2
+    - template: jinja
+    - source: salt://edx/templates/extra_locations_lms.j2
+    - require:
+        - git: clone_edx_configuration
+
 add_mitx_devstack_playbook:
   file.managed:
     - name: {{ repo_path }}/playbooks/mitx_devstack.yml

--- a/salt/edx/templates/extra_locations_lms.j2
+++ b/salt/edx/templates/extra_locations_lms.j2
@@ -1,0 +1,24 @@
+{% raw %}
+{% if EDXAPP_SCORM_PKG_STORAGE_DIR %}
+    location ~ ^/{{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_SCORM_PKG_STORAGE_DIR }}/(?P<file>.*) {
+        add_header 'Access-Control-Allow-Origin' $cors_origin;
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+
+        root {{ edxapp_media_dir }}/{{ EDXAPP_SCORM_PKG_STORAGE_DIR }};
+        try_files /$file =404;
+        expires 604800s;
+    }
+{% endif %}
+{% endraw %}
+
+{% set environment = salt.grains.get('environment') %}
+{% if environment.startswith('mitxpro') %}
+	{% set token = salt.pillar.get('edx:mitxpro:registration_access_token') %}
+    location /register {
+        if ($http_x_access_token != "{{ token }}") {
+            return 403;
+        }
+        try_files @proxy_to_lms_app;
+    }
+{% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/mitxpro/issues/134

#### What's this PR do?

It adds an Nginx configuration for MITxPro to allow access to `/register` only if the value of the `X-Access-Token` HTTP header is correct.

`extra_locations_lms.j2` is defined in https://github.com/mitodl/configuration/blob/master/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/extra_locations_lms.j2

The Vault value for the access token is referenced in one other place: https://github.com/mitodl/salt-ops/blob/3e63b383f1ffa7b3f26e90b94c02bca807cdf353/pillar/heroku/xpro.sls#L75
