### PR TITLE
Fix Elasticsearch log timestamp in FluentD config

### DIFF
--- a/pillar/fluentd/elasticsearch.sls
+++ b/pillar/fluentd/elasticsearch.sls
@@ -15,8 +15,8 @@ fluentd:
             - path: /usr/share/elasticsearch/logs/*.log
             - pos_file: /usr/share/elasticsearch/logs/elasticsearch_fluentd.log.pos
             - format: multiline
-            - format_firstline: '/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\]/'
-            - format1: '/^\[(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\]\[(?<log_level>\w+)\]\[(?<module_name>.*?)\] (?<message>.*)$/'
+            - format_firstline: '/^\[\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2},\d{3}\]/'
+            - format1: '/^\[(?<time>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2},\d{3})\]\[(?<log_level>\w+)\]\[(?<module_name>.*?)\] (?<message>.*)$/'
             - multiline_flush_interval: '5s'
         - {{ auth_log_source('syslog.auth', '/var/log/auth.log') }}
         - {{ auth_log_filter('grep', 'ident', 'CRON') }}


### PR DESCRIPTION

#### What are the relevant tickets?

I noticed this issue after committing https://github.com/mitodl/salt-ops/commit/ef621cdb505fafc846f1c0e8ff3bc2cf01f8e2f3 to get FluentD to follow the logging cluster's logs.

The Operations logging cluster's logs were not being shipped, though the correct logs were now being tailed.

#### What's this PR do?

Fix FluentD's regular expression for Elasticsearch server messages to allow timestamps with a "T", such as `2019-08-09T15:06:11,483`. Also allow a space in that position. It appears that our operations Elasticsearch cluster (version 6.x) has timestamps with "T" but other instances like those in MITx have timestamps with " ".

#### How should this be manually tested?

I've tested the revised regex in Rubular, using a sample line from the Operations Elasticsearch logging cluster.

I assume that the regex with the space character in the timestamp has been working fine for other Elasticsearch clusters, so I didn't want to break that. I'm allowing either a space or a "T" for this reason.

