### PR TITLE
Renaming and recreating security group for master SSH

### DIFF
--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -10,7 +10,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|rejectattr('availability_zone', '==', 'us-east-1e')|map(attribute='id')|list %}
 {% set security_groups = env_data.purposes[app_name].get('security_groups', []) %}
-{% do security_groups.extend(['salt_master', 'consul-agent']) %}
+{% do security_groups.extend(['master-ssh', 'consul-agent']) %}
 {% set release_id = (salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id') or 'v1') %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 

--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -361,13 +361,13 @@ create_postgres_rds_security_group:
         OU: {{ BUSINESS_UNIT }}
         Environment: {{ ENVIRONMENT }}
 
-create_salt_master_security_group:
+create_master_ssh_security_group:
   boto_secgroup.present:
-    - name: salt_master-{{ ENVIRONMENT }}
+    - name: master-ssh-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL for allowing access to hosts from Salt Master
     - tags:
-        Name: salt_master-{{ ENVIRONMENT }}
+        Name: master-ssh-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
     - rules:
         - ip_protocol: tcp

--- a/salt/orchestrate/aws/mitxpro_autoscaling.sls
+++ b/salt/orchestrate/aws/mitxpro_autoscaling.sls
@@ -14,7 +14,7 @@
 {% else %}
 {% set security_groups = ['edx-worker'] %}
 {% endif %}
-{% do security_groups.extend(['salt_master', 'consul-agent', 'default']) %}
+{% do security_groups.extend(['master-ssh', 'consul-agent', 'default']) %}
 {% set subnet_ids = salt.boto_vpc.describe_subnets(vpc_id=salt.boto_vpc.describe_vpcs(name=VPC_NAME).vpcs[0].id).subnets|map(attribute='id')|list %}
 
 {% set region = 'us-east-1' %}

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -15,9 +15,9 @@
 {% set MIT_VPN_0_CIDR = '18.28.0.0/16' %}
 {% set MIT_VPN_1_CIDR = '18.30.0.0/16' %}
 
-create_salt_master_security_group:
+create_master_ssh_security_group:
   boto_secgroup.present:
-    - name: salt_master-{{ ENVIRONMENT }}
+    - name: master-ssh-{{ ENVIRONMENT }}
     - vpc_name: {{ VPC_NAME }}
     - description: ACL to allow Salt master to SSH to instances
     - rules:
@@ -28,7 +28,7 @@ create_salt_master_security_group:
             - 10.0.0.0/22
             - 10.1.0.0/22
     - tags:
-        Name: salt-master-{{ ENVIRONMENT }}
+        Name: master-ssh-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}
         Department: {{ BUSINESS_UNIT }}
         OU: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -58,7 +58,7 @@ deploy_backup_instance_to_{{ ENVIRONMENT }}:
               SubnetId: {{ subnet_ids[0] }}
               SecurityGroupId:
                 - {{ salt.boto_secgroup.get_group_id(
-                     'salt_master-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
+                     'master-ssh-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(
                      'edx-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -70,7 +70,7 @@ create_edx_baseline_instance_in_{{ ENVIRONMENT }}:
               - {{ salt.boto_secgroup.get_group_id(
               'default', vpc_name=VPC_NAME) }}
               - {{ salt.boto_secgroup.get_group_id(
-              'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+              'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
               - {{ salt.boto_secgroup.get_group_id(
               'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
             SubnetId: {{ subnet_ids[0] }}
@@ -104,7 +104,7 @@ create_edx_worker_baseline_instance_in_{{ ENVIRONMENT }}:
               - {{ salt.boto_secgroup.get_group_id(
               'default', vpc_name=VPC_NAME) }}
               - {{ salt.boto_secgroup.get_group_id(
-              'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+              'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
               - {{ salt.boto_secgroup.get_group_id(
               'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
             SubnetId: {{ subnet_ids[0] }}

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -56,7 +56,7 @@ generate_edx_cloud_map_file:
           default: {{ salt.boto_secgroup.get_group_id(
               'default', vpc_name=VPC_NAME) }}
           salt-master: {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           consul-agent: {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}

--- a/salt/orchestrate/edx/mitx_analytics.sls
+++ b/salt/orchestrate/edx/mitx_analytics.sls
@@ -35,7 +35,7 @@ generate_analytics_edx_cloud_map_file:
           default: {{ salt.boto_secgroup.get_group_id(
               'default', vpc_name=VPC_NAME) }}
           salt-master: {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           public-ssh: {{ salt.boto_secgroup.get_group_id(
             'public-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           consul-agent: {{ salt.boto_secgroup.get_group_id(

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -59,7 +59,7 @@ deploy_restore_instance_to_{{ ENVIRONMENT }}:
               SubnetId: {{ subnet_ids[0] }}
               SecurityGroupId:
                 - {{ salt.boto_secgroup.get_group_id(
-                     'salt_master-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
+                     'master-ssh-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(
                      'edx-{}'.format(VPC_RESOURCE_SUFFIX), vpc_name=VPC_NAME) }}
                 - {{ salt.boto_secgroup.get_group_id(

--- a/salt/orchestrate/edx/xqwatcher.sls
+++ b/salt/orchestrate/edx/xqwatcher.sls
@@ -23,7 +23,7 @@ ensure_instance_profile_exists_for_xqwatcher:
 {% for course in env_data.purposes[app_name].courses %}
 {% set INSTANCE_COUNT = course.num_instances %}
 {% set security_groups = course.get('security_groups', []) %}
-{% do security_groups.extend(['salt_master', 'consul-agent']) %}
+{% do security_groups.extend(['master-ssh', 'consul-agent']) %}
 generate_xqwatcher_{{ course.name }}_cloud_map_file:
   file.managed:
     - name: /etc/salt/cloud.maps.d/{{ ENVIRONMENT }}_xqwatcher_map.yml

--- a/salt/orchestrate/operations/services/kibana.sls
+++ b/salt/orchestrate/operations/services/kibana.sls
@@ -32,7 +32,7 @@ generate_{{ app_name }}_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'webapp-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}

--- a/salt/orchestrate/reddit/init.sls
+++ b/salt/orchestrate/reddit/init.sls
@@ -10,7 +10,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|map(attribute='id')|list %}
 {% set security_groups = env_data.purposes[app_name].get('security_groups', []) %}
-{% do security_groups.extend(['salt_master', 'consul-agent']) %}
+{% do security_groups.extend(['master-ssh', 'consul-agent']) %}
 
 load_{{ app_name }}_cloud_profile:
   file.managed:

--- a/salt/orchestrate/services/cassandra.sls
+++ b/salt/orchestrate/services/cassandra.sls
@@ -45,7 +45,7 @@ generate_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'scylladb-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids }}

--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -45,9 +45,7 @@ generate_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'consul-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
-          - {{ salt.boto_secgroup.get_group_id(
-            'salt-master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -40,7 +40,7 @@ generate_elasticsearch_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'elasticsearch-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}

--- a/salt/orchestrate/services/mongodb.sls
+++ b/salt/orchestrate/services/mongodb.sls
@@ -57,7 +57,7 @@ generate_mongodb_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'mongodb-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(

--- a/salt/orchestrate/services/rabbitmq.sls
+++ b/salt/orchestrate/services/rabbitmq.sls
@@ -58,7 +58,7 @@ generate_rabbitmq_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'rabbitmq-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(

--- a/salt/orchestrate/services/scylladb.sls
+++ b/salt/orchestrate/services/scylladb.sls
@@ -53,7 +53,7 @@ generate_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'scylladb-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}
         profile_overrides:
           userdata_file: '/etc/salt/cloud.d/edx_userdata.yml'


### PR DESCRIPTION
Moving master-ssh security group to be consistent everywhere and make the purpose clearer