### PR TITLE
Move JWT config to production.py

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -13,18 +13,18 @@
 {% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
 
 edx:
+  JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
+  JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
+  JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
+  JWT_SIGNING_ALGORITHM: 'RS512'
+  JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
+  JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
   ansible_vars:
     EDXAPP_SESSION_COOKIE_DOMAIN: .xpro.mit.edu
     EDXAPP_SESSION_COOKIE_NAME: {{ environment }}-{{ purpose }}-session
     EDXAPP_COMMENTS_SERVICE_URL: "http://localhost:4567"
     EDXAPP_COMMENTS_SERVICE_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/global/forum-api-key>data>value
     EDXAPP_IDA_LOGOUT_URI_LIST: ['{{ heroku_env }}/logout']
-    EDXAPP_JWT_ISSUER: 'OAUTH_OIDC_ISSUER'
-    EDXAPP_JWT_AUDIENCE: '{{ business_unit }}-{{ environment }}-key'
-    EDXAPP_JWT_SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/jwt-secret-key>data>value
-    EDXAPP_JWT_SIGNING_ALGORITHM: 'RS512'
-    EDXAPP_JWT_PRIVATE_SIGNING_JWK: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/private-key>data>value
-    EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET: __vault__::secret-{{ business_unit }}/{{ environment }}/jwt-signing-jwk/public-key>data>value
     EDXAPP_PRIVATE_REQUIREMENTS:
       - name: mitxpro-openedx-extensions==0.1.0
       - name: social-auth-mitxpro==0.2

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -5,6 +5,12 @@
     'xpro-production': 'https://xpro.mit.edu'
   } %}
 {% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
+{% set JWT_SECRET_KEY = salt.pillar.get('edx:JWT_SECRET_KEY') %}
+{% set JWT_ISSUER = salt.pillar.get('edx:JWT_ISSUER') %}
+{% set JWT_AUDIENCE = salt.pillar.get('edx:JWT_AUDIENCE') %}
+{% set JWT_SECRET_KEY = salt.pillar.get('edx:JWT_SECRET_KEY') %}
+{% set JWT_PUBLIC_SIGNING_JWK_SET = salt.pillar.get('edx:JWT_PUBLIC_SIGNING_JWK_SET') %}
+{% set JWT_PRIVATE_SIGNING_JWK_SET = salt.pillar.get('edx:JWT_PRIVATE_SIGNING_JWK_SET') %}
 
 {% if salt.file.directory_exists('/edx/var/edxapp/staticfiles/studio/templates') %}
 ensure_license_selector_template_is_in_expected_location:
@@ -51,4 +57,20 @@ add_xpro_base_url_to_{{ app }}_production_file:
     - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
     - text: XPRO_BASE_URL = '{{ heroku_env }}'
 {% endfor %}
+add_jwt_auth_to_production_file:
+  file.append:
+    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
+    - text: |
+        JWT_AUTH.update({
+        'JWT_SECRET_KEY': '{{ JWT_SECRET_KEY }}',
+        'JWT_ISSUER': '{{ JWT_ISSUER }}',
+        'JWT_AUDIENCE': '{{ JWT_AUDIENCE }}',
+        'JWT_PUBLIC_SIGNING_JWK_SET': (
+            '{{ JWT_PUBLIC_SIGNING_JWK_SET }}'
+        ),
+
+        'JWT_PRIVATE_SIGNING_JWK': (
+            '{{ JWT_PRIVATE_SIGNING_JWK_SET }}'
+        ),
+    })
 {% endif %}


### PR DESCRIPTION
Even after using the JWT settings based on [this](https://github.com/edx/configuration/blob/open-release%2Fironwood.master/playbooks/roles/edxapp/defaults/main.yml#L1213-L1223), when the values were written to disk, it was still doing something weird with the rendering by adding quotes and a `\n` to the private and public key sets which was throwing a `ValueError: No JSON object could be decoded` in the lms error log.
This just moves the values to the `production.py` file