### PR TITLE
Upgraded testinfra version after fixing extension

### DIFF
--- a/salt/utils/install_libs.sls
+++ b/salt/utils/install_libs.sls
@@ -1,6 +1,6 @@
 {% set python_dependencies = salt.grains.filter_by({
     'default': {
-      'python_libs': ['testinfra~=1.19', 'pyinotify'],
+      'python_libs': ['testinfra~=3.06', 'pyinotify'],
       'pkgs': ['gcc', 'make']
     },
     'Debian': {


### PR DESCRIPTION
#### What's this PR do?
Updates the testinfra version after having merged the fix on the extension repo. I have already updated and tested the new version manually on the salt-master and all appears to be working.