### PR TITLE
Fix OCW origin server's fluentD access log parsing

### DIFF
--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -17,13 +17,8 @@ fluentd:
             - nested_directives:
               - directive: parse
                 attrs:
-                  - '@type': ltsv
-                  - null_value_pattern: '-'
+                  - '@type': apache2
                   - keep_time_key: 'true'
-                  - label_delimiter: '='
-                  - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'
-                  - time_key: time
-                  - types: time:time
         - directive: source
           attrs:
             - '@id': ocworigin_nginx_error_log

--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -17,8 +17,13 @@ fluentd:
             - nested_directives:
               - directive: parse
                 attrs:
-                  - '@type': apache2
+                  - '@type': ltsv
+                  - null_value_pattern: '-'
                   - keep_time_key: 'true'
+                  - label_delimiter: '='
+                  - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'
+                  - time_key: time
+                  - types: time:time
         - directive: source
           attrs:
             - '@id': ocworigin_nginx_error_log

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -257,6 +257,7 @@ base:
     - match: grain
     - apps.ocw
     - letsencrypt.ocw_origin
+    - nginx
     - nginx.ocw_origin
     - fluentd.ocw_origin
   'P@roles:ocw-(cms|mirror|origin) and G@ocw-environment:production':


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/932

#### What's this PR do?

~~Fix the parsing attributes for the fluentD configuration that parses OCW origin server Nginx access logs.~~

~~Use the fluentD bundled 'apache2' type, which is a misnomer: it's the standard Combined Log Format, which is used by our Nginx servers. It's the same log format that has been working fine with `ocs_cms.sls`.~~


Fix OCW origin server's access log format in Nginx configuration so that fluentD can parse it correctly. Include the `nginx` pillar in top.sls under 'roles:ocw-origin' so that the `nginx.ng` state knows the correct log format parameters.

#### How should this be manually tested?

See https://github.com/mitodl/salt-ops/issues/932
