### PR TITLE
Updated Consul DNS for operations services to simplify discovery

### DIFF
--- a/pillar/elastic_stack/beats/init.sls
+++ b/pillar/elastic_stack/beats/init.sls
@@ -17,7 +17,7 @@ elastic_stack:
           - add_host_metadata: ~
         output.elasticsearch:
           hosts:
-            - http://elasticsearch.service.operations.consul:9200
+            - http://operations-elasticsearch.query.consul:9200
           compression_level: 3
       modules:
         system:

--- a/pillar/fluentd/consul.sls
+++ b/pillar/fluentd/consul.sls
@@ -34,5 +34,5 @@ fluentd:
             - nested_directives:
               - directive: server
                 attrs:
-                  - host: fluentd.service.operations.consul
+                  - host: operations-fluentd.query.consul
                   - port: 5001

--- a/pillar/fluentd/elasticsearch.sls
+++ b/pillar/fluentd/elasticsearch.sls
@@ -32,5 +32,5 @@ fluentd:
             - nested_directives:
               - directive: server
                 attrs:
-                  - host: fluentd.service.operations.consul
+                  - host: operations-fluentd.query.consul
                   - port: 5001

--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -130,5 +130,5 @@ fluentd:
             - nested_directives:
                 - directive: server
                   attrs:
-                    - host: fluentd.service.operations.consul
+                    - host: operations-fluentd.query.consul
                     - port: 5001

--- a/pillar/fluentd/mongodb.sls
+++ b/pillar/fluentd/mongodb.sls
@@ -37,5 +37,5 @@ fluentd:
             - nested_directives:
               - directive: server
                 attrs:
-                  - host: fluentd.service.operations.consul
+                  - host: operations-fluentd.query.consul
                   - port: 5001

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -50,5 +50,5 @@ fluentd:
             - nested_directives:
                 - directive: server
                   attrs:
-                    - host: fluentd.service.operations.consul
+                    - host: operations-fluentd.query.consul
                     - port: 5001

--- a/pillar/fluentd/rabbitmq.sls
+++ b/pillar/fluentd/rabbitmq.sls
@@ -33,5 +33,5 @@ fluentd:
             - nested_directives:
               - directive: server
                 attrs:
-                  - host: fluentd.service.operations.consul
+                  - host: operations-fluentd.query.consul
                   - port: 5001

--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -81,5 +81,5 @@ fluentd:
             - nested_directives:
                 - directive: server
                   attrs:
-                    - host: fluentd.service.operations.consul
+                    - host: operations-fluentd.query.consul
                     - port: 5001

--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -199,7 +199,7 @@ fluentd:
                   - '@type': elasticsearch_dynamic
                   - logstash_format: 'true'
                   - flush_interval: '10s'
-                  - hosts: elasticsearch.service.operations.consul
+                  - hosts: operations-elasticsearch.query.consul
                   - logstash_prefix: 'logstash-${record.fetch("environment", "blank") != "blank" ? record.fetch("environment") : tag_parts[0]}'
                   - include_tag_key: 'true'
                   - tag_key: fluentd_tag

--- a/pillar/fluentd/xqwatcher.sls
+++ b/pillar/fluentd/xqwatcher.sls
@@ -51,5 +51,5 @@ fluentd:
             - nested_directives:
                 - directive: server
                   attrs:
-                    - host: fluentd.service.operations.consul
+                    - host: operations-fluentd.query.consul
                     - port: 5001

--- a/pillar/master/config.sls
+++ b/pillar/master/config.sls
@@ -55,7 +55,7 @@ salt_master:
       log_granular_levels:
         'py.warnings': 'quiet'
       logstash_udp_handler:
-        host: fluentd.service.operations.consul
+        host: fluentd.service.consul
         port: 9999
         version: 1
     reactors:
@@ -111,7 +111,7 @@ salt_master:
     sdb:
       consul:
         driver: consul
-        host: consul.service.operations.consul
+        host: consul.service.consul
       osenv:
         driver: env
     vault:
@@ -214,7 +214,7 @@ salt_master:
     sdb:
       consul:
         driver: consul
-        host: consul.service.operations.consul
+        host: consul.service.consul
   proxy_configs:
     apps:
       {% if 'qa' in purpose %}

--- a/salt/consul/query_template.sls
+++ b/salt/consul/query_template.sls
@@ -18,3 +18,29 @@ create_query_template_for_nearest_service:
     - match_type: pcre
     - decode: True
     - raise_error: False
+
+create_query_template_for_ops_service:
+  http.query:
+    - name: 'http://consul.service.consul:8500/v1/query'
+    - method: POST
+    - data: >-
+        {
+          "Name": "operations",
+          "Service": {
+            "Failover": {
+              "Datacenters": [
+                "operations",
+                "operations-qa"
+              ]
+            },
+            "Service": "${match(1)}"
+          },
+          "Template": {
+            "Regexp": "^operations-(.*?)$",
+            "Type": "name_prefix_match"
+          }
+        }
+    - match: (ID|existing)
+    - match_type: pcre
+    - decode: True
+    - raise_error: False


### PR DESCRIPTION
With the introduction of the operations-qa environment there were a number of hardcoded DNS records that would fail to resolve for QA services. Added a query template to allow for querying operations and operations-qa environments based on what is reachable to the given client, removing the need to generate a mapping of which envs talk to which other envs.

#### What are the relevant tickets?
#1050 

#### What's this PR do?
Adds a query template for Consul DNS to simplify operations services discovery

#### How should this be manually tested?
Apply the template and run a dig command for the relevant services