### PR TITLE
Fix fluentD parsing of Nginx access log null value

### DIFF
--- a/pillar/fluentd/cas.sls
+++ b/pillar/fluentd/cas.sls
@@ -19,7 +19,7 @@ fluentd:
                 - directive: parse
                   attrs:
                     - '@type': ltsv
-                    - null_value_pattern: '-'
+                    - null_value_pattern: '/^-$/'
                     - keep_time_key: 'true'
                     - label_delimiter: '='
                     - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'

--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -18,7 +18,7 @@ fluentd:
               - directive: parse
                 attrs:
                   - '@type': ltsv
-                  - null_value_pattern: '-'
+                  - null_value_pattern: '/^-$/'
                   - keep_time_key: 'true'
                   - label_delimiter: '='
                   - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -19,7 +19,7 @@ fluentd:
                 - directive: parse
                   attrs:
                     - '@type': ltsv
-                    - null_value_pattern: '-'
+                    - null_value_pattern: '/^-$/'
                     - keep_time_key: 'true'
                     - label_delimiter: '='
                     - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'

--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -50,7 +50,7 @@ fluentd:
                 - directive: parse
                   attrs:
                     - '@type': ltsv
-                    - null_value_pattern: '-'
+                    - null_value_pattern: '/^-$/'
                     - keep_time_key: 'true'
                     - label_delimiter: '='
                     - delimiter_pattern: '/\s+(?=(?:[^"]*"[^"]*")*[^"]*$)/'


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes https://github.com/mitodl/salt-ops/issues/935

#### What's this PR do?

Fix the regex that fluentD uses to determine a null value in a field in an Nginx access log.

With the `null_value_pattern` option, fluentD takes a field with a whole value of "-" and stores it as null. The problem was that the `null_value_pattern` parameter is a regex, so it was registering anything _containing_ a hyphen as null.

I have taken the liberty of modifying some other fluentD configurations for other products that had the same `null_value_pattern`.

#### How should this be manually tested?

I have made the change manually to `/etc/fluent/fluent.d/ocworigin.conf` on our origin webserver and have observed that it fixes the problem.

