### PR TITLE
Changes to resize residential elasticache

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -513,13 +513,13 @@ environments:
           purpose: mitx-cas
       elasticache:
         - engine: memcached
-          engine_version: '1.5.16'
-          node_type: cache.r5.large
-          num_cache_nodes: 3
+          engine_version: '1.4.34'
+          node_type: cache.m3.medium
+          num_cache_nodes: 6
           purpose: residential-live
           cluster_id: residential-live
         - engine: memcached
-          engine_version: '1.5.16'
+          engine_version: '1.4.34'
           node_type: cache.t2.small
           num_cache_nodes: 2
           purpose: residential-draft

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -188,13 +188,13 @@ environments:
           mount_point: mysql-mitxpro-qa
       elasticache:
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: xpro-edxapp
           purpose: xpro-qa
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: xpro-video
@@ -288,7 +288,7 @@ environments:
           mount_point: mysql-mitxpro-production
       elasticache:
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.r5.large
           num_cache_nodes: 3
           cluster_id: xpro-production-edxapp
@@ -342,31 +342,31 @@ environments:
           purpose: mitx-cas
       elasticache:
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: continuous-delivery
           purpose: continuous-delivery
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: current-res-live
           purpose: current-residential-live
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: current-res-draft
           purpose: current-residential-draft
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: next-res-live
           purpose: next-residential-live
         - engine: memcached
-          engine_version: '1.4.34'
+          engine_version: '1.5.16'
           node_type: cache.t2.small
           num_cache_nodes: 1
           cluster_id: next-res-draft
@@ -513,14 +513,14 @@ environments:
           purpose: mitx-cas
       elasticache:
         - engine: memcached
-          engine_version: '1.4.34'
-          node_type: cache.m3.medium
+          engine_version: '1.5.16'
+          node_type: cache.r5.large
           num_cache_nodes: 3
           purpose: residential-live
           cluster_id: residential-live
         - engine: memcached
-          engine_version: '1.4.34'
-          node_type: cache.t3.small
+          engine_version: '1.5.16'
+          node_type: cache.t2.small
           num_cache_nodes: 2
           purpose: residential-draft
           cluster_id: residential-draft
@@ -567,7 +567,7 @@ environments:
           <<: *current_residential_versions_rp
         instances:
           edx:
-            number: 9
+            number: 15
             type: r5.large
           edx-worker:
             number: 3

--- a/salt/orchestrate/aws/elasticache.sls
+++ b/salt/orchestrate/aws/elasticache.sls
@@ -3,6 +3,7 @@
 {% set env_settings = env_data.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}
+{% set release_id = (salt.sdb.get('sdb://consul/elasticache/' ~ ENVIRONMENT ~ '/release-id') or 'v1') %}
 
 {% set network_prefix = env_settings.network_prefix %}
 {% set SUBNETS_CIDR = '{}.0.0/22'.format(network_prefix) %}
@@ -61,7 +62,7 @@ create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_replication_group
 {% else %}
 create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_cluster_{{ cache_purpose }}:
   boto3_elasticache.cache_cluster_present:
-    - CacheClusterId: {{ cache_config.cluster_id[:20].strip('-') }}
+    - CacheClusterId: {{ cache_config.cluster_id }}-{{ release_id }}
     - NumCacheNodes: {{ cache_config.get('num_cache_nodes', 2) }}
     - AZMode: {{ 'cross-az' if cache_config.get('num_cache_nodes', 2) > 1 else 'single-az' }}
 {% endif %}

--- a/salt/orchestrate/aws/elasticache.sls
+++ b/salt/orchestrate/aws/elasticache.sls
@@ -3,7 +3,6 @@
 {% set env_settings = env_data.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}
-{% set release_id = (salt.sdb.get('sdb://consul/elasticache/' ~ ENVIRONMENT ~ '/release-id') or 'v1') %}
 
 {% set network_prefix = env_settings.network_prefix %}
 {% set SUBNETS_CIDR = '{}.0.0/22'.format(network_prefix) %}
@@ -62,7 +61,7 @@ create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_replication_group
 {% else %}
 create_{{ ENVIRONMENT }}_elasticache_{{ cache_config.engine }}_cluster_{{ cache_purpose }}:
   boto3_elasticache.cache_cluster_present:
-    - CacheClusterId: {{ cache_config.cluster_id }}-{{ release_id }}
+    - CacheClusterId: {{ cache_config.cluster_id[:20].strip('-') }}
     - NumCacheNodes: {{ cache_config.get('num_cache_nodes', 2) }}
     - AZMode: {{ 'cross-az' if cache_config.get('num_cache_nodes', 2) > 1 else 'single-az' }}
 {% endif %}


### PR DESCRIPTION
#### What's this PR do?
A few weeks ago we experienced a tremendous load on the residential instances caused by what was determined to be a quiz for 8.01L. Another one is scheduled for this coming Monday and we have to decided to make the following changes:
- Add an additional 6 edxapp instances to the existing pool
- Build a new elasticache memcached cluster (can't resize individual nodes) using instances types with more memory and the latest engine as we've seen some cache evictions, albeit a low number, but worth a change.

* Note: While trying to figure out what to name the new cluster given the 20 char limitation faced previously, I noticed that the limitation is now 50 chars. I tried creating a cluster through the console and also confirmed that by checking out [boto3's elasticache library](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticache.html#ElastiCache.Client.create_cache_cluster)

