### PR TITLE
Disabled services on analytics instances

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -109,7 +109,7 @@ restart_edx_worker_service:
 
 {% if 'edx-analytics' in salt.grains.get('roles') %}
 stop_edxapp_services:
-  supervisord.stop:
+  supervisord.dead:
     - name: all
     - bin_env: '/edx/bin/supervisorctl'
     - require:

--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -106,3 +106,17 @@ restart_edx_worker_service:
     - require:
       - cmd: run_ansible
 {% endif %}
+
+{% if 'edx-analytics' in salt.grains.get('roles') %}
+stop_edxapp_services:
+  supervisord.stop:
+    - name: all
+    - bin_env: '/edx/bin/supervisorctl'
+    - require:
+      - cmd: run_ansible
+
+stop_nginx_service:
+  service.dead:
+    - name: nginx
+    - enable: False
+{% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#832](https://github.com/mitodl/salt-ops/issues/832)

#### What's this PR do?
Stops all supervisord services along with Nginx on analytics instances as those services aren't required to be running on those instances.