### PR TITLE
Add "JSON for mobile" and Zope restart cron jobs

### DIFF
--- a/salt/apps/ocw/cms_plone.sls
+++ b/salt/apps/ocw/cms_plone.sls
@@ -7,3 +7,14 @@ manage_plone_env_vars:
     - user: root
     - group: root
     - mode: '0644'
+
+# Restart Plone nightly in order to avoid out-of-memory issues. This should
+# be done after normal working hours and sufficiently ahead of any cron jobs,
+# such as those defined in engines.sls.
+restart_cms_cronjob:
+  cron.present:
+    - identifier: restart_cms
+    - name: /usr/local/Plone/zeocluster/bin/client1 restart > /var/log/restart_cms.log 2>&1
+    - user: root
+    - minute: 30
+    - hour: 3

--- a/salt/apps/ocw/engines.sls
+++ b/salt/apps/ocw/engines.sls
@@ -44,6 +44,14 @@ generate_ocw_news_feeds_cronjob:
     - user: ocwuser
     - minute: 0
 
+generate_json_for_mobile_cronjob:
+  cron.present:
+    - identifier: generate_json_for_mobile
+    - name: {{ engines_basedir }}/generate_json_for_mobile.sh > {{ cron_log_dir }}/generate_json_for_mobile.log 2>&1
+    - user: ocwuser
+    - minute: 1
+    - hour: 5
+
 youtube_csv_file_cronjob:
   cron.present:
     - identifier: generate_youtube_videos_csv


### PR DESCRIPTION
See https://github.com/mitocw/ocwcms/pull/81

A new cron job has been added. We've decided in Slack that we will try restarting the CMS on cron before it runs to avoid issues with its known high memory usage. This will restart both CMS 1 and 2. It might be nice to have that done, anyway, cron job or not.
