### PR TITLE
Add micromasters to Nginx Elasticsearch proxy

### DIFF
--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -45,7 +45,7 @@ nginx:
                 - listen:
                     - '[::]:443'
                     - ssl
-                - location ~ ^/(_alias|_aliases|discussions|_refresh|_mapping):
+                - location ~ ^/(_alias|_aliases|discussions|micromasters|_refresh|_mapping):
                     - proxy_pass: http://127.0.0.1:9200$request_uri
                     - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                     - proxy_pass_header: 'X-Api-Key'


### PR DESCRIPTION

#### What are the relevant tickets?

https://github.com/mitodl/micromasters/issues/3748
https://github.com/mitodl/salt-ops/issues/867

#### What's this PR do?

It adds `micromasters` to the allowed index patterns in the configuration for the Nginx proxies in front of the `apps` Elasticsearch clusters.
