### PR TITLE
Remove hubble-salt as it's been depractaed

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -117,7 +117,6 @@ salt_master:
         - https://github.com/mitodl/rabbitmq-formula
         - https://github.com/mitodl/nginx-formula
         - https://github.com/mitodl/letsencrypt-formula
-        - https://github.com/hubblestack/hubble-salt
         - https://github.com/mitodl/reddit-formula
         - https://github.com/mitodl/nginx-shibboleth-formula
         - https://github.com/mitodl/uwsgi-formula


### PR DESCRIPTION
#### What's this PR do?
Removed hubble-salt from salt-master config as we don't use it and it's [no longer maintained](https://github.com/hubblestack/hubble-salt)