### PR TITLE
Fix evaluation of role, OCW logrotate pillar

### DIFF
--- a/pillar/logrotate/ocw_cms.sls
+++ b/pillar/logrotate/ocw_cms.sls
@@ -21,7 +21,7 @@ logrotate:
       - notifempty
       - compress
       - delaycompress
-  {% if if 'engine' in ocw_cms_role %}
+  {% if 'engine' in ocw_cms_role %}
   ocw_publishing_logs:
     name: {{ engines_basedir }}/logs/*.log
     options:

--- a/pillar/logrotate/ocw_cms.sls
+++ b/pillar/logrotate/ocw_cms.sls
@@ -1,5 +1,6 @@
 {% set engines_basedir = salt.pillar.get('ocw:engines:basedir') %}
 {% set cron_log_dir = salt.pillar.get('ocw:engines:cron_log_dir') %}
+{% set ocw_cms_role = salt.grains.get('ocw-cms-role') %}
 
 logrotate:
   zeoclient_event:
@@ -20,7 +21,7 @@ logrotate:
       - notifempty
       - compress
       - delaycompress
-  {% if salt.grains.get('ocw-cms-role') == 'engine' %}
+  {% if if 'engine' in ocw_cms_role %}
   ocw_publishing_logs:
     name: {{ engines_basedir }}/logs/*.log
     options:


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/772

#### What's this PR do?

Fixes how it's determined that logrotate configuration files need to be written for logs that are only found on the "engine" CMS server for OCW.

I'm making a variable assignment for `ocw_cms_role` for readability and to be more consistent with other `.sls` files, and I'm fixing the equality evaluation because `ocw_cms_role` is a list, not a string.
