### PR TITLE
Resize reddit instance to t3.large

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/reddit.conf
+++ b/salt/orchestrate/aws/cloud_profiles/reddit.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 reddit:
   provider: mitx
-  size: t3.medium
+  size: t3.large
   image: ami-cee00cb4
   ssh_username: ubuntu
   ssh_interface: private_ips


### PR DESCRIPTION
#### What's this PR do?
I have already manually resized the `reddit-production` instances from `t2.medium` to `t3.large` and this is to keep things in line as far instance type.

#### Any background context you want to provide?
We have been continually getting notifications in the `devops-notfications` slack channel about restarting the reddit surface due to low memory on the reddit-production instances.