### PR TITLE
Updated default course mode settings for xpro

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -51,8 +51,15 @@ edx:
       COURSE_ABOUT_VISIBILITY_PERMISSION: staff
       COURSE_CATALOG_VISIBILITY_PERMISSION: staff
       COURSE_MODE_DEFAULTS:
-        name: "Audit"
-        slug: "audit"
+        bulk_sku: !!null
+        currency: 'usd'
+        description: !!null
+        expiration_datetime: !!null
+        min_price: 0
+        name: 'Professional'
+        sku: !!null
+        slug: 'no-id-professional'
+        suggested_prices: ''
       EMAIL_USE_DEFAULT_FROM_FOR_BULK: True
       MARKETING_SITE_ROOT: {{ heroku_env }}
       MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)"]


### PR DESCRIPTION
Turning on the `no-id-professional` track for xpro students

#### What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/474

#### What's this PR do?
Sets the default course mode to be `no-id-professional`

#### How should this be manually tested?
Apply to CI and QA instances of edx and validate desired behaviour in sample course.