### PR TITLE
Updated instance type and count for Redash workers

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -609,7 +609,7 @@ environments:
     purposes:
       redash:
         app: redash
-        num_instances: 2
+        num_instances: 3
         domains:
           - bi.odl.mit.edu
         business_unit: operations

--- a/salt/orchestrate/aws/cloud_profiles/redash.conf
+++ b/salt/orchestrate/aws/cloud_profiles/redash.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 redash:
   provider: mitx
-  size: r5.large
+  size: m5.xlarge
   image: sdb://consul/debian_ami_id
   ssh_username: admin
   ssh_interface: private_ips


### PR DESCRIPTION
Redash periodically has a flood of tasks which causes a bottleneck and poor user experience. Increasing instance size for more CPU cores and adding to instance count.

#### What are the relevant tickets?
N/A

#### What's this PR do?
Increases instance size and count for Redash to scale Celery

#### How should this be manually tested?
N/A