### PR TITLE
Improve file_limits sls, apply it to log cluster

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -45,6 +45,7 @@ base:
     - master_utils.dns
   'G@roles:elasticsearch and G@environment:operations':
     - match: compound
+    - utils.file_limits
     - elastic-stack.elasticsearch
     - elastic-stack.elasticsearch.plugins
     - datadog.plugins

--- a/salt/utils/file_limits.sls
+++ b/salt/utils/file_limits.sls
@@ -2,6 +2,10 @@
 increase_file_descriptor_limit:
   cmd.run:
     - name: sysctl -w fs.file-max={{ fd_limit }}
-  file.append:
+  file.replace:
     - name: /etc/sysctl.conf
-    - text: fs.file_max={{ fd_limit }}
+    # Look for underscore or hyphen because underscore has been used before on
+    # some of our systems. Hyphen is the correct one. (Per `/sbin/sysctl -a')
+    - pattern: fs.file[\-_]max=\d+
+    - repl: fs.file-max={{ fd_limit }}
+    - append_if_not_found: True


### PR DESCRIPTION
* Improve `file_limits.sls` by doing a `file.replace` instead of `file.append`, in case the `fs.file-max` line is already present.
* Apply the state to the Operations Elasticsearch logging cluster, where we have run into problems due to the open-files limit having been exceeded.