### PR TITLE
Restart edx-workers to use new creds

### DIFF
--- a/pillar/edx/scheduled_jobs.sls
+++ b/pillar/edx/scheduled_jobs.sls
@@ -5,3 +5,13 @@ schedule:
     function: state.sls
     args:
       - edx.maintenance_tasks
+  {% if 'edx-worker' in salt.grains.get('roles') %}
+  restart_edx_worker_services:
+    days: 5
+    splay: 30
+    function: supervisord.restart
+    args:
+      - all
+    kwargs:
+      bin_env: /edx/bin/supervisorctl
+  {% endif %}


### PR DESCRIPTION
#### What's this PR do?
Restart instances with the `edx-worker` role on a schedule to pick up new/updated credentials.