### PR TITLE
Changes security groups to use id instead of name

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -317,6 +317,8 @@ environments:
           edx-worker:
             number: 3
             type: t3.large
+        security_groups:
+          - edx
   mitx-qa:
     business_unit: residential
     network_prefix: '10.5'


### PR DESCRIPTION
#### What's this PR do?
Changed security_group to use id instead of name as it was throwing the following error when running this state:
```
[ERROR   ] BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>Invalid value 'consul-agent-mitxpro-production' for groupName. You may not reference Amazon VPC security groups by name. Please use the corresponding id for this operation.</Message>
  </Error>
  <RequestId>f8673ece-8e04-11e9-9848-c7d8dc85a881</RequestId>
</ErrorResponse>
```