### PR TITLE
Change ocw-origin instance type in AWS cloud profile

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/ocw-origin.conf
+++ b/salt/orchestrate/aws/cloud_profiles/ocw-origin.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 ocw-origin:
   provider: mitx
-  size: t3.small
+  size: m4.large
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-03006931f694ea7eb') }}
   ssh_username: admin
   ssh_interface: private_ips


### PR DESCRIPTION
Change its instance type to m4.large. m5.large would have been ideal, but that type is not available in us-east-e.
