### PR TITLE
Fixing list rendering in vault pki

### DIFF
--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -7,10 +7,14 @@
 {% set street_address = '77 Massachusetts Ave' %}
 {% set postal_code = '02139' %}
 
+{% set key_usage_list = "{'key_usage': '["DigitalSignature", "KeyAgreement", "KeyEncipherment"]'}"|load_json %}
+
 vault:
   roles:
     {% for env_name, env_data in env_settings.environments.items() %}
     {% for app in env_data.get('backends', {}).get('pki', []) %}
+    {% set server_allowed_domains = "{'allowed_domains': '["{}.service.consul", "nearest-{}.query.consul", "{}-master.service.consul", "{}.service.operations.consul"]'.format(app)}"|load_json %}
+    {% set client_allowed_domains = "{'allowed_domains': '["{}.*.{}"]'.format(app, env_name)}"|load_json %}
     {% for type in ['client', 'server'] %}
     {{ app }}-{{ env_name }}-{{ type }}-pki:
       backend: pki-intermediate-{{ env_name }}
@@ -18,10 +22,10 @@ vault:
       options:
         {% if type == 'server' %}
         server_flag: true
-        allowed_domains: '["{{ app }}.service.consul", "nearest-{{ app }}.query.consul", "{{ app }}-master.service.consul", "{{ app }}.service.operations.consul"]'
+        allowed_domains: {{ server_allowed_domains.allowed_domains }}
         {% else %}
         client_flag: true
-        allowed_domains: '["{{ app }}.*.{{ env_name }}"]'
+        allowed_domains: {{ client_allowed_domains.allowed_domains }}
         allow_glob_domains: true
         {% endif %}
         ttl: {{ ttl }}
@@ -29,7 +33,7 @@ vault:
         allow_bare_domains: true
         key_type: rsa
         key_bits: 4096
-        key_usage: '["DigitalSignature", "KeyAgreement", "KeyEncipherment"]'
+        key_usage: {{ key_usage_list.key_usage }}
         ou: {{ ou }}
         organization: {{ org }}
         country: {{ country }}


### PR DESCRIPTION
#### What's this PR do?
Vault pki roles is rendering keys that have list values in the following fashion:
`allowed_domains":["['fluentd.service.consul'" ...`

I'm hoping this PR would address the problem as I made changes based on load_filters in [this](https://docs.saltstack.com/en/latest/ref/renderers/all/salt.renderers.jinja.html) doc.

