### PR TITLE
Set from bulk email address in lms production

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -51,6 +51,11 @@ add_social_auth_https_redirect_to_lms_production_file:
     - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
     - text: SOCIAL_AUTH_REDIRECT_IS_HTTPS = ENV_TOKENS.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', True)
 
+set_from_bulk_email_address_in_lms_production_file:
+  file.append:
+    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
+    - text: EMAIL_USE_DEFAULT_FROM_FOR_BULK = ENV_TOKENS.get('EMAIL_USE_DEFAULT_FROM_FOR_BULK', False)
+
 {% for app in ['lms', 'cms'] %}
 add_xpro_base_url_to_{{ app }}_production_file:
   file.append:


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#986](https://github.com/mitodl/mitxpro/issues/986)

#### What's this PR do?
This sets the `from` email address to a fixed value as opposed to adding the class prefix to the sent from address which can cause emails to mislabeled as spam.