### PR TITLE
Change OCW Akamai netstorage host, production

### DIFF
--- a/pillar/apps/ocw-production.sls
+++ b/pillar/apps/ocw-production.sls
@@ -34,7 +34,7 @@ ocw:
       url: http://ocw-rsync.odl.mit.edu/
       host: ocw-production-rsync
     netstorage:
-      host: ocw-production-netstorage.odl.mit.edu
+      host: ocwzip.upload.akamai.com
       user: sshacs
       rootdirectory: /15436/ZipForEndUsers
       zipurlprefix: /ans15436/ZipForEndUsers


### PR DESCRIPTION
Change the hostname of the Akamak netstorage host, as configured in the OCW engine configuration file.

See https://github.com/mitodl/salt-ops/issues/955

@JoeMartis Is there any reason I should not merge this and update the configuration right now so that any production publishes run from now on are pushing files to the real netstorage?