### PR TITLE
Update ocw mirror scripts

### DIFF
--- a/pillar/apps/ocw-production.sls
+++ b/pillar/apps/ocw-production.sls
@@ -58,3 +58,8 @@ ocw:
     base_site_url: https://ocw-origin.odl.mit.edu
     base_staging_site_url: https://ocw-production-ocw2.odl.mit.edu
     zodb_ipaddr: "{{ zodb_ipaddr }}"
+  mirror:
+    host_aliases:
+      - ['ocw.mit.edu', '10.100.0.9']
+      - ['ocwcms.mit.edu', '10.100.0.54']
+      - ['ocwpcms2.mit.edu', '10.100.0.24']

--- a/pillar/apps/ocw-qa.sls
+++ b/pillar/apps/ocw-qa.sls
@@ -58,3 +58,8 @@ ocw:
     base_site_url: https://ocw-qa-origin.odl.mit.edu
     base_staging_site_url: https://ocw-qa-ocw2.odl.mit.edu
     zodb_ipaddr: "{{ zodb_ipaddr }}"
+  mirror:
+    host_aliases:
+      - ['ocw.mit.edu': '10.100.0.29']
+      - ['ocwcms.mit.edu': '10.100.0.25']
+      - ['ocwpcms2.mit.edu': '10.100.0.22']

--- a/pillar/apps/ocw.sls
+++ b/pillar/apps/ocw.sls
@@ -20,29 +20,29 @@ ocw:
     # are put for being rsynced.
     rootdirectory: /data2/prod
     # data_dirs are directories that are hardcoded in
-    # https://github.com/mitocw/ocwcms/blob/25f31dd2a15b6b658b0fa59d0cd8ebb8ebe0f7c7/mirror/scripts/ocw6%20Mirror%20Scripts/create_new_snapshot.sh
+    # https://github.com/mitocw/ocwcms/blob/d98a4919813cd97103dce3ee1a7a41ae359eac15/mirror/scripts/create_new_snapshot.sh
     data_dirs:
       - /ans15436
-      - /data/InternetArchive
-      - /data/prod/about
-      - /data/prod/courses
-      - /data/prod/give
-      - /data/prod/educator
-      - /data/prod/faculty
-      - /data/prod/help
-      - /data/prod/high-school
-      - /data/prod/resources
-      - /data/prod/support
-      - /data/prod/terms
-      - /data/prod/images
-      - /data/prod/jsp
-      - /data/prod/jw-player-free
-      - /data/prod/mathjax
-      - /data/prod/OcWeb
-      - /data/prod/scripts
-      - /data/prod/styles
-      - /data/prod/webfonts
-      - /data/prod/subscribe
+      - /data2/InternetArchive
+      - /data2/prod/about
+      - /data2/prod/courses
+      - /data2/prod/give
+      - /data2/prod/educator
+      - /data2/prod/faculty
+      - /data2/prod/help
+      - /data2/prod/high-school
+      - /data2/prod/resources
+      - /data2/prod/support
+      - /data2/prod/terms
+      - /data2/prod/images
+      - /data2/prod/jsp
+      - /data2/prod/jw-player-free
+      - /data2/prod/mathjax
+      - /data2/prod/OcWeb
+      - /data2/prod/scripts
+      - /data2/prod/styles
+      - /data2/prod/webfonts
+      - /data2/prod/subscribe
 
 {% if 'ocw-origin' in ROLES %}
 schedule:

--- a/salt/apps/ocw/mirror.sls
+++ b/salt/apps/ocw/mirror.sls
@@ -2,6 +2,7 @@
 {% set data_dirs = salt.pillar.get('ocw:mirror:data_dirs') %}
 {% set fs_owner = salt.pillar.get('ocw:mirror:fs_owner') %}
 {% set fs_group = salt.pillar.get('ocw:mirror:fs_group') %}
+{% set host_aliases = salt.pillar.get('ocw:mirror:host_aliases') %}
 
 {% for dir in data_dirs %}
 ensure_state_of_mirror_{{ dir }}_directory:
@@ -20,3 +21,13 @@ ensure_state_of_mirror_rootdirectory:
     - group: {{ fs_group }}
     - dir_mode: '0755'
     - makedirs: True
+
+# We need these /etc/hosts aliases because there are hardcoded hostnames in the
+# shell scripts that run on the mirror server.
+{% for alias in host_aliases %}
+alias_{{ alias }}_for_mirror_script:
+  module.run:
+    - name: hosts.set_host
+    - alias: alias[0]
+    - ip: alias[1]
+{% endfor %}

--- a/salt/apps/ocw/sync_repo.sls
+++ b/salt/apps/ocw/sync_repo.sls
@@ -135,3 +135,13 @@ ensure_correct_ownership_of_json_for_mobile_working_dir:
     - group: plone
 
 {% endif %}
+
+
+{% if 'ocw-mirror' in roles %}
+ensure_state_of_scripts_symlink:
+  file.symlink:
+    - name: /data2/scripts
+    - target: /var/lib/ocwcms/mirror/scripts
+    - force: True
+    - backupname: scripts_old
+{% endif %}

--- a/salt/apps/ocw/templates/engines.conf.jinja
+++ b/salt/apps/ocw/templates/engines.conf.jinja
@@ -48,8 +48,8 @@ url: {{ engines_conf.mirror.url }}
 host: {{ engines_conf.mirror.host }}
 user: {{ mirror.fs_owner }}
 rootdirectory: {{ mirror.rootdirectory }}
-mirror_create_snapshot_script: "/var/lib/ocwcms/mirror/scripts/ocw6 Mirror Scripts/create_new_snapshot.sh"
-mirror_update_snapshot_script: "/var/lib/ocwcms/mirror/scripts/ocw6 Mirror Scripts/update_snapshot.sh"
+mirror_create_snapshot_script: "/var/lib/ocwcms/mirror/scripts/create_new_snapshot.sh"
+mirror_update_snapshot_script: "/var/lib/ocwcms/mirror/scripts/update_snapshot.sh"
 
 [NetStorage]
 host: {{ engines_conf.netstorage.host }}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -224,6 +224,7 @@ base:
   'roles:ocw-mirror':
     - match: grain
     - apps.ocw.mirror
+    - apps.ocw.sync_repo
   'roles:sandbox':
     - match: grain
     - edx.prod


### PR DESCRIPTION
Make adjustments to pillars and states to account for recent updates in the `ocwcms` repository to files that had been out-of-sync between the mirror server and repository.

Add some /etc/hosts entries for hardcoded hostnames in scripts that are supposed to run on the mirror server, where there is no engines.conf file to parameterize such strings.

Add syncing of the `ocwcms` repository to the mirror server in order to deploy the scripts that are supposed to run there.

See `ocwcms` commits:
https://github.com/mitocw/ocwcms/commit/435b26a4daffb87845a88cc687968b7298f874c0
https://github.com/mitocw/ocwcms/commit/d98a4919813cd97103dce3ee1a7a41ae359eac15

