### PR TITLE
Enable Datadog on OCW CMS & DB, production

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -270,3 +270,5 @@ base:
     - match: grain
     - logrotate.ocw_cms
     - fluentd.ocw_db
+  'P@roles:ocw-(cms|db) and G@ocw-environment:production':
+    - datadog

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -225,6 +225,8 @@ base:
     - match: grain
     - apps.ocw.mirror
     - apps.ocw.sync_repo
+  'P@roles:ocw-(cms|db) and G@ocw-environment:production':
+    - datadog
   'roles:sandbox':
     - match: grain
     - edx.prod


### PR DESCRIPTION
#### What are the relevant tickets?

Recent Slack conversations about monitoring OCW servers for OOM problems.

#### What's this PR do?

Adds Datadog agent to OCW CMS and DB servers, in production.
Only adds the base system monitoring, not any integrations / plugins.
