### PR TITLE
Use new "stable" branch for MITx current residential

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -41,7 +41,7 @@ current_residential_versions_rp: &current_residential_versions_rp
   edx_config_repo: https://github.com/mitodl/configuration
   edx_config_version: open-release/ironwood.master
   edx_platform_repo: 'https://github.com/mitodl/edx-platform'
-  edxapp: mitx/ironwood
+  edxapp: mitx/ironwood-stable
   forum_source_repo: 'https://github.com/mitodl/cs_comments_service'
   forum: open-release/ironwood.master
   xqueue_source_repo: 'https://github.com/mitodl/xqueue'

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -25,7 +25,7 @@ current_residential_versions_qa: &current_residential_versions_qa
   edx_config_repo: https://github.com/mitodl/configuration
   edx_config_version: open-release/ironwood.master
   edx_platform_repo: 'https://github.com/mitodl/edx-platform'
-  edxapp: mitx/ironwood
+  edxapp: mitx/ironwood-stable
   forum_source_repo: 'https://github.com/mitodl/cs_comments_service'
   forum: open-release/ironwood.master
   xqueue_source_repo: 'https://github.com/mitodl/xqueue'


### PR DESCRIPTION
@blarghmatey, per our discussion, I'm trying to update `environement_settings.yml` to use the new `mitx/ironwood-stable` branch that we created in order to safely cherry-pick some changes onto the `mitx/ironwood` branch.

Is this change sufficient, or should I also modify any of the other values of `mitx/ironwood`?
