### PR TITLE
Change OCW ocwcms deployed git ref configuration

### DIFF
--- a/pillar/apps/ocw-production.sls
+++ b/pillar/apps/ocw-production.sls
@@ -13,7 +13,7 @@ mine_functions:
   network.ip_addrs: [eth0]
 
 ocw:
-  ocwcms_branch: master
+  ocwcms_git_ref: master
   engines_conf:
     # database is the MySQL database, not Zope database.
     database:

--- a/pillar/apps/ocw-qa.sls
+++ b/pillar/apps/ocw-qa.sls
@@ -13,7 +13,7 @@ mine_functions:
   network.ip_addrs: [eth0]
 
 ocw:
-  ocwcms_branch: ag/fix_duplication
+  ocwcms_git_ref: qa
   engines_conf:
     # database is the MySQL database, not Zope database.
     database:

--- a/salt/apps/ocw/sync_repo.sls
+++ b/salt/apps/ocw/sync_repo.sls
@@ -8,7 +8,7 @@
 #     /mnt/ocwfileshare/OCWEngines.
 #
 
-{% set ocwcms_branch = salt.pillar.get('ocw:ocwcms_branch', 'master') %}
+{% set ocwcms_git_ref = salt.pillar.get('ocw:ocwcms_git_ref') %}
 {% set roles = salt.grains.get('roles') %}
 
 ensure_that_rsync_is_installed:
@@ -26,7 +26,7 @@ git_pull_ocwcms_working_copy:
   git.latest:
     - name: git@github.com:mitocw/ocwcms
     - target: /var/lib/ocwcms
-    - rev: {{ ocwcms_branch }}
+    - rev: {{ ocwcms_git_ref }}
     - force_checkout: True
     - force_clone: True
     - force_reset: True


### PR DESCRIPTION

#### What are the relevant tickets?

Partly inspired by https://github.com/mitodl/salt-ops/pull/917 (see "relevant tickets"), which is accompanied by the settings change in the `salt-ops` repo to remove the ability to push commits haphazardly to the `master` branch. :-)

#### What's this PR do?

* Change the name of the parameter for the deployed branch or tag, from  'ocwcms_branch' to 'ocwcms_git_ref' to be more clear about the fact that it can be any kind of git ref: e.g. branch, tag, or commit.
* Set the QA instance's git ref to 'qa'. This should stay this way (no more pushing commits to `master` all the time to change the branch that's deployed to QA). We will keep the name of the ref the same from here on out, probably maintaining it as a tag that points to whichever branch we want deployed on QA.
* In the variable assignment in sync_repo.sls, don't provide a default value, because we want to fail if it hasn't been defined explicitly.

