### PR TITLE
Fix FluentD error about buffer path

### DIFF
--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -285,7 +285,7 @@ fluentd:
                       - directive: buffer
                         attrs:
                           - '@type': file
-                          - path: {{ fluentd_directories.residential_tracking_logs }}
+                          - path: {{ fluentd_directories.xpro_tracking_logs }}
                           - timekey: 3600
                           - timekey_wait: '10m'
                           - timekey_use_utc: 'true'


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes https://github.com/mitodl/salt-ops/issues/1070

#### What's this PR do?

Fixes FluentD error about duplicate buffer path.
See issue above.