### PR TITLE
Add elastalert alert for edX git export failure

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -379,3 +379,30 @@ elastic_stack:
                 filter:
                   - term:
                       fluentd_tag: ocwcms.zope.event
+      - name: mitx_git_export_failure
+        settings:
+          name: Automated git export failure
+          description: >-
+            An exception was encountered from the edX application when exporting
+            a course to git.
+          type: frequency
+          index: logstash-mitx*-production*
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - slack
+          alert_text: "Automated git export failure"
+          slack_webhook_url: {{ slack_webhook_url }}
+          slack_channel_override: '#mitx-tech-notifs'
+          slack_username_override: Elastalert
+          slack_msg_color: "warning"
+          filter:
+            - bool:
+                must:
+                  - query_string:
+                      default_field: message
+                      query: error AND export_git
+                filter:
+                  - term:
+                      fluentd_tag: edx.cms


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/990

#### What's this PR do?

Adds an Elastalert alert for a failure in the edX app when exporting course data to Git.

It sends an alert to the `#mitx-tech-notifs` Slack channel.

There is talk in https://github.com/mitodl/salt-ops/issues/990 of adding a new channel for MIT xPRO, but that has not been accounted for here, yet. Do we want to create that channel now and update this PR, or follow up later with another commit to add it? This changeset, as it is at the moment, will create messages for both MITx residential and xPRO in `#mitx-tech-notifs`.

#### How should this be manually tested?

The Elasticserch query represented by the `filter` property of the configuration can be approximated as follows, where `localhost:9200` is an SSH tunnel to the logging cluster:

```
curl -X POST \
  http://localhost:9200/logstash-mitx%2A-production-%2A/_search \
  -H 'Content-Type: application/json' \
  -d '{
	"query": {
		"bool": {
			"must": {
				"query_string": {
					"default_field": "message",
					"query": "error AND export_git"
				}
			},
			"filter": {
				"term": {
					"fluentd_tag": "edx.cms"
				}
			}
		}
	}
}'
```

If I execute that at the time of this writing, I get 18 documents from Elasticsearch.

