### PR TITLE
Added location route for lti POST requests

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -56,7 +56,7 @@ edx:
         slug: "audit"
       EMAIL_USE_DEFAULT_FROM_FOR_BULK: True
       MARKETING_SITE_ROOT: {{ heroku_env }}
-      MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)"]
+      MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]
       THIRD_PARTY_AUTH_BACKENDS: ["social_auth_mitxpro.backends.MITxProOAuth2"]
       FEATURES:
         REROUTE_ACTIVATION_EMAIL: {{ support_email }}

--- a/salt/edx/templates/extra_locations_lms.j2
+++ b/salt/edx/templates/extra_locations_lms.j2
@@ -24,7 +24,4 @@
         }
         try_files $uri @proxy_to_lms_app;
     }
-    location ~ ^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler {
-        try_files $uri @proxy_to_lms_app;
-    }
 {% endif %}

--- a/salt/edx/templates/extra_locations_lms.j2
+++ b/salt/edx/templates/extra_locations_lms.j2
@@ -24,4 +24,7 @@
         }
         try_files $uri @proxy_to_lms_app;
     }
+    location ~ ^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler {
+        try_files $uri @proxy_to_lms_app;
+    }
 {% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#1082](https://github.com/mitodl/mitxpro/issues/1082)

#### What's this PR do?
Allows POST requests to a specific endpoint used by LTI's. Main use case for now is Yellowdig