### PR TITLE
Added configuration for Open youtube integration

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -207,6 +207,7 @@ heroku:
     USE_X_FORWARDED_PORT: True
     XPRO_CATALOG_API_URL: https://{{ env_data.MITXPRO_BASE_URL }}/api/programs/
     XPRO_COURSES_API_URL: https://{{ env_data.MITXPRO_BASE_URL }}/api/courses/
+    YOUTUBE_DEVELOPER_KEY: __vault__::secret-{{ business_unit }}/{{ environment }}/youtube-developer-key>data>value
 
 schedule:
   refresh_{{ env_data.app_name }}_configs:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/open-discussions/issues/2349

#### What's this PR do?
Adds a variable for configuring per-environment developer keys. Please double-check that I wrote the vault variable correctly based on how you guys structure those

#### How should this be manually tested?
For each environment, we'll need separate developer keys, instructions on how to create these are here:

https://developers.google.com/youtube/v3/getting-started#before-you-start

They can be testing with this curl command (bad credentials will 403, otherwise you should see data):

```bash
curl "https://www.googleapis.com/youtube/v3/channels?id=UCEBb1b_L6zDS3xTUrIALZOw&part=snippet&key=$YOUR_API_KEY"
```