### PR TITLE
Fix FluentD shipping, OCW Zope and Apache access logs

### DIFF
--- a/pillar/fluentd/ocw_cms.sls
+++ b/pillar/fluentd/ocw_cms.sls
@@ -18,7 +18,6 @@ fluentd:
               - directive: parse
                 attrs:
                   - '@type': apache2
-                  - keep_time_key: 'true'
         - directive: source
           attrs:
             - '@id': ocwcms_apache_error_log
@@ -59,7 +58,6 @@ fluentd:
               - directive: parse
                 attrs:
                   - '@type': apache2
-                  - keep_time_key: 'true'
 {% if salt.grains.get('ocw-cms-role') == 'engine' %}
         - directive: source
           attrs:


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes https://github.com/mitodl/salt-ops/issues/946

#### What's this PR do?

Fix how FluentD ships Apache2-format access logs from OCW's Zope and Apache acccess logs.

Stop it from sending the `time` field, which has special significance for Elasticsearch, which tries to parse it as a long int and fails to save the log message with a parsing error.

FluentD's default for the `keep_time_key` parameter is `false`, but we had it set to `true`.


#### How should this be manually tested?

I have removed the `keep_time_key` parameter from a FluentD config file in QA and have observed log messages being shipped as a result.

