### PR TITLE
Fix fluentD parsing of nginx error logs

### DIFF
--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -36,7 +36,7 @@ fluentd:
               - directive: parse
                 attrs:
                   - '@type': regexp
-                  - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)client:\s(?<client_ip>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}),\sserver:\s(?<server>.*),\srequest:\s"(?<method>.*)",\supstream:\s"(?<upstream>.*)",\shost:\s"(?<host>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})"$'
+                  - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ record_tagging | yaml() }}
         - directive: match
           directive_arg: '**'

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -37,7 +37,7 @@ fluentd:
                 - directive: parse
                   attrs:
                     - '@type': regexp
-                    - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)client:\s(?<client_ip>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}),\sserver:\s(?<server>.*),\srequest:\s"(?<method>.*)",\supstream:\s"(?<upstream>.*)",\shost:\s"(?<host>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})"$'
+                    - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ record_tagging |yaml() }}
         - directive: match
           directive_arg: '**'

--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -68,7 +68,7 @@ fluentd:
                 - directive: parse
                   attrs:
                     - '@type': regexp
-                    - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)client:\s(?<client_ip>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}),\sserver:\s(?<server>.*),\srequest:\s"(?<method>.*)",\supstream:\s"(?<upstream>.*)",\shost:\s"(?<host>\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})"$'
+                    - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ record_tagging |yaml() }}
         - directive: match
           directive_arg: '**'


### PR DESCRIPTION

#### What are the relevant tickets?

None. I noticed the problem while looking at our logs in Kibana.

#### What's this PR do?

Fix the fluentD parse directives for various products' nginx error logs.

The one that has been working correctly is in `pillar/fluentd/cas.sls`. Correct the regular expressions in the other ones to match the one in `cas.sls`.

#### How should this be manually tested?

Filter on the following `fluentd_tag` values in Kibana: `cas.nginx.error`, `ocworigin.nginx.error`, `odlvideo.nginx.error`, and `reddit.nginx.error`. You'll see that `cas.nginx.error` is the only one that shows up, and the `cas.sls` configuration is the one that is different than the others.

