### PR TITLE
Added config for blocking visibility of xpro course catalog

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -43,6 +43,8 @@ edx:
     EDXAPP_SUPPORT_SITE_LINK: 'https://xpro.zendesk.com/hc/en-us/requests/new'
     EDXAPP_LMS_ENV_EXTRA:
       BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ support_email }}
+      COURSE_ABOUT_VISIBILITY_PERMISSION: staff
+      COURSE_CATALOG_VISIBILITY_PERMISSION: staff
       COURSE_MODE_DEFAULTS:
         name: "Audit"
         slug: "audit"


### PR DESCRIPTION
In order to prevent anonymous users from viewing the course catalog on the edX deployment for xpro we are setting the visibility level to staff only.