### PR TITLE
Update OCW Zope base site URLs

### DIFF
--- a/pillar/apps/ocw-production.sls
+++ b/pillar/apps/ocw-production.sls
@@ -56,8 +56,8 @@ ocw:
       dspace_endpoint_prefix: https://dspace.mit.edu/sword/deposit/
       deposit_uri_lookup_file_name: DepositURILookup.xml
   zope_conf:
-    base_site_url: https://ocw-origin.odl.mit.edu
-    base_staging_site_url: https://ocw-production-ocw2.odl.mit.edu
+    base_site_url: https://ocw.mit.edu
+    base_staging_site_url: http://ocw2.mit.edu
     zodb_ipaddr: "{{ zodb_ipaddr }}"
   mirror:
     host_aliases:


### PR DESCRIPTION
Update the environment variable definitions in the Zope configuration that govern the base site URLs that will be written to HTML meta tags.

The canonical URL meta tag values are wrong on the production site, and this should fix them.
