### PR TITLE
Change redirect for xpro /register

### DIFF
--- a/salt/edx/templates/extra_locations_lms.j2
+++ b/salt/edx/templates/extra_locations_lms.j2
@@ -14,8 +14,11 @@
 
 {% set environment = salt.grains.get('environment') %}
 {% if environment.startswith('mitxpro') %}
-	{% set token = salt.pillar.get('edx:mitxpro:registration_access_token') %}
+    {% set token = salt.pillar.get('edx:mitxpro:registration_access_token') %}
     location /register {
+        return 301 /login;
+    }
+    location /user_api/v1/account/registration {
         if ($http_x_access_token != "{{ token }}") {
             return 403;
         }


### PR DESCRIPTION
Following up on `https://github.com/mitodl/salt-ops/pull/843`, where /register was checked for the `X-Access-Token` header before allowing access, make `/register` redirect to `/login` and apply the access token authentication to the API endpoint, `/user_api/v1/account/registration`.
