### PR TITLE
Added reactor for pruning vault cache on instance termination

### DIFF
--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -169,6 +169,8 @@ salt_master:
             - salt://reactors/slack/post_event.sls
         - salt/cloud/edx-*mitxpro-production-xpro-production-*/created:
             - salt://reactors/mitxpro/edxapp_highstate.sls
+        - salt/cloud/*/destroying:
+            - salt://reactors/vault/cache_cleanup_on_terminate.sls
     engines:
       sqs:
         region: us-east-1

--- a/salt/reactors/vault/cache_cleanup_on_terminate.sls
+++ b/salt/reactors/vault/cache_cleanup_on_terminate.sls
@@ -1,0 +1,6 @@
+purge_vault_cache_for_terminated_instance:
+  local.vault.purge_cache_data:
+    - tgt: 'roles:master'
+    - tgt_type: grain
+    - kwarg:
+        prefix: {{ data['name'] }}


### PR DESCRIPTION
When deleting an instance we should purge the associated cache in Vault to keep it clean without manual intervention.