### PR TITLE
Tweaks for asg to highstate new instances

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -166,6 +166,8 @@ salt_master:
             - salt://reactors/slack/post_event.sls
         - salt/engine/sqs/mitxpro-production-autoscaling:
             - salt://reactors/mitxpro/edxapp_ec2_autoscale.sls
+        - salt/cloud/edx-*mitxpro-production-xpro-production-*/created:
+            - salt://reactors/mitxpro/edxapp_highstate.sls
     engines:
       sqs:
         region: us-east-1

--- a/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
+++ b/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
@@ -7,6 +7,7 @@
 {% set purposes = env_settings.purposes %}
 {% set edx_codename = purposes[PURPOSE].versions.codename %}
 {% set ami_id = salt.sdb.get('sdb://consul/edx_{}_{}_ami_id'.format(ENVIRONMENT, edx_codename)) %}
+{% set business_unit = 'mitxpro' %}
 
 {% if 'Event' in payload['Message'] %}
 {% if 'LAUNCH' in payload['Message'] %}
@@ -19,7 +20,13 @@ ec2_autoscale_launch:
     - ssh_interface: private_ips
     - ssh_username: ubuntu
     - wait_for_ip_interval: 60
-    - wait_for_passwd_maxtries: 60 
+    - wait_for_passwd_maxtries: 60
+    - grains:
+        roles:
+          - edx
+        environemnt: {{ ENVIRONMENT }}
+        business_unit: {{ business_unit }}
+
 {% elif 'TERMINATE' in payload['Message'] %}
 remove_key:
   wheel.key.delete:

--- a/salt/reactors/mitxpro/edxapp_highstate.sls
+++ b/salt/reactors/mitxpro/edxapp_highstate.sls
@@ -1,0 +1,4 @@
+edxapp_highstate:
+  local.state.apply:
+    - tgt: 'edx-*mitxpro-production-xpro-production-*'
+    - queue: True

--- a/salt/reactors/mitxpro/edxapp_highstate.sls
+++ b/salt/reactors/mitxpro/edxapp_highstate.sls
@@ -2,3 +2,7 @@ edxapp_highstate:
   local.state.apply:
     - tgt: 'edx-*mitxpro-production-xpro-production-*'
     - queue: True
+    - kwargs:
+        pillar:
+          edx:
+            ansible_flags: '--tags install:configuration'


### PR DESCRIPTION
#### What's this PR do?
Added an additional reactor to highstate mitxpro instances once they've been created by the autoscaling group. Tried replacing `cloud.create` with the `cloud.profile` directive as it had an option to highstate the instance once the minion was installed, however it was creating two instances, one through salt, and one through auto-scaling, so had to stick with `cloud.create`.