### PR TITLE
Add EDX_API_ACCESS_TOKEN_URL to discussions

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -116,6 +116,7 @@ heroku:
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/opendiscussions
     {% endif %}
     DEBUG: {{ env_data.DEBUG }}
+    EDX_API_ACCESS_TOKEN_URL: https://api.edx.org/oauth2/v1/access_token
     EDX_API_CLIENT_ID: __vault__::secret-{{ business_unit }}/{{ env_data.vault_env_path }}/edx-api-client>data>id
     EDX_API_CLIENT_SECRET: __vault__::secret-{{ business_unit }}/{{ env_data.vault_env_path }}/edx-api-client>data>secret
     EDX_API_URL: https://api.edx.org/catalog/v1/catalogs/10/courses


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/open-discussions/issues/2276

#### What's this PR do?
Adds the new environment variable introduced [here](https://github.com/mitodl/open-discussions/commit/69d506380155064857a713da139ad5b4947fc17d#diff-6a1b6963e828b69fcc667e3c45df78bbR54-R57).

#### How should this be manually tested?
Deploy to CI