### PR TITLE
Moved JWT_AUTH to hacks.sls

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -49,13 +49,6 @@ edx:
       MARKETING_SITE_ROOT: {{ heroku_env }}
       MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)"]
       THIRD_PARTY_AUTH_BACKENDS: ["social_auth_mitxpro.backends.MITxProOAuth2"]
-      JWT_AUTH:
-        JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
-        JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
-        JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
-        JWT_SIGNING_ALGORITHM: 'RS512'
-        JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
-        JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
       FEATURES:
         REROUTE_ACTIVATION_EMAIL: {{ support_email }}
         ENABLE_VIDEO_UPLOAD_PIPELINE: False

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -49,6 +49,13 @@ edx:
       MARKETING_SITE_ROOT: {{ heroku_env }}
       MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)"]
       THIRD_PARTY_AUTH_BACKENDS: ["social_auth_mitxpro.backends.MITxProOAuth2"]
+      JWT_AUTH:
+        JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
+        JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
+        JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
+        JWT_SIGNING_ALGORITHM: 'RS512'
+        JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
+        JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
       FEATURES:
         REROUTE_ACTIVATION_EMAIL: {{ support_email }}
         ENABLE_VIDEO_UPLOAD_PIPELINE: False

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -19,6 +19,12 @@ edx:
     EDXAPP_COMMENTS_SERVICE_URL: "http://localhost:4567"
     EDXAPP_COMMENTS_SERVICE_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/global/forum-api-key>data>value
     EDXAPP_IDA_LOGOUT_URI_LIST: ['{{ heroku_env }}/logout']
+    EDXAPP_JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
+    EDXAPP_JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
+    EDXAPP_JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
+    EDXAPP_JWT_SIGNING_ALGORITHM: 'RS512'
+    EDXAPP_JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
+    EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
     EDXAPP_PRIVATE_REQUIREMENTS:
       - name: mitxpro-openedx-extensions==0.1.0
       - name: social-auth-mitxpro==0.2
@@ -49,13 +55,6 @@ edx:
       MARKETING_SITE_ROOT: {{ heroku_env }}
       MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)"]
       THIRD_PARTY_AUTH_BACKENDS: ["social_auth_mitxpro.backends.MITxProOAuth2"]
-      JWT_AUTH:
-        JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
-        JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
-        JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
-        JWT_SIGNING_ALGORITHM: 'RS512'
-        JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
-        JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
       FEATURES:
         REROUTE_ACTIVATION_EMAIL: {{ support_email }}
         ENABLE_VIDEO_UPLOAD_PIPELINE: False

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -1,3 +1,5 @@
+{% set business_unit = salt.grains.get('business_unit', 'mitxpro') %}
+{% set environment = salt.grains.get('environment', 'mitxpro-qa') %}
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
 {% set heroku_xpro_env_url_mapping = {
     'sandbox': 'https://xpro-ci.odl.mit.edu',
@@ -5,6 +7,9 @@
     'xpro-production': 'https://xpro.mit.edu'
   } %}
 {% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
+{% set JWT_SECRET_KEY = '__vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value' %}
+{% set JWT_PRIVATE_SIGNING_JWK = '__vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value' %}
+{% set JWT_PUBLIC_SIGNING_JWK_SET = '__vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value' %}
 
 {% if salt.file.directory_exists('/edx/var/edxapp/staticfiles/studio/templates') %}
 ensure_license_selector_template_is_in_expected_location:
@@ -51,4 +56,16 @@ add_xpro_base_url_to_{{ app }}_production_file:
     - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
     - text: XPRO_BASE_URL = '{{ heroku_env }}'
 {% endfor %}
+
+add_xpro_jwt_auth_to_production_file:
+  file.append:
+    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
+    - text: |
+        JWT_AUTH.update({
+          'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
+          'JWT_AUDIENCE': '{{ business_unit }}-{{ environment }}-key',
+          'JWT_SECRET_KEY': '{{ JWT_SECRET_KEY }}',
+          'JWT_PRIVATE_SIGNING_JWK': '{{ JWT_PRIVATE_SIGNING_JWK }}',
+          'JWT_PUBLIC_SIGNING_JWK_SET': {{ JWT_PUBLIC_SIGNING_JWK_SET }}'
+
 {% endif %}

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -1,5 +1,3 @@
-{% set business_unit = salt.grains.get('business_unit', 'mitxpro') %}
-{% set environment = salt.grains.get('environment', 'mitxpro-qa') %}
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
 {% set heroku_xpro_env_url_mapping = {
     'sandbox': 'https://xpro-ci.odl.mit.edu',
@@ -7,9 +5,6 @@
     'xpro-production': 'https://xpro.mit.edu'
   } %}
 {% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
-{% set JWT_SECRET_KEY = '__vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value' %}
-{% set JWT_PRIVATE_SIGNING_JWK = '__vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value' %}
-{% set JWT_PUBLIC_SIGNING_JWK_SET = '__vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value' %}
 
 {% if salt.file.directory_exists('/edx/var/edxapp/staticfiles/studio/templates') %}
 ensure_license_selector_template_is_in_expected_location:
@@ -56,16 +51,4 @@ add_xpro_base_url_to_{{ app }}_production_file:
     - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
     - text: XPRO_BASE_URL = '{{ heroku_env }}'
 {% endfor %}
-
-add_xpro_jwt_auth_to_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
-    - text: |
-        JWT_AUTH.update({
-          'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
-          'JWT_AUDIENCE': '{{ business_unit }}-{{ environment }}-key',
-          'JWT_SECRET_KEY': '{{ JWT_SECRET_KEY }}',
-          'JWT_PRIVATE_SIGNING_JWK': '{{ JWT_PRIVATE_SIGNING_JWK }}',
-          'JWT_PUBLIC_SIGNING_JWK_SET': {{ JWT_PUBLIC_SIGNING_JWK_SET }}'
-
 {% endif %}


### PR DESCRIPTION
#### What's this PR do?
Came across an issue where by the time the vault values were written out to `lms.env.json` lms was throwing errors for an invalid `JWT_PRIVATE_SIGNING_JWK`. It appeared that some `'` and `\n` were being added along the line (probably ansible rendering). The suggestion was to use the values as specified [here](https://github.com/edx/configuration/blob/open-release%2Fironwood.master/playbooks/roles/edxapp/defaults/main.yml#L1213-L1223)
