### PR TITLE
Set Elasticsearch cluster.initial_master_nodes for v7

### DIFF
--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -1,4 +1,13 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
+{% set es_hostnames = [] %}
+{% for host, addr in salt.saltutil.runner(
+    'mine.get',
+    tgt='G@roles:elasticsearch and G@environment:{}'.format(ENVIRONMENT),
+    fun='grains.item',
+    tgt_type='compound').items() %}
+{% do es_hostnames.append(host) %}
+{% endfor %}
+{% version_data = salt.cp.get_file_str('salt://elastic_stack/version_{}.sls'.format(ENVIRONMENT))|load_yaml %}
 
 elastic_stack:
   elasticsearch:
@@ -8,5 +17,11 @@ elastic_stack:
       cluster.name: {{ ENVIRONMENT }}
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       network.host: ['_eth0:ipv4_', '_lo:ipv4_']
+      {% if version_data.elastic_stack.version.startswith('7') %}
+      cluster.initial_master_nodes:
+        {%- for hostname in es_hostnames %}
+        - {{ hostname }}
+        {%- endfor -%}
+      {% endif %}
     plugins:
       - name: discovery-ec2

--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -1,13 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
-{% set es_hostnames = [] %}
-{% for host, addr in salt.saltutil.runner(
-    'mine.get',
-    tgt='G@roles:elasticsearch and G@environment:{}'.format(ENVIRONMENT),
-    fun='grains.item',
-    tgt_type='compound').items() %}
-{% do es_hostnames.append(host) %}
-{% endfor %}
-{% version_data = salt.cp.get_file_str('salt://elastic_stack/version_{}.sls'.format(ENVIRONMENT))|load_yaml %}
+{% set version = salt.pkg.version('elasticsearch').split('.')[0]|int %}
 
 elastic_stack:
   elasticsearch:
@@ -17,11 +9,9 @@ elastic_stack:
       cluster.name: {{ ENVIRONMENT }}
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       network.host: ['_eth0:ipv4_', '_lo:ipv4_']
-      {% if version_data.elastic_stack.version.startswith('7') %}
+      {% if version > 6 %}
       cluster.initial_master_nodes:
-        {%- for hostname in es_hostnames %}
-        - {{ hostname }}
-        {%- endfor -%}
+        - elasticsearch.service.consul
       {% endif %}
     plugins:
       - name: discovery-ec2

--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
-{% set version = salt.pkg.version('elasticsearch').split('.')[0]|int %}
+{% set pkg_version = salt.pkg.version('elasticsearch') | default('') %}
 
 elastic_stack:
   elasticsearch:
@@ -9,7 +9,7 @@ elastic_stack:
       cluster.name: {{ ENVIRONMENT }}
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       network.host: ['_eth0:ipv4_', '_lo:ipv4_']
-      {% if version > 6 %}
+      {% if version and version.split('.')[0]|int > 6 %}
       cluster.initial_master_nodes:
         - elasticsearch.service.consul
       {% endif %}

--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
-{% set pkg_version = salt.pkg.version('elasticsearch') | default('') %}
+{% set pkg_version = salt.pkg.version('elasticsearch').split('.')[0] %}
 
 elastic_stack:
   elasticsearch:
@@ -9,7 +9,7 @@ elastic_stack:
       cluster.name: {{ ENVIRONMENT }}
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       network.host: ['_eth0:ipv4_', '_lo:ipv4_']
-      {% if version and version.split('.')[0]|int > 6 %}
+      {% if pkg_version and pkg_version|int > 6 %}
       cluster.initial_master_nodes:
         - elasticsearch.service.consul
       {% endif %}


### PR DESCRIPTION
In the Elastic Stack for Elasticsearch pillar, set cluster.initial_master_nodes if the version of Elastic Stack is 7 or above.

This setting has been introduced with version 7 and the cluster will not run without it.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_cluster_bootstrapping_is_required_if_discovery_is_configured

I'm not sure if I've got the discovery of the cluster hostnames right. The new convention in ES 7 is for the node name to equal the hostname. I imitated some code that I saw elsewhere that employs `mine.get` for a similar purpose.

I could probably improve the `if` statement that evaluates the version number. It's hardcoded to check for version 7 specifically, which won't be right when version 8 comes out.
