### PR TITLE
Fix problem with OCW environment names

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -898,7 +898,7 @@ environments:
           parameter_group_name: default.redis3.2
           failover_enabled: False
           business_unit: odl-video
-  ocw:
+  ocw: &ocw
     business_unit: open-courseware
     network_prefix: '10.100'
     vpc_name: OCW
@@ -921,6 +921,10 @@ environments:
         security_groups:
           - webapp
           - ssh
+  ocw-production:
+    <<: *ocw
+  ocw-qa:
+    <<: *ocw
 
 business_units:
   - bootcamps


### PR DESCRIPTION
Add include syntax to `environment_settings.yml` to work around a
subtlety with environment name grains.

Commit 7c834d5badd51b4ac18e6aaa82401bba597c1d6a introduced a problem
with OCW environment names. Per https://github.com/mitodl/salt-ops/pull/939#issuecomment-511955312 I modified the Salt grains on our OCW instances from "ocw" to "ocw-production" or "ocw-qa". As a result, Nginx templates now fail to render in the nginx.ocw_origin pillar, where it tries to look up data in `environment_settings.yml`.