### PR TITLE
Added alert when account provisioning fails

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -298,3 +298,27 @@ elastic_stack:
                       fluentd_tag: '*.nginx.*'
                   - term:
                       status: 502
+      - name: mitxpro_openedx_oauth2error
+        settings:
+          name: MIT xPRO openedx account provisioning failed
+          description: >-
+            MIT xPRO openedx account provisioning failed.
+            Might need to check configs and verify that
+            there no mismatches
+          opsgenie_key: {{ opsgenie_key }}
+          opsgenie_priority: P3
+          type: frequency
+          index: logstash-*
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - opsgenie
+          alert_text: "MIT xPRO openedx account provisioning failed"
+          filter:
+            - bool:
+                must:
+                  - match:
+                      message: courseware.exceptions.OpenEdXOAuth2Error
+                  - term:
+                      fluentd_tag.raw: heroku.xpro


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#877](https://github.com/mitodl/salt-ops/issues/877)

#### What's this PR do?
Sends a `P3` OpsGenie alert when something is abnormal with account provisioning on the openedx instances for MIT xPRO