### PR TITLE
Changed xpro sheets task timing settings

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -164,7 +164,8 @@ heroku:
     SENTRY_LOG_LEVEL: {{ env_data.sentry_log_level }}
     SHEETS_ADMIN_EMAILS: {{ salt.sdb.get('sdb://consul/xpro/' ~ environment ~'/sheets-admin-emails') }}
     SHEETS_DATE_TIMEZONE: America/New_York
-    SHEETS_MONITORING_FREQUENCY: 300
+    SHEETS_MONITORING_FREQUENCY: 3600
+    SHEETS_TASK_OFFSET: 120
     SITE_NAME: "MIT xPRO"
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
     USE_X_FORWARDED_HOST: {{ env_data.USE_X_FORWARDED_HOST }}


### PR DESCRIPTION
Reset xpro sheets settings so that tasks run every hour by default in all environments, and the wait time in between successive tasks in 2 minutes