### PR TITLE
xPro salt reactor autoscaling

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -164,6 +164,8 @@ salt_master:
             - salt://reactors/opsgenie/post_notification.sls
         - backup/*/*/completed:
             - salt://reactors/slack/post_event.sls
+         - salt/engine/sqs/autoscaling:
+            - salt://reactors/mitxpro/edxapp_ec2_autoscale.sls
     misc:
       worker_threads: 25
       {# this is to avoid timeouts waiting for edx asset compilation during AMI build (TMM 2019-04-01) #}

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -164,7 +164,7 @@ salt_master:
             - salt://reactors/opsgenie/post_notification.sls
         - backup/*/*/completed:
             - salt://reactors/slack/post_event.sls
-         - salt/engine/sqs/autoscaling:
+        - salt/engine/sqs/mitxpro-production-autoscaling:
             - salt://reactors/mitxpro/edxapp_ec2_autoscale.sls
     misc:
       worker_threads: 25

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -247,6 +247,11 @@ environments:
     business_unit: mitxpro
     network_prefix: '10.8'
     vpc_name: MITxPro Production
+    provider_services:
+      sns:
+        topic: edxapp-xpro-production-autoscaling
+      sqs:
+        queue: edxapp-xpro-production-autoscaling
     secret_backends:
       mysql:
         role_prefixes:
@@ -306,7 +311,8 @@ environments:
           <<: *xpro_production_versions
         instances:
           edx:
-            number: 6
+            min_number: 6
+            max_number: 10
             type: r5.large
           edx-worker:
             number: 3

--- a/salt/orchestrate/aws/mitxpro_autoscaling.sls
+++ b/salt/orchestrate/aws/mitxpro_autoscaling.sls
@@ -1,0 +1,85 @@
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitxpro-production') %}
+{% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_data.business_unit) %}
+{% set purpose = salt.grains.get('purpose', 'xpro-production') %}
+{% set env_data = env_settings.environments[ENVIRONMENT] %}
+{% set purpose_data = env_data.purposes[purpose] %}
+{% set sqs_queue = ENVIRONMENT ~ env_data.provider_services.sqs.queue %}
+{% set sns_topic = ENVIRONMENT ~ env_data.provider_services.sns.topic %}
+{% set edx_codename = purposes[PURPOSE].versions.codename %}
+
+{% set region = 'us-east-1' %}
+{% set AWS_ACCOUNT_ID = salt.vault.read('secret-operations/global/aws-account-id') %}
+{% set ami_id = salt.sdb.get('sdb://consul/edx_{}_{}_ami_id'.format(ENVIRONMENT, edx_codename)) %}
+
+create_{{ sqs_queue }}-sqs-queue:
+  boto_sqs.present:
+    - name: {{ sqs_queue }}
+    - region: {{ region }}
+    - attributes:
+        Policy: {"Version":"2012-10-17","Id":"arn:aws:sqs:{{ region }}:{{ AWS_ACCOUNT_ID }}:{{ sqs_queue }}/SQSDefaultPolicy","Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:aws:iam::{{ AWS_ACCOUNT_ID }}:role/mitx-salt-master-role"]},"Action":"SQS:*","Resource":"arn:aws:sqs:{{ region }}:{{ AWS_ACCOUNT_ID }}:{{ sqs_queue }}}]}
+
+create_{{ sns_topic }}-sns-topic:
+  boto_sns.present:
+    - name: {{ sns_topic }}
+    - region: {{ region }}
+    - subscriptions:
+        - protocol: sqs
+        - endpoint: 'arn:aws:sqs:{{ region }}:{{ AWS_ACCOUNT_ID }}:{{ sqs_queue }}'
+
+create_autoscaling_group:
+  boto_asg.present:
+    - name: edx-{{ ENVIRONMENT }}-autoscaling-group
+    - launch_config:
+      - ebs_optimized: false
+      - instance_profile_name: edx-instance-role
+      - image_name: {{ ami_id }}
+      - key_name: salt-master-prod
+      - instance_type: {{ purpose_data.instances.edx.type }}
+      - security_groups:
+        - salt_master
+        - consul-agent
+        - edx
+    - min_size: {{ purpose_data.instances.edx.min_number }}
+    - max_size: {{ purpose_data.instances.edx.max_number }}
+    - desired_capacity: {{ purpose_data.instances.edx.min_number }}
+    - region: {{ region }}
+    - availability_zones:
+      - us-east-1b
+      - us-east-1c
+      - us-east-1d
+    - load_balancers:
+      - edx-{{ purpose }}-{{ ENVIRONMENT }}
+    - suspended_processes:
+        - AddToLoadBalancer
+        - AlarmNotification
+    - scaling_policies:
+        - name: ScaleUp
+          adjustment_type: ChangeInCapacity
+          as_name: edx-{{ ENVIRONMENT }}-autoscaling-group
+          cooldown: 1800
+          scaling_adjustment: 1
+        - name: ScaleDown
+          adjustment_type: ChangeInCapacity
+          as_name: edx-{{ ENVIRONMENT }}-autoscaling-group
+          cooldown: 1800
+          scaling_adjustment: -1
+    - alarms:
+        CPU:
+          name: edx-{{ ENVIRONMENT }}-autoscaling-group-alarm
+          attributes:
+            metric: CPUUtilization
+            namespace: AWS/EC2
+            statistic: Average
+            comparison: '>='
+            threshold: 70.0
+            period: 60
+            evaluation_periods: 3
+            unit: null
+            description: 'edx-{{ ENVIRONMENT }}-autoscaling-groups-alarm'
+            alarm_actions: [ 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:launch' ]
+            ok_actions: [ 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:ok' ]
+    - notfication_arn: 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:{{ sns_topic }}'
+    - notification_types:
+        - autoscaling:EC2_INSTANCE_LAUNCH
+        - autoscaling:EC2_INSTANCE_TERMINATE

--- a/salt/orchestrate/aws/mitxpro_autoscaling.sls
+++ b/salt/orchestrate/aws/mitxpro_autoscaling.sls
@@ -37,7 +37,7 @@ create_{{ sns_topic }}-sns-topic:
 
 create_autoscaling_group:
   boto_asg.present:
-    - name: edx-{{ ENVIRONMENT }}-autoscaling-group
+    - name: edx-{{ purpose }}-{{ ENVIRONMENT }}-autoscaling-group
     - launch_config:
       - instance_profile_name: edx-instance-role
       - image_name: {{ ami_id }}
@@ -63,17 +63,17 @@ create_autoscaling_group:
     - scaling_policies:
         - name: ScaleUp
           adjustment_type: ChangeInCapacity
-          as_name: edx-{{ ENVIRONMENT }}-autoscaling-group
+          as_name: edx-{{ purpose }}-{{ ENVIRONMENT }}-autoscaling-group
           cooldown: 1800
           scaling_adjustment: 2
         - name: ScaleDown
           adjustment_type: ChangeInCapacity
-          as_name: edx-{{ ENVIRONMENT }}-autoscaling-group
+          as_name: edx-{{ purpose }}-{{ ENVIRONMENT }}-autoscaling-group
           cooldown: 1800
           scaling_adjustment: -1
     - alarms:
         CPU:
-          name: edx-{{ ENVIRONMENT }}-autoscaling-group-alarm
+          name: edx-{{ purpose }}-{{ ENVIRONMENT }}-autoscaling-group-alarm
           attributes:
             metric: CPUUtilization
             namespace: AWS/EC2
@@ -83,7 +83,7 @@ create_autoscaling_group:
             period: 60
             evaluation_periods: 3
             unit: null
-            description: 'edx-{{ ENVIRONMENT }}-autoscaling-groups-alarm'
+            description: 'edx-{{ purpose }}-{{ ENVIRONMENT }}-autoscaling-groups-alarm'
             alarm_actions: [ 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:launch' ]
             ok_actions: [ 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:ok' ]
     - notfication_arn: 'arn:aws:sns:{{ region }}:{{ AWS_ACCOUNT_ID }}:{{ sns_topic }}'

--- a/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
+++ b/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
@@ -1,0 +1,23 @@
+{% set payload = data['message']|load_json %}
+{% set ENVIRONMENT = 'mitxpro-production' %}
+{% set PURPOSE = 'xpro-production' %}
+{% set env_dict = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = env_dict.environments[ENVIRONMENT] %}
+{% set purposes = env_settings.purposes %}
+{% set edx_codename = purposes[PURPOSE].versions.codename %}
+{% set ami_id = salt.sdb.get('sdb://consul/edx_{}_{}_ami_id'.format(ENVIRONMENT, edx_codename)) %}
+
+{% if 'Event' in payload %}
+{% if 'LAUNCH' in payload['Event'] %}
+ec2_autoscale_launch:
+  runner.cloud.create:
+    - provider: mitx
+    - instances: edx-{{ ENVIRONMENT }}-xpro-production-{{ payload['EC2InstanceId'].strip('i-') }}
+    - instance_id: {{ payload['EC2InstanceId'] }}
+    - image: {{ ami_id }}
+{% elif 'TERMINATE' in payload['Event'] %}
+remove_key:
+  wheel.key.delete:
+    - match: edx-{{ ENVIRONMENT }}-xpro-production-{{ payload['EC2InstanceId'].strip('i-') }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#854](https://github.com/mitodl/salt-ops/issues/854)

#### What's this PR do?
Based on CPU load of xPro edxapp instances in the auto scaling group, an event is triggered which uses AWS SNS to post something to SQS that the salt-master is configured to check. That event (instance creation and termination) triggers either a build of the edxapp based on a AMI snapshot in the case of an instance creation, or the salt-key removal in case of an instance termination when the load is reduced.

This PR should include all the needed configs to get all the pieces in place for a fully functional deployment of xPro production.
