### PR TITLE
Manage edx buckets in separate state file

### DIFF
--- a/salt/orchestrate/aws/s3_buckets/edx.sls
+++ b/salt/orchestrate/aws/s3_buckets/edx.sls
@@ -4,6 +4,27 @@
 {% for purpose in env_data.purposes %}
 {% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
 
+{% for use in bucket_uses %}
+create_edx_s3_bucket_{{ use }}_{{ purpose }}_{{ ENVIRONMENT }}:
+  boto_s3_bucket.present:
+    - Bucket: {{ bucket_prefix }}-{{ use }}-{{ purpose }}-{{ ENVIRONMENT }}
+    - region: us-east-1
+    - Versioning:
+       Status: "Enabled"
+    {% if use == 'storage' %}
+    - CORSRules:
+        - AllowedHeaders:
+            - "*"
+          AllowedMethods:
+            - GET
+            - POST
+            - PUT
+          AllowedOrigins:
+            - "*"
+          MaxAgeSeconds: 3000
+    {% endif %}
+{% endfor %}
+
 video_uploads_bucket_{{ purpose }}_{{ env }}:
   boto_s3_bucket.present:
     - Bucket: {{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}
@@ -25,26 +46,5 @@ video_uploads_bucket_{{ purpose }}_{{ env }}:
             Principal: "*"
             Action: "s3:GetObject"
             Resource: "arn:aws:s3:::{{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}/*"
-
-{% for use in bucket_uses %}
-create_edx_s3_bucket_{{ use }}_{{ purpose }}_{{ ENVIRONMENT }}:
-  boto_s3_bucket.present:
-    - Bucket: {{ bucket_prefix }}-{{ use }}-{{ purpose }}-{{ ENVIRONMENT }}
-    - region: us-east-1
-    - Versioning:
-       Status: "Enabled"
-    {% if use == 'storage' %}
-    - CORSRules:
-        - AllowedHeaders:
-            - "*"
-          AllowedMethods:
-            - GET
-            - POST
-            - PUT
-          AllowedOrigins:
-            - "*"
-          MaxAgeSeconds: 3000
-    {% endif %}
-{% endfor %}
 {% endfor %}
 {% endfor %}

--- a/salt/orchestrate/aws/s3_buckets/edx.sls
+++ b/salt/orchestrate/aws/s3_buckets/edx.sls
@@ -1,0 +1,50 @@
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% for env in ['mitxpro-qa', 'mitxpro-production', 'mitx-qa', 'mitx-production'] %}
+{% set env_data = env_settings.environments[env] %}
+{% for purpose in env_data.purposes %}
+{% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
+
+video_uploads_bucket_{{ purpose }}_{{ env }}:
+  boto_s3_bucket.present:
+    - Bucket: {{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}
+    - Versioning:
+        Status: Enabled
+    - region: us-east-1
+    - Tagging:
+        OU: mitxpro
+        business_unit: mitxpro
+        Department: mitxpro
+        Environment: {{ env }}
+    - ACL:
+        GrantRead: "uri=http://acs.amazonaws.com/groups/global/AllUsers"
+    - Policy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "PublicRead"
+            Effect: "Allow"
+            Principal: "*"
+            Action: "s3:GetObject"
+            Resource: "arn:aws:s3:::{{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}/*"
+
+{% for use in bucket_uses %}
+create_edx_s3_bucket_{{ use }}_{{ purpose }}_{{ ENVIRONMENT }}:
+  boto_s3_bucket.present:
+    - Bucket: {{ bucket_prefix }}-{{ use }}-{{ purpose }}-{{ ENVIRONMENT }}
+    - region: us-east-1
+    - Versioning:
+       Status: "Enabled"
+    {% if use == 'storage' %}
+    - CORSRules:
+        - AllowedHeaders:
+            - "*"
+          AllowedMethods:
+            - GET
+            - POST
+            - PUT
+          AllowedOrigins:
+            - "*"
+          MaxAgeSeconds: 3000
+    {% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/salt/orchestrate/aws/s3_buckets/xpro.sls
+++ b/salt/orchestrate/aws/s3_buckets/xpro.sls
@@ -3,29 +3,6 @@
 {% set env_data = env_settings.environments[env] %}
 {% for purpose in env_data.purposes %}
 {% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
-video_uploads_bucket_{{ purpose }}_{{ env }}:
-  boto_s3_bucket.present:
-    - Bucket: {{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}
-    - Versioning:
-        Status: Enabled
-    - region: us-east-1
-    - Tagging:
-        OU: mitxpro
-        business_unit: mitxpro
-        Department: mitxpro
-        Environment: {{ env }}
-    - ACL:
-        GrantRead: "uri=http://acs.amazonaws.com/groups/global/AllUsers"
-    - Policy:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: "PublicRead"
-            Effect: "Allow"
-            Principal: "*"
-            Action: "s3:GetObject"
-            Resource: "arn:aws:s3:::{{ bucket_prefix }}-edx-video-upload-{{ purpose }}-{{ env }}/*"
-{% endfor %}
-{% endfor %}
 
 {% for env in ['rc', 'ci', 'production'] %}
 xpro-app-{{ env }}:

--- a/salt/orchestrate/aws/s3_buckets/xpro.sls
+++ b/salt/orchestrate/aws/s3_buckets/xpro.sls
@@ -1,8 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
 {% for env in ['mitxpro-qa', 'mitxpro-production'] %}
-{% set env_data = env_settings.environments[env] %}
-{% for purpose in env_data.purposes %}
-{% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
 
 {% for env in ['rc', 'ci', 'production'] %}
 xpro-app-{{ env }}:

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -27,8 +27,6 @@
 {% set app_image = salt.sdb.get('sdb://consul/xenial_ami_id') %}
 {% set worker_image = salt.sdb.get('sdb://consul/xenial_ami_id') %}
 {% endif %}
-{% set bucket_prefix = env_settings.secret_backends.aws.bucket_prefix %}
-{% set bucket_uses = env_settings.secret_backends.aws.bucket_uses %}
 
 update_edxapp_codename_value:
   salt.function:

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -117,29 +117,6 @@ ensure_instance_profile_exists_for_edx:
   boto_iam_role.present:
     - name: edx-instance-role
 
-{% for use in bucket_uses %}
-{% for purpose in purposes %}
-create_edx_s3_bucket_{{ use }}_{{ purpose }}_{{ ENVIRONMENT }}:
-  boto_s3_bucket.present:
-    - Bucket: {{ bucket_prefix }}-{{ use }}-{{ purpose }}-{{ ENVIRONMENT }}
-    - region: us-east-1
-    - Versioning:
-       Status: "Enabled"
-    {% if use == 'storage' %}
-    - CORSRules:
-        - AllowedHeaders:
-            - "*"
-          AllowedMethods:
-            - GET
-            - POST
-            - PUT
-          AllowedOrigins:
-            - "*"
-          MaxAgeSeconds: 3000
-    {% endif %}
-{% endfor %}
-{% endfor %}
-
 load_pillar_data_on_edx_base_nodes:
   salt.function:
     - name: saltutil.refresh_pillar


### PR DESCRIPTION
#### What's this PR do?
Moved edx (residential and xpro) bucket orchestration to its own state file while removing that part from the `build_ami` is it was overwriting bucket permissions and causing read permission error on video thumbnails.