### PR TITLE
Fix sdb path and make it consistent with others

### DIFF
--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -10,7 +10,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|rejectattr('availability_zone', 'equalto', 'us-east-1e')|map(attribute='id')|list %}
 {% set app_name = 'consul' %}
-{% set release_id = salt.sdb.get('sdb://osenv/RELEASE_ID') %}
+{% set release_id = salt.sdb.get('sdb://consul/osenv/release-id') %}
 {% if not release_id %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
 {% endif %}

--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -10,10 +10,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|rejectattr('availability_zone', 'equalto', 'us-east-1e')|map(attribute='id')|list %}
 {% set app_name = 'consul' %}
-{% set release_id = salt.sdb.get('sdb://consul/osenv/release-id') %}
-{% if not release_id %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
-{% endif %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 
 load_consul_cloud_profile:

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -11,10 +11,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|rejectattr('availability_zone', 'equalto', 'us-east-1e')|map(attribute='id')|list %}
 {% set app_name = 'elasticsearch' %}
-{% set release_id = salt.sdb.get('sdb://consul/osenv/release-id') %}
-{% if not release_id %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
-{% endif %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
 
 load_elasticsearch_cloud_profile:

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -11,7 +11,7 @@
         name=env_data.vpc_name).vpcs[0].id
     ).subnets|rejectattr('availability_zone', 'equalto', 'us-east-1e')|map(attribute='id')|list %}
 {% set app_name = 'elasticsearch' %}
-{% set release_id = salt.sdb.get('sdb://osenv/RELEASE_ID') %}
+{% set release_id = salt.sdb.get('sdb://consul/osenv/release-id') %}
 {% if not release_id %}
 {% set release_id = salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id')|default('v1') %}
 {% endif %}


### PR DESCRIPTION
#### What's this PR do?
When running a build on one of the instances of a consul cluster, ran into a problem where the call to `sdb://osenv/RELEASE_ID` was not being rendered. Initially I assumed I needed to add the right value to the sdb, however when I tried doing that, it was add the call itself to sdb and not the value specified. Upon reading [documentation](https://docs.saltstack.com/en/latest/topics/sdb/#sdb-configuration), my understanding is that the `profile` specified in the config file for sdb, in our case `consul`, needs to be in the path name. Once I renamed the path and added consul, it worked. While making that change, I noticed that most of our calls to sdb, we use `release-id` instead of `RELEASE_ID`, so ended up modifying that as well for consistency.

