### PR TITLE
Added memcached config options

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -22,6 +22,8 @@
   {% set edxapp_upload_storage_prefix = 'submissions_attachments_dev' %}
   {% set edxapp_log_env_suffix = 'dev' %}
 {% endif %}
+# Set max memcached object to 2MB
+{% set memcached_server_max_value_length = 2097152 %}
 
 {% if environment == 'mitx-production' %}
     {% if 'draft' in purpose %}
@@ -78,6 +80,8 @@ edx:
     EDXAPP_GOOGLE_ANALYTICS_ACCOUNT: {{ edxapp_google_analytics_account }}
     EDXAPP_YOUTUBE_API_KEY: __vault__::secret-residential/global/edxapp-youtube-api-key>data>value
     EDXAPP_SUPPORT_SITE_LINK: 'https://odl.zendesk.com/hc/en-us/requests/new'
+    EDXAPP_CACHE_OPTIONS:
+      'server_max_value_length': {{ memcached_server_max_value_length }}
 
     EDXAPP_LMS_AUTH_EXTRA:
       SECRET_KEY: __vault__:gen_if_missing:secret-residential/global/edxapp-lms-django-secret-key>data>value


### PR DESCRIPTION
#### What's this PR do?
This is tied to the [addition](https://github.com/mitodl/configuration/pull/87) added to the `edx/configuration` fork to be able to configure the memcached server max value from its default of 1MB to 2MB. This is a temporary fix as we need to refactor our elasticache state since the value specified here needs to match or at least not exceed the value set in the parameter group of the elasticache cluster.