### PR TITLE
Applied bulk email hack to all envs

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -45,16 +45,16 @@ copy_select_static_assets_to_static_subfolder:
     - preserve: True
 {% endif %}
 
+set_from_bulk_email_address_in_lms_production_file:
+  file.append:
+    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
+    - text: EMAIL_USE_DEFAULT_FROM_FOR_BULK = ENV_TOKENS.get('EMAIL_USE_DEFAULT_FROM_FOR_BULK', False)
+
 {% if 'mitxpro' in salt.grains.get('environment') %}
 add_social_auth_https_redirect_to_lms_production_file:
   file.append:
     - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
     - text: SOCIAL_AUTH_REDIRECT_IS_HTTPS = ENV_TOKENS.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', True)
-
-set_from_bulk_email_address_in_lms_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
-    - text: EMAIL_USE_DEFAULT_FROM_FOR_BULK = ENV_TOKENS.get('EMAIL_USE_DEFAULT_FROM_FOR_BULK', False)
 
 {% for app in ['lms', 'cms'] %}
 add_xpro_base_url_to_{{ app }}_production_file:


### PR DESCRIPTION
#### What's this PR do?
This is required so that the setting in `lms.env.json` gets read in otherwise when the bulk email task runs it'll throw an error about the value not being set.