### PR TITLE
Fix ownerships of OCW course dirs on origin server

### DIFF
--- a/salt/apps/ocw/sync_repo.sls
+++ b/salt/apps/ocw/sync_repo.sls
@@ -65,11 +65,24 @@ ensure_that_webroot_is_writable_by_fsuser:
     - user: fsuser
     - group: www-data
 
-ensure_that_courses_dir_is_writable_by_fsuser:
+# Ensure that the following course-related directories are owned by fsuser.
+# These have static files that are maintained in the `ocwcms' Git repository,
+# in addition to files that are copied over by the publishing process.
+# Other directories in `courses' should be safe because they don't have
+# files managed in Git, and aren't rsynced over from the working copy in
+# `/var/lib/ocwcms'.
+{% set course_dirs = [
+     'courses', 'courses/find-by-department', 'courses/find-by-educator-tags',
+     'courses/find-by-number', 'courses/find-by-topic'
+   ]
+%}
+{% for dir in course_dirs %}
+ensure_that_{{ dir }}_is_writable_by_fsuser:
   file.directory:
-    - name: /var/www/ocw/courses
+    - name: /var/www/ocw/{{ dir }}
     - user: fsuser
     - group: www-data
+{% endfor %}
 
 ensure_that_highschool_dir_is_writable_by_fsuser:
   file.directory:


### PR DESCRIPTION
After the rsync of files from the ocwcms working copy, make sure that various subdirectories of `/var/www/ocw/courses` are owned by `fsuser`, so that the publishing process (which copies files as `fsuser`) can copy files into these directories.

@blarghmatey Do you think this is an OK way to do this?