### PR TITLE
Added filter to avoid launching in us-east-1e

### DIFF
--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -8,10 +8,10 @@
 {% set subnet_ids = salt.boto_vpc.describe_subnets(
     vpc_id=salt.boto_vpc.describe_vpcs(
         name=env_data.vpc_name).vpcs[0].id
-    ).subnets|map(attribute='id')|list %}
+    ).subnets|rejectattr('availability_zone', '==', 'us-east-1e')|map(attribute='id')||list %}
 {% set security_groups = env_data.purposes[app_name].get('security_groups', []) %}
 {% do security_groups.extend(['salt_master', 'consul-agent']) %}
-{% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
+{% set release_id = (salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id') or 'v1') %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 
 load_{{ app_name }}_cloud_profile:

--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -8,7 +8,7 @@
 {% set subnet_ids = salt.boto_vpc.describe_subnets(
     vpc_id=salt.boto_vpc.describe_vpcs(
         name=env_data.vpc_name).vpcs[0].id
-    ).subnets|map(attribute='id')|list %}
+    ).subnets|rejectattr('availability_zone', '==', 'us-east-1e')|map(attribute='id')||list %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -9,7 +9,7 @@
 {% set subnet_ids = salt.boto_vpc.describe_subnets(
     vpc_id=salt.boto_vpc.describe_vpcs(
         name=env_data.vpc_name).vpcs[0].id
-    ).subnets|map(attribute='id')|list %}
+    ).subnets|rejectattr('availability_zone', '==', 'us-east-1e')|map(attribute='id')||list %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 


### PR DESCRIPTION
Our mapping of the 1e AZ is for a datacenter which doesn't support newer instance types. Avoiding launching in that to prevent deployment failures when using newer instance types.