### PR TITLE
Adjust nginx max_body_size

### DIFF
--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -49,6 +49,7 @@ nginx:
                     - proxy_pass: http://127.0.0.1:9200$request_uri
                     - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                     - proxy_pass_header: 'X-Api-Key'
+                    - client_max_body_size: '20m'
                 - location /_search/scroll:
                     - proxy_pass: http://127.0.0.1:9200$request_uri
                     - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'


### PR DESCRIPTION
#### What are the relevant tickets?
In response to the [sentry issue](https://sentry.io/organizations/mit-office-of-digital-learning/issues/1369981344/?project=216201) reported 

#### What's this PR do?
This increases the default of 1mb to 20mb. I picked 20 cause that's what we have in edx, not that is any indication of a good measure, but mainly for parity. The [setting](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) can be in either the http, server, or location contexts and I chose the one that's most restrictive.