### PR TITLE
Refactored to add edx-worker instances

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -237,10 +237,16 @@ environments:
     network_prefix: '10.8'
     vpc_name: MITxPro Production
     provider_services:
-      sns:
-        topic: edxapp-xpro-production
-      sqs:
-        queue: edxapp-xpro-production
+      edxapp:
+        sns:
+          topic: edxapp-xpro-production
+        sqs:
+          queue: edxapp-xpro-production
+      edx-worker:
+        sns:
+          topic: edx-worker-xpro-production
+        sqs:
+          queue: edx-worker-xpro-production
     secret_backends:
       mysql:
         role_prefixes:
@@ -301,12 +307,12 @@ environments:
           <<: *xpro_production_versions
         instances:
           edx:
-            number: 6
             min_number: 6
             max_number: 10
             type: r5.large
           edx-worker:
-            number: 3
+            min_number: 3
+            max_number: 7
             type: t3.large
           analytics:
             number: 1


### PR DESCRIPTION
#### What's this PR do?
Refactored autoscaling group code to also create a group for the worker instances. One caveat to it is that the alarm based on CPU load isn't really the ideal way to determine load on those instance and it would be better to base it on queue length, but that would require some integration between CloudWatch and rabbit and we can revisit at a later date.