### PR TITLE
Fix OCW CMS Elastalert

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -331,6 +331,7 @@ elastic_stack:
             overconsumption -- memory or disk cache.
           opsgenie_key: {{ opsgenie_key }}
           opsgenie_priority: P3
+          opsgenie_alias: ocw_invalid_literal_for_int
           type: frequency
           index: logstash-ocw-*
           num_events: 1
@@ -342,7 +343,9 @@ elastic_stack:
           filter:
             - bool:
                 must:
-                  - match:
-                      message: invalid literal for int
-                  - term:
-                      fluentd_tag.raw: ocwcms.zope.event
+                  - query_string:
+                      default_field: message
+                      query: error AND invalid AND literal AND int
+                filter:
+                  term:
+                    fluentd_tag: ocwcms.zope.event


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/907

#### What's this PR do?

Fix OCW CMS Elastalert for OOM or cache exhaustion errors that manifest themselves as "invalid literal for int()" errors.

* Get rid of false positives by using a better query
* Get rid of redundant alerts by using the OpsGenie `alias` field.
