### PR TITLE
Move xpro settings changes to run_ansible state

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -1,10 +1,4 @@
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
-{% set heroku_xpro_env_url_mapping = {
-    'sandbox': 'https://xpro-ci.odl.mit.edu',
-    'xpro-qa': 'https://xpro-rc.odl.mit.edu',
-    'xpro-production': 'https://xpro.mit.edu'
-  } %}
-{% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
 
 ensure_license_selector_template_is_in_expected_location:
   file.copy:
@@ -32,17 +26,3 @@ copy_select_static_assets_to_static_subfolder:
     - recurse: True
     - remove_existing: True
     - preserve: True
-
-{% if 'mitxpro' in salt.grains.get('environment') %}
-add_social_auth_https_redirect_to_lms_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
-    - text: SOCIAL_AUTH_REDIRECT_IS_HTTPS = ENV_TOKENS.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', True)
-
-{% for app in ['lms', 'cms'] %}
-add_xpro_base_url_to_{{ app }}_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
-    - text: XPRO_BASE_URL = '{{ heroku_env }}'
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
#### What's this PR do?
When a scheduled configuration task runs, it overwrites changes made to `production.py` and thus the supervisord services fail to start. Changes to that file were made through the `hacks` state however that does not runs as part of the scheduled configuration task. So, I moved those directives to the `edx.run_ansible` state to resolve the problem.