### PR TITLE
Fixed missing celery task logs

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -182,7 +182,7 @@ uwsgi:
         - touch-reload: /opt/{{ app_name }}/deploy_complete.txt
         - uid: deploy
         - attach-daemon2: >-
-            cmd=/usr/local/pyenv/versions/{{ python_version }}/bin/celery worker -A odl_video -B --pidfile /opt/{{ app_name }}/celery.pid,
+            cmd=/usr/local/pyenv/versions/{{ python_version }}/bin/celery worker -A odl_video -B --pidfile /opt/{{ app_name }}/celery.pid -l {{ env_data.log_level }},
             pidfile=/opt/{{ app_name }}/celery.pid,
             daemonize=true,
             touch=/opt/{{ app_name}}/deploy_complete.txt


### PR DESCRIPTION
#### What's this PR do?
Noticed that the celery task logs weren't showing up `/var/log/uwsgi/apps/odl-video-service.log`. After reading docs and testing the fix by adding `-l LOG_LEVEL` to the launch daemon, celery task logs started showing up. 