### PR TITLE
Ensure same version for Elastic Stack products

### DIFF
--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -2,7 +2,6 @@
 
 elastic_stack:
   elasticsearch:
-    version: '6.x'
     configuration_settings:
       discovery:
         zen.hosts_provider: ec2

--- a/pillar/elastic_stack/version_production.sls
+++ b/pillar/elastic_stack/version_production.sls
@@ -1,0 +1,2 @@
+elastic_stack:
+  version: 6.8.4

--- a/pillar/elastic_stack/version_qa.sls
+++ b/pillar/elastic_stack/version_qa.sls
@@ -1,0 +1,2 @@
+elastic_stack:
+  version: 6.8.5

--- a/pillar/elasticsearch/init.sls
+++ b/pillar/elasticsearch/init.sls
@@ -1,6 +1,7 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 
 elasticsearch:
+  version: '6.x'
   lookup:
     elastic_stack: True
     configuration_settings:

--- a/pillar/elasticsearch/init.sls
+++ b/pillar/elasticsearch/init.sls
@@ -1,7 +1,6 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 
 elasticsearch:
-  version: '6.x'
   lookup:
     elastic_stack: True
     configuration_settings:

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -23,6 +23,12 @@ base:
     - monit
     - monit.lms_503
     - logrotate.kibana
+  'G@roles:kibana and G@environment:operations-qa':
+    - match: grain
+    - elastic_stack.version_qa
+  'G@roles:kibana and G@environment:operations':
+    - match: grain
+    - elastic_stack.version_production
   'roles:master':
     - match: grain
     - master


### PR DESCRIPTION
Per recent changes to elastic-stack-formula, use one version variable for all Elastic Stack products.

See https://github.com/mitodl/elastic-stack-formula/pull/9