### PR TITLE
Tweaks to edx.tracking

### DIFF
--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -115,7 +115,7 @@ fluentd:
             - path: /edx/var/log/tracking/tracking.log
             - pos_file: /edx/var/log/tracking/tracking.log.pos
             - format: json
-            - time_format: '%Y-%m-%dT%H:%M:%S.%N+%z'
+            - time_format: '%Y-%m-%dT%H:%M:%S.%N+%:z'
         - {{ auth_log_source('syslog.auth', '/var/log/auth.log') }}
         - {{ auth_log_filter('grep', 'ident', 'python') }}
         - {{ record_tagging |yaml() }}

--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -133,7 +133,7 @@ fluentd:
                     - s3_region: us-east-1
                     - path: logs/
                     - s3_object_key_format: '%{path}%{time_slice}_%{index}.%{file_extension}'
-                    - time_slice_format: '%Y-%m-%d'
+                    - time_slice_format: '%Y-%m-%d-%H'
                     - nested_directives:
                       - directive: buffer
                         attrs:
@@ -278,7 +278,7 @@ fluentd:
                     - s3_region: us-east-1
                     - path: logs/
                     - s3_object_key_format: '%{path}%{time_slice}_%{index}.%{file_extension}'
-                    - time_slice_format: '%Y-%m-%d-%H'
+                    - time_slice_format: '%Y-%m-%d'
                     - nested_directives:
                       - directive: buffer
                         attrs:

--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -242,7 +242,7 @@ fluentd:
                     - s3_region: us-east-1
                     - path: logs/
                     - s3_object_key_format: '%{path}%{time_slice}_%{index}.%{file_extension}'
-                    - time_slice_format: '%Y-%m-%d'
+                    - time_slice_format: '%Y-%m-%d-%H'
                     - nested_directives:
                       - directive: buffer
                         attrs:
@@ -263,7 +263,11 @@ fluentd:
                   directive_arg: 'edx.tracking'
                   attrs:
                     - '@type': grep
-                    - regexp1: environment mitxpro-production
+                    - nested_directives:
+                      - directive: regexp
+                        attrs:
+                          - key: environment
+                          - pattern: mitxpro-production
                 - directive: match
                   directive_arg: edx.tracking
                   attrs:
@@ -274,7 +278,7 @@ fluentd:
                     - s3_region: us-east-1
                     - path: logs/
                     - s3_object_key_format: '%{path}%{time_slice}_%{index}.%{file_extension}'
-                    - time_slice_format: '%Y-%m-%d'
+                    - time_slice_format: '%Y-%m-%d-%H'
                     - nested_directives:
                       - directive: buffer
                         attrs:


### PR DESCRIPTION
#### What's this PR do?
This is in response to Ike's comment about the tracking logs in BigQuery missing the time stamp. The logs showing up in Kibana do have the `@timestamp` in but they don't appear in the S3 files. Also noticed that the xpro-production s3 bucket doesn't have the latest tracking logs.
