### PR TITLE
Added MicroMasters catalog API url for discussions

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -128,6 +128,7 @@ heroku:
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
     MAILGUN_URL: https://api.mailgun.net/v3/{{ env_data.MAILGUN_SENDER_DOMAIN }}
     MICROMASTERS_BASE_URL: https://{{ env_data.MICROMASTERS_BASE_URL }}
+    MICROMASTERS_CATALOG_API_URL: https://{{ env_data.MICROMASTERS_BASE_URL }}/api/v0/catalog/
     MICROMASTERS_COURSE_URL: https://{{ env_data.MICROMASTERS_BASE_URL }}/api/v0/courseruns/
     MICROMASTERS_EXTERNAL_LOGIN_URL: https://{{ env_data.MICROMASTERS_BASE_URL}}/discussions
     NEW_RELIC_LOG: stdout


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/2200

#### What's this PR do?
Adds the MICROMASTERS_CATALOG_URL setting for discussions on Heroku