### PR TITLE
Added settings for controlling salt environments

### DIFF
--- a/pillar/common.sls
+++ b/pillar/common.sls
@@ -1,3 +1,5 @@
+{% set environment = salt.grains.get('environment') %}
+
 mine_functions:
   network.ip_addrs: [eth0]
   network.get_hostname: []
@@ -16,3 +18,12 @@ salt_minion:
       log_granular_levels:
         salt: warning
         salt.loader: warning
+    environment:
+      {% if 'production' in environment %}
+      saltenv: production
+      lock_saltenv: True
+      pillarenv: production
+      {% else %}
+      saltenv: rc
+      pillarenv_from_saltenv: True
+      {% endif %}

--- a/pillar/salt_master.sls
+++ b/pillar/salt_master.sls
@@ -103,6 +103,11 @@ salt_master:
       fileserver_backend:
         - git
         - roots
+      gitfs_saltenv:
+        - rc:
+            - ref: rc
+        - production:
+            - ref: master
       gitfs_remotes:
         - https://github.com/mitodl/salt-ops:
             - root: salt
@@ -134,6 +139,10 @@ salt_master:
         - git:
             - master https://github.com/mitodl/salt-ops:
                 - root: pillar
+                - env: production
+            - rc https://github.com/mitodl/salt-ops:
+                - root: pillar
+                - env: rc
         - vault: {}
     logging:
       log_granular_levels:

--- a/salt/orchestrate/aws/map_templates/analytics_edx.yml
+++ b/salt/orchestrate/aws/map_templates/analytics_edx.yml
@@ -27,3 +27,12 @@ edx:
           - edx
           - edx-draft
           - edx-residential-analytics
+      minion:
+        {% if 'production' in environment_name %}
+        saltenv: production
+        lock_saltenv: True
+        pillarenv: production
+        {% else %}
+        saltenv: rc
+        pillarenv_from_saltenv: True
+        {% endif %}

--- a/salt/orchestrate/aws/map_templates/edx.yml
+++ b/salt/orchestrate/aws/map_templates/edx.yml
@@ -44,6 +44,15 @@ edx:
       {% for profile_setting, profile_value in profile_overrides.items() %}
       {{ profile_setting }}: {{ profile_value }}
       {% endfor %}
+      minion:
+        {% if 'production' in environment_name %}
+        saltenv: production
+        lock_saltenv: True
+        pillarenv: production
+        {% else %}
+        saltenv: rc
+        pillarenv_from_saltenv: True
+        {% endif %}
 {% endfor %}
 {% endfor %}
 
@@ -87,5 +96,14 @@ edx-worker:
       {% for profile_setting, profile_value in profile_overrides.items() %}
       {{ profile_setting }}: {{ profile_value }}
       {% endfor %}
+      minion:
+        {% if 'production' in environment_name %}
+        saltenv: production
+        lock_saltenv: True
+        pillarenv: production
+        {% else %}
+        saltenv: rc
+        pillarenv_from_saltenv: True
+        {% endif %}
 {% endfor %}
 {% endfor %}

--- a/salt/orchestrate/aws/map_templates/instance_map.yml
+++ b/salt/orchestrate/aws/map_templates/instance_map.yml
@@ -32,4 +32,13 @@
       {% for profile_setting, profile_value in profile_overrides.items() %}
       {{ profile_setting }}: {{ profile_value|tojson }}
       {% endfor %}
+      minion:
+        {% if 'production' in environment_name %}
+        saltenv: production
+        lock_saltenv: True
+        pillarenv: production
+        {% else %}
+        saltenv: rc
+        pillarenv_from_saltenv: True
+        {% endif %}
   {% endfor %}


### PR DESCRIPTION
Added configurations for specifying salt envs based on git branches in order to avoid accidentally pushing changes to production before they are ready

#### What are the relevant tickets?
#862 #860 #861 

#### What's this PR do?
Specifies salt envs based on git branches and updates minion settings to specify their assigned envs

#### How should this be manually tested?
Merge, deploy configs to pre-production minions, make a minor change in master and verify that it isn't reflected

#### Any background context you want to provide?
Because of the fact that we have configuration updates that run automatically we run the risk of accidentally applying changes to production infrastructure before it has been fully vetted. This is designed to avoid that situation.