### PR TITLE
Add sentry to openedx instances

### DIFF
--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -9,6 +9,7 @@
 {% set purpose_data = env_data.purposes[purpose] %}
 {% set bucket_prefix = env_data.secret_backends.aws.bucket_prefix %}
 {% set bucket_uses = env_data.secret_backends.aws.bucket_uses %}
+{% set sentry_dsn = salt.vault.read('secret-operations/global/{business_unit}/sentry-dsn'.format(business_unit=business_unit)) %}
 
 {% set DEFAULT_FEEDBACK_EMAIL = 'mitx-support@mit.edu' %}
 {% set DEFAULT_FROM_EMAIL = 'mitx-support@mit.edu' %}
@@ -239,12 +240,15 @@ edx:
     common_env_config: &common_env_config
       ADDL_INSTALLED_APPS:
         - ubcpi
+        - raven.contrib.django.raven_compat
       ADMINS:
       - ['MITx Stacktrace Recipients', 'cuddle-bunnies@mit.edu']
       BOOK_URL: ""
       DATA_DIR: {{ edxapp_git_repo_dir }}
       SERVER_EMAIL: mitxmail@mit.edu
       TIME_ZONE_DISPLAYED_FOR_DEADLINES: "{{ TIME_ZONE }}"
+      RAVEN_CONFIG:
+        dsn: {{ sentry_dsn }}
 
     EDXAPP_CODE_JAIL_LIMITS:
       REALTIME: 3

--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -39,3 +39,5 @@ edx:
         - name: git+https://github.com/Stanford-Online/xblock-in-video-quiz@release/v0.1.7#egg=xblock-in-video-quiz
           extra_args: -e
         - name: xblock-image-modal==0.4.2
+        # Python client for Sentry
+        - name: raven

--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -116,6 +116,8 @@ edx:
           extra_args: -e
         - name: git+https://github.com/Stanford-Online/xblock-in-video-quiz@release/v0.1.7#egg=xblock-in-video-quiz
           extra_args: -e
+        # Python client for Sentry
+        - name: raven
 
     EDXAPP_LMS_ENV_EXTRA:
       EMAIL_USE_DEFAULT_FROM_FOR_BULK: True

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -31,6 +31,8 @@ edx:
       - name: social-auth-mitxpro==0.2
       - name: ubcpi-xblock==0.6.4
       - name: git+https://github.com/mitodl/edx-git-auto-export.git@v0.1#egg=edx-git-auto-export
+      # Python client for Sentry
+      - name: raven
     EDXAPP_REGISTRATION_EXTRA_FIELDS:
       confirm_email: "hidden"
       level_of_education: "optional"

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -50,6 +50,13 @@ set_from_bulk_email_address_in_lms_production_file:
     - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
     - text: EMAIL_USE_DEFAULT_FROM_FOR_BULK = ENV_TOKENS.get('EMAIL_USE_DEFAULT_FROM_FOR_BULK', False)
 
+{% for app in ['lms', 'cms'] %}
+add_sentry_integration_to_{{ app }}_production_file:
+file.append:
+    - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
+    - text: RAVEN_CONFIG = ENV_TOKENS.get('RAVEN_CONFIG', {})
+{% endfor %}
+
 {% if 'mitxpro' in salt.grains.get('environment') %}
 add_social_auth_https_redirect_to_lms_production_file:
   file.append:


### PR DESCRIPTION
#### What are the relevant tickets?
[Issue#984](https://github.com/mitodl/salt-ops/issues/984)

#### What's this PR do?
Using the raven client, it integrates sentry with our openedx deployment for better visibility. I tested this by manually configuring the xpro sandbox instance and was able to trigger and observe events in sentry.
I was tempted to add the `raven` install to base requirements, but didn't want to add more changes to our own fork that might differ from upstream.

* Note: When this PR is merged, a new project for residential (openedx-xpro has already been created for testing sandbox) needs to be created in sentry. Additionally, the sentry DSN's for both projects need to be added to vault.