### PR TITLE
Added google analytics accounts for xpro

### DIFF
--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -42,13 +42,10 @@
 {% set efs_id = 'fs-1f27ae56' %}
 {% elif environment == 'mitxpro-qa' %}
 {% set efs_id = 'fs-b3865653' %}
+{% set edxapp_google_analytics_account = 'UA-5145472-40' %}
 {% elif environment == 'mitxpro-production' %}
 {% set efs_id = 'fs-68918b88' %}
-{% endif %}
-{% if environment == 'mitxpro-qa' %}
-  {% set edxapp_google_analytics_account = 'UA-5145472-40' %}
-  {% elif environment = 'mitxpro-production' %}
-  {% set edxapp_google_analytics_account = 'UA-5145472-38' %}
+{% set edxapp_google_analytics_account = 'UA-5145472-38' %}
 {% endif %}
 {% if 'live' in purpose %}
   {% set edxapp_git_repo_dir = '/mnt/data/prod_repos' %}

--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -46,6 +46,8 @@
 {% elif environment == 'mitxpro-production' %}
 {% set efs_id = 'fs-68918b88' %}
 {% set edxapp_google_analytics_account = 'UA-5145472-38' %}
+{% else %}
+{% set edxapp_google_analytics_account = '' %}
 {% endif %}
 {% if 'live' in purpose %}
   {% set edxapp_git_repo_dir = '/mnt/data/prod_repos' %}

--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -45,7 +45,11 @@
 {% elif environment == 'mitxpro-production' %}
 {% set efs_id = 'fs-68918b88' %}
 {% endif %}
-{% set edxapp_google_analytics_account = '' %}
+{% if environment == 'mitxpro-qa' %}
+  {% set edxapp_google_analytics_account = 'UA-5145472-40' %}
+  {% elif environment = 'mitxpro-production' %}
+  {% set edxapp_google_analytics_account = 'UA-5145472-38' %}
+{% endif %}
 {% if 'live' in purpose %}
   {% set edxapp_git_repo_dir = '/mnt/data/prod_repos' %}
   {% set edxapp_course_about_visibility_permission = 'see_exists' %}


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#279](https://github.com/mitodl/mitxpro/issues/279)

#### What's this PR do?
Adds values for `edxapp_google_analytics_account` for `mitxpro-qa` and `mitxpro-production` using the same value used by the existing xPRO accounts used by the xPRO Heroku apps in CI/RC and production.