### PR TITLE
Daemonize salt-proxy

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -177,3 +177,10 @@ heroku:
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
     USE_X_FORWARDED_HOST: True
     USE_X_FORWARDED_PORT: True
+
+schedule:
+  refresh_{{ app_name }}_configs:
+    days: 5
+    function: state.sls
+    args:
+      - heroku.update_heroku_config

--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -140,3 +140,9 @@ heroku:
     VOUCHER_INTERNATIONAL_PROGRAM_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/voucher-international>data>program_key
     VOUCHER_INTERNATIONAL_SCHOOL_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/voucher-international>data>school_key
 
+schedule:
+  refresh_{{ app_name }}_configs:
+    days: 5
+    function: state.sls
+    args:
+      - heroku.update_heroku_config

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -233,3 +233,11 @@ salt_master:
           script_args: -U -P
           sync_after_install: all
           delete_ssh_keys: True
+  proxy_configs:
+    apps:
+      - xpro-ci
+      - xpro-rc
+      - xpro-production
+      - odl-open-discussions-ci
+      - odl-open-discussions-rc
+      - odl-open-discussions-production

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -61,6 +61,8 @@ base:
     - fluentd.odlvideo
   proxy-xpro-*:
     - heroku.xpro
+  proxy-discussions-*:
+    - heroku.discussions
   'roles:mitx-cas':
     - match: grain
     - apps.mitx_cas


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [Issue#857](https://github.com/mitodl/salt-ops/issues/857)

#### What's this PR do?
- Adds `heroku.update_heroku_config` scheduled state run for discussions and xpro proxy minions
- Defines salt-proxy names in salt_master so that it can be used for salt config (separate PR against the master-formula) to generate a systemd service for all the needed proxy minions
- Adds an entry in top pillar file for the new heroku discussions pillar.
