### PR TITLE
Adapt to restructured Nginx formula

### DIFF
--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -1,93 +1,92 @@
 {% set app_name = 'amps-redirect' %}
 
 nginx:
-  ng:
-    install_from_source: False
-    source_version: 1.15.1
-    source_hash: c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460
-    certificates:
-      odl_wildcard:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: amps-web.amps.ms.mit.edu
-                - listen:
-                    - 80
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:80'
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may14-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/ef3aa2b5dbb14adc9c15452b0d27c436/?start=398
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may07-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/c5691b38739d4a43a232bf3ef07f1646/?start=504
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may05-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/b5cc48724aa5405c9fd7b1211a2b0b3c/
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr30-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/4656112ede89496fb100fe10b02fa304/?start=396
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr28-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/59219f99dd30490e9586ad960ad2691f/?start=463
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr23-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/9ea370cd18b14656a712e7cc723cf7a9/?start=393
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr16-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/201c33a2dab349359f5af23a293d9c5a/?start=333
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr14-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/b5cc48724aa5405c9fd7b1211a2b0b3c/
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr09-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/33abf21f4e174e6e8f21a5071c30a66f/?start=250
-                - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr07-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/65da1d1388ce400983c9447f75883760/?start=278
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar31-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/5605b2609dcc4661b7aeb0c18645d5c9/?start=301
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar19-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/4c89dc64071f4c5ea5f948b80a2201bc/?start=128
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar17-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/3d86fd1c074840988b4480356e2d4746/?start=290
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar12-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/08eaaeb932d54d119e529deac416e804/?start=331
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar10-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/d7248606616240dca81337d163a28055/?start=172
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar05-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/bc78f4af98e9492cbef7278d92156b92/?start=170
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar03-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/bc78f4af98e9492cbef7278d92156b92/?start=170
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb26-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/7dcf75a64fa54356bc2e6f0a8e38fc79/?start=272
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb24-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/c973ebdcbca34ecf868cc12a0344d8f5/?start=268
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb19-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/9178561d53b5460db360c72bd9dec2b5/?start=430
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb12-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/5d64d5e504c140a19efb1b69b5385482/
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb05-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/2f043945501941e9a0fe35e5a4bbf782/
-                - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb03-0929-L01/:
-                    - return: 301 https://video.odl.mit.edu/videos/7a11f55dd99d49349f377d2d87f0aef2/?start=341
-                - location /:
-                    - return: 301 https://docs.google.com/forms/d/e/1FAIpQLSdvkI2cPG1iMM4gN_KyKem4fNLh4irWzrmjX-JhcFXa51su5g/viewform?fbzx=2658557852628862500
+  install_from_source: False
+  source_version: 1.15.1
+  source_hash: c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460
+  certificates:
+    odl_wildcard:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: amps-web.amps.ms.mit.edu
+              - listen:
+                  - 80
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:80'
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may14-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/ef3aa2b5dbb14adc9c15452b0d27c436/?start=398
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may07-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/c5691b38739d4a43a232bf3ef07f1646/?start=504
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015may05-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/b5cc48724aa5405c9fd7b1211a2b0b3c/
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr30-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/4656112ede89496fb100fe10b02fa304/?start=396
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr28-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/59219f99dd30490e9586ad960ad2691f/?start=463
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr23-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/9ea370cd18b14656a712e7cc723cf7a9/?start=393
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr16-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/201c33a2dab349359f5af23a293d9c5a/?start=333
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr14-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/b5cc48724aa5405c9fd7b1211a2b0b3c/
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr09-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/33abf21f4e174e6e8f21a5071c30a66f/?start=250
+              - location /courses/6/6.045/2015spring/L01/MIT-6.045-lec-mit-0000-2015apr07-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/65da1d1388ce400983c9447f75883760/?start=278
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar31-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/5605b2609dcc4661b7aeb0c18645d5c9/?start=301
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar19-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/4c89dc64071f4c5ea5f948b80a2201bc/?start=128
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar17-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/3d86fd1c074840988b4480356e2d4746/?start=290
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar12-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/08eaaeb932d54d119e529deac416e804/?start=331
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar10-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/d7248606616240dca81337d163a28055/?start=172
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar05-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/bc78f4af98e9492cbef7278d92156b92/?start=170
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015mar03-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/bc78f4af98e9492cbef7278d92156b92/?start=170
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb26-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/7dcf75a64fa54356bc2e6f0a8e38fc79/?start=272
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb24-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/c973ebdcbca34ecf868cc12a0344d8f5/?start=268
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb19-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/9178561d53b5460db360c72bd9dec2b5/?start=430
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb12-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/5d64d5e504c140a19efb1b69b5385482/
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb05-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/2f043945501941e9a0fe35e5a4bbf782/
+              - location /courses/6/6.045/2015spring/MIT-6.045-lec-mit-0000-2015feb03-0929-L01/:
+                  - return: 301 https://video.odl.mit.edu/videos/7a11f55dd99d49349f377d2d87f0aef2/?start=341
+              - location /:
+                  - return: 301 https://docs.google.com/forms/d/e/1FAIpQLSdvkI2cPG1iMM4gN_KyKem4fNLh4irWzrmjX-JhcFXa51su5g/viewform?fbzx=2658557852628862500
 

--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -1,72 +1,71 @@
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 
 nginx:
-  ng:
-    server:
-      config:
-        http:
-          access_log: !!null
-      extra_config:
-        logging:
-          log_format app_metrics: >-
-            'time=$time_iso8601
-            client=$remote_addr
-            method=$request_method
-            request="$request"
-            request_length=$request_length
-            status=$status
-            bytes_sent=$bytes_sent
-            body_bytes_sent=$body_bytes_sent
-            referer=$http_referer
-            user_agent="$http_user_agent"
-            upstream_addr=$upstream_addr
-            upstream_status=$upstream_status
-            request_time=$request_time
-            upstream_response_time=$upstream_response_time
-            upstream_connect_time=$upstream_connect_time
-            upstream_header_time=$upstream_header_time'
-          access_log: /var/log/nginx/access.log app_metrics
-    dh_param:
-      dhparam.pem: __vault__::secret-operations/{{ ENVIRONMENT }}/dhparam>data>value
-    certificates:
-      apps-es:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        elasticsearch:
-          enabled: True
-          config:
-            - server:
-                - server_name: elasticsearch-{{ ENVIRONMENT }}.odl.mit.edu
-                - listen:
-                    - 443
-                    - ssl
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - location ~ ^/(_alias|_aliases|discussions|micromasters|_refresh|_mapping):
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-                    - client_max_body_size: '20m'
-                - location /_search/scroll:
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-                - location /nginx_status:
-                    - stub_status: 'on'
-                    - allow: 127.0.0.1
-                    - deny: all
-                - ssl_certificate: /etc/nginx/ssl/apps-es.crt
-                - ssl_certificate_key: /etc/nginx/ssl/apps-es.key
-                - ssl_dhparam: /etc/nginx/ssl/dhparam.pem
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 8.8.8.8
+  server:
+    config:
+      http:
+        access_log: !!null
+    extra_config:
+      logging:
+        log_format app_metrics: >-
+          'time=$time_iso8601
+          client=$remote_addr
+          method=$request_method
+          request="$request"
+          request_length=$request_length
+          status=$status
+          bytes_sent=$bytes_sent
+          body_bytes_sent=$body_bytes_sent
+          referer=$http_referer
+          user_agent="$http_user_agent"
+          upstream_addr=$upstream_addr
+          upstream_status=$upstream_status
+          request_time=$request_time
+          upstream_response_time=$upstream_response_time
+          upstream_connect_time=$upstream_connect_time
+          upstream_header_time=$upstream_header_time'
+        access_log: /var/log/nginx/access.log app_metrics
+  dh_param:
+    dhparam.pem: __vault__::secret-operations/{{ ENVIRONMENT }}/dhparam>data>value
+  certificates:
+    apps-es:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      elasticsearch:
+        enabled: True
+        config:
+          - server:
+              - server_name: elasticsearch-{{ ENVIRONMENT }}.odl.mit.edu
+              - listen:
+                  - 443
+                  - ssl
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - location ~ ^/(_alias|_aliases|discussions|micromasters|_refresh|_mapping):
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+                  - client_max_body_size: '20m'
+              - location /_search/scroll:
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+              - location /nginx_status:
+                  - stub_status: 'on'
+                  - allow: 127.0.0.1
+                  - deny: all
+              - ssl_certificate: /etc/nginx/ssl/apps-es.crt
+              - ssl_certificate_key: /etc/nginx/ssl/apps-es.key
+              - ssl_dhparam: /etc/nginx/ssl/dhparam.pem
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+              - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 8.8.8.8

--- a/pillar/nginx/init.sls
+++ b/pillar/nginx/init.sls
@@ -1,43 +1,42 @@
 nginx:
-  ng:
-    install_from_repo: True
-    server:
-      config:
-        http:
-          access_log: !!null
-      extra_config:
-        logging:
-          - log_format app_metrics: >-
-              'time=$time_iso8601
-              client=$remote_addr
-              method=$request_method
-              request="$request"
-              request_length=$request_length
-              status=$status
-              bytes_sent=$bytes_sent
-              body_bytes_sent=$body_bytes_sent
-              referer=$http_referer
-              user_agent="$http_user_agent"
-              upstream_addr=$upstream_addr
-              upstream_status=$upstream_status
-              request_time=$request_time
-              request_id=$request_id
-              upstream_response_time=$upstream_response_time
-              upstream_connect_time=$upstream_connect_time
-              upstream_header_time=$upstream_header_time'
-          - access_log: /var/log/nginx/access.log app_metrics
-    servers:
-      managed:
-        default: # Disable the default nginx config
-          enabled: False
-          deleted: True
-          config: None
-        nginx_metrics:
-          enabled: True
-          config:
-            - server:
-                - location /nginx-status:
-                    - stub_status: 'on'
-                    - access_log: 'off'
-                    - allow: 127.0.0.1
-                    - deny: all
+  install_from_repo: True
+  server:
+    config:
+      http:
+        access_log: !!null
+    extra_config:
+      logging:
+        log_format app_metrics: >-
+          'time=$time_iso8601
+          client=$remote_addr
+          method=$request_method
+          request="$request"
+          request_length=$request_length
+          status=$status
+          bytes_sent=$bytes_sent
+          body_bytes_sent=$body_bytes_sent
+          referer=$http_referer
+          user_agent="$http_user_agent"
+          upstream_addr=$upstream_addr
+          upstream_status=$upstream_status
+          request_time=$request_time
+          request_id=$request_id
+          upstream_response_time=$upstream_response_time
+          upstream_connect_time=$upstream_connect_time
+          upstream_header_time=$upstream_header_time'
+        access_log: /var/log/nginx/access.log app_metrics
+  servers:
+    managed:
+      default: # Disable the default nginx config
+        enabled: False
+        deleted: True
+        config: None
+      nginx_metrics:
+        enabled: True
+        config:
+          - server:
+              - location /nginx-status:
+                  - stub_status: 'on'
+                  - access_log: 'off'
+                  - allow: 127.0.0.1
+                  - deny: all

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -5,70 +5,69 @@
 {% set server_domain_names = env_data.purposes[app_name].domains %}
 
 nginx:
-  ng:
-    install_from_repo: True
-    certificates:
-      odl.mit.edu:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        default:
-          enabled: False
-          deleted: True
-          config: None
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /:
-                    - proxy_pass: http://localhost:5601/
-                    - proxy_set_header:
-                      - Host
-                      - $host
-                    - proxy_set_header:
-                      - X-Real-IP
-                      - $remote_addr
-                    - proxy_set_header:
-                      - X-Forwarded-For__vault__::secret-operations/global/mitca_ssl_cert>data>value
-                      - $remote_addr
-                    - proxy_headers_hash_bucket_size: 128
-                    - proxy_read_timeout: 240s
-                - ssl_client_certificate: /etc/ssl/certs/mitca.pem
-                - ssl_verify_client: 'on'
-                - set $authorized: 'no'
-                - if ($ssl_client_s_dn ~ "emailAddress=(tmacey|pdpinch|shaidar|ichuang|gsidebo|mkdavies|gschneel|mattbert|nlevesq|ferdial|maxliu|annagav|mbrdlove|jmartis)@MIT.EDU"):
-                  - set $authorized: 'yes'
-                - if ($authorized !~ "yes"):
-                  - return: 403
+  install_from_repo: True
+  certificates:
+    odl.mit.edu:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      default:
+        enabled: False
+        deleted: True
+        config: None
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /:
+                  - proxy_pass: http://localhost:5601/
+                  - proxy_set_header:
+                    - Host
+                    - $host
+                  - proxy_set_header:
+                    - X-Real-IP
+                    - $remote_addr
+                  - proxy_set_header:
+                    - X-Forwarded-For__vault__::secret-operations/global/mitca_ssl_cert>data>value
+                    - $remote_addr
+                  - proxy_headers_hash_bucket_size: 128
+                  - proxy_read_timeout: 240s
+              - ssl_client_certificate: /etc/ssl/certs/mitca.pem
+              - ssl_verify_client: 'on'
+              - set $authorized: 'no'
+              - if ($ssl_client_s_dn ~ "emailAddress=(tmacey|pdpinch|shaidar|ichuang|gsidebo|mkdavies|gschneel|mattbert|nlevesq|ferdial|maxliu|annagav|mbrdlove|jmartis)@MIT.EDU"):
+                - set $authorized: 'yes'
+              - if ($authorized !~ "yes"):
+                - return: 403

--- a/pillar/nginx/micromasters_es.sls
+++ b/pillar/nginx/micromasters_es.sls
@@ -1,64 +1,63 @@
 nginx:
-  ng:
-    dh_param:
-      dhparam.pem: __vault__::secret-micromasters/production/dhparam>data>value
-    certificates:
-      micromasters-es:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        elasticsearch:
-          enabled: True
-          config:
-            - server:
-                - server_name:
-                    - micromasters-es.odl.mit.edu
-                    - '""'
-                - listen: 80
-                - location /_cluster:
-                    - allow: 127.0.0.1
-                    - allow: 10.10.0.0/16
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-            - server:
-                - server_name:
-                    - micromasters-es.odl.mit.edu
-                    - '""'
-                - listen:
-                    - 443
-                    - ssl
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - location /_cluster:
-                    - allow: 127.0.0.1
-                    - allow: 10.10.0.0/16
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-                - location ~ ^/(_alias|_aliases|micromasters|_refresh|_mapping):
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-                - location /_search/scroll:
-                    - proxy_pass: http://127.0.0.1:9200$request_uri
-                    - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
-                    - proxy_pass_header: 'X-Api-Key'
-                - location /nginx_status:
-                    - stub_status: 'on'
-                    - allow: 127.0.0.1
-                    - deny: all
-                - ssl_certificate: /etc/nginx/ssl/micromasters-es.crt
-                - ssl_certificate_key: /etc/nginx/ssl/micromasters-es.key
-                - ssl_dhparam: /etc/nginx/ssl/dhparam.pem
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 8.8.8.8
+  dh_param:
+    dhparam.pem: __vault__::secret-micromasters/production/dhparam>data>value
+  certificates:
+    micromasters-es:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      elasticsearch:
+        enabled: True
+        config:
+          - server:
+              - server_name:
+                  - micromasters-es.odl.mit.edu
+                  - '""'
+              - listen: 80
+              - location /_cluster:
+                  - allow: 127.0.0.1
+                  - allow: 10.10.0.0/16
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+          - server:
+              - server_name:
+                  - micromasters-es.odl.mit.edu
+                  - '""'
+              - listen:
+                  - 443
+                  - ssl
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - location /_cluster:
+                  - allow: 127.0.0.1
+                  - allow: 10.10.0.0/16
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+              - location ~ ^/(_alias|_aliases|micromasters|_refresh|_mapping):
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+              - location /_search/scroll:
+                  - proxy_pass: http://127.0.0.1:9200$request_uri
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+                  - proxy_pass_header: 'X-Api-Key'
+              - location /nginx_status:
+                  - stub_status: 'on'
+                  - allow: 127.0.0.1
+                  - deny: all
+              - ssl_certificate: /etc/nginx/ssl/micromasters-es.crt
+              - ssl_certificate_key: /etc/nginx/ssl/micromasters-es.key
+              - ssl_dhparam: /etc/nginx/ssl/dhparam.pem
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+              - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 8.8.8.8

--- a/pillar/nginx/mitx_cas.sls
+++ b/pillar/nginx/mitx_cas.sls
@@ -4,101 +4,100 @@
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes['mitx-cas'].domains %}
 {% set server_domains = {
-  'mitx-qa': server_domain_names[0],
-  'mitx-production': server_domain_names[1]
-} %}
+'mitx-qa': server_domain_names[0],
+'mitx-production': server_domain_names[1]
+%}
 
 nginx:
-  ng:
-    install_from_source: True
-    source_version: 1.15.1
-    source_hash: c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460
-    certificates:
-      mitx_wildcard:
-        public_cert: __vault__::secret-operations/global/mitx_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/mitx_wildcard_cert>data>key
-    server:
-      extra_config:
-        shib_params:
-          source_path: salt://nginx/ng/files/nginx.conf
-          shib_request_set:
-            - $shib_uid $upstream_http_variable_uid
-            - $shib_eppn $upstream_http_variable_eppn
-            - $shib_given_name $upstream_http_variable_givenName
-            - $shib_mail $upstream_http_variable_mail
-            - $shib_surname $upstream_http_variable_sn
-          uwsgi_param:
-            - REMOTE_USER $shib_eppn
-            - REMOTE_USER $shib_uid if_not_empty
-            - mail $shib_mail
-            - givenName $shib_given_name
-            - sn $shib_surname
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domains[ENVIRONMENT] }} {# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domains[ENVIRONMENT] }}{# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /opt/mitx-cas/
-                - ssl_certificate: /etc/nginx/ssl/mitx_wildcard.crt
-                - ssl_certificate_key: /etc/nginx/ssl/mitx_wildcard.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.1
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /shibauthorizer:
-                    - internal: ''
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
-                - location /Shibboleth.sso:
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibresponder.sock'
-                - location /shib:
-                    - include: includes/shib_clear_headers
-                    - shib_request: /shibauthorizer
-                    - shib_request_use_headers: 'on'
-                    - include: conf.d/shib_params.conf
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/mitx-cas.sock
-                - location /:
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/mitx-cas.sock
-                - location ~* /static/(.*$):
-                    - expires: max
-                    - add_header: 'Access-Control-Allow-Origin *'
-                    - try_files:
-                        - $uri
-                        - $uri/
-                        - /staticfiles/$1
-                        - /staticfiles/$1/
-                        - =404
+  install_from_source: True
+  source_version: 1.15.1
+  source_hash: c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460
+  certificates:
+    mitx_wildcard:
+      public_cert: __vault__::secret-operations/global/mitx_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/mitx_wildcard_cert>data>key
+  server:
+    extra_config:
+      shib_params:
+        source_path: salt://nginx/ng/files/nginx.conf
+        shib_request_set:
+          - $shib_uid $upstream_http_variable_uid
+          - $shib_eppn $upstream_http_variable_eppn
+          - $shib_given_name $upstream_http_variable_givenName
+          - $shib_mail $upstream_http_variable_mail
+          - $shib_surname $upstream_http_variable_sn
+        uwsgi_param:
+          - REMOTE_USER $shib_eppn
+          - REMOTE_USER $shib_uid if_not_empty
+          - mail $shib_mail
+          - givenName $shib_given_name
+          - sn $shib_surname
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domains[ENVIRONMENT] }} {# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domains[ENVIRONMENT] }}{# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /opt/mitx-cas/
+              - ssl_certificate: /etc/nginx/ssl/mitx_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/mitx_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.1
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /shibauthorizer:
+                  - internal: ''
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
+              - location /Shibboleth.sso:
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibresponder.sock'
+              - location /shib:
+                  - include: includes/shib_clear_headers
+                  - shib_request: /shibauthorizer
+                  - shib_request_use_headers: 'on'
+                  - include: conf.d/shib_params.conf
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/mitx-cas.sock
+              - location /:
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/mitx-cas.sock
+              - location ~* /static/(.*$):
+                  - expires: max
+                  - add_header: 'Access-Control-Allow-Origin *'
+                  - try_files:
+                      - $uri
+                      - $uri/
+                      - /staticfiles/$1
+                      - /staticfiles/$1/
+                      - =404

--- a/pillar/nginx/ocw_mirror.sls
+++ b/pillar/nginx/ocw_mirror.sls
@@ -19,57 +19,56 @@
 
 
 nginx:
-  ng:
-    install_from_repo: True
-    certificates:
-      odl_wildcard:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /data2/rsync
-                - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.1
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /:
-                    - try_files:
-                        - $uri
-                        - $uri/index.htm
-                        - =404
-                    - rewrite:
-                        - ^(/[^\.\?]+[^/])$
-                        - $1/
-                        - permanent
+  install_from_repo: True
+  certificates:
+    odl_wildcard:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /data2/rsync
+              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.1
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /:
+                  - try_files:
+                      - $uri
+                      - $uri/index.htm
+                      - =404
+                  - rewrite:
+                      - ^(/[^\.\?]+[^/])$
+                      - $1/
+                      - permanent

--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -18,67 +18,66 @@
 
 
 nginx:
-  ng:
-    install_from_repo: True
-    certificates:
-      odl_wildcard:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location ~ /.well-known:
-                    - allow: all
-                - location /courses/edx_courses.json:
-                    - root: /var/www/ocw
-                    - allow: all
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /var/www/ocw
-                - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.1
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /status:
-                    - return: 200
-                - location /:
-                    - try_files:
-                        - $uri
-                        - $uri/index.htm
-                        - =404
-                    - error_page:
-                        - '404'
-                        - /jsp/error.html
-                    - rewrite:
-                        - ^(/[^\.\?]+[^/])$
-                        - $1/
-                        - permanent
+  install_from_repo: True
+  certificates:
+    odl_wildcard:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location ~ /.well-known:
+                  - allow: all
+              - location /courses/edx_courses.json:
+                  - root: /var/www/ocw
+                  - allow: all
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /var/www/ocw
+              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.1
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /status:
+                  - return: 200
+              - location /:
+                  - try_files:
+                      - $uri
+                      - $uri/index.htm
+                      - =404
+                  - error_page:
+                      - '404'
+                      - /jsp/error.html
+                  - rewrite:
+                      - ^(/[^\.\?]+[^/])$
+                      - $1/
+                      - permanent

--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -6,98 +6,97 @@
 {% set ovs_login_path = 'login' %}
 
 nginx:
-  ng:
-    install_from_source: True
-    source_version: 1.13.8
-    source_hash: 8410b6c31ff59a763abf7e5a5316e7629f5a5033c95a3a0ebde727f9ec8464c5
-    certificates:
-      ovs_web_cert:
-        public_cert: __vault__::secret-odl-video/{{ ENVIRONMENT }}/ovs_web_cert>data>value
-        private_key: __vault__::secret-odl-video/{{ ENVIRONMENT }}/ovs_web_cert>data>key
-    server:
-      extra_config:
-        shib_params:
-          source_path: salt://nginx/ng/files/nginx.conf
-          shib_request_set:
-            - $shib_remote_user $upstream_http_variable_remote_user
-            - $shib_eppn $upstream_http_variable_eppn
-            - $shib_mail $upstream_http_variable_mail
-            - $shib_displayname $upstream_http_variable_displayname
-          uwsgi_param:
-            - REMOTE_USER $shib_remote_user
-            - EPPN $shib_eppn
-            - MAIL $shib_mail
-            - DISPLAY_NAME $shib_displayname
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /opt/odl-video-service/
-                - ssl_certificate: /etc/nginx/ssl/ovs_web_cert.crt
-                - ssl_certificate_key: /etc/nginx/ssl/ovs_web_cert.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1
-                    - TLSv1.1
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /shibauthorizer:
-                    - internal: ''
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
-                - location /Shibboleth.sso:
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibresponder.sock'
-                - location /{{ ovs_login_path }}:
-                    - include: includes/shib_clear_headers
-                    - shib_request: /shibauthorizer
-                    - shib_request_use_headers: 'on'
-                    - include: conf.d/shib_params.conf
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
-                - location /status:
-                    - include: uwsgi_params
-                    - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
-                - location /:
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
-                - location ~* /static/(.*$):
-                    - expires: max
-                    - add_header: 'Access-Control-Allow-Origin *'
-                    - try_files:
-                        - $uri
-                        - $uri/
-                        - /staticfiles/$1
-                        - /staticfiles/$1/
-                        - =404
+  install_from_source: True
+  source_version: 1.13.8
+  source_hash: 8410b6c31ff59a763abf7e5a5316e7629f5a5033c95a3a0ebde727f9ec8464c5
+  certificates:
+    ovs_web_cert:
+      public_cert: __vault__::secret-odl-video/{{ ENVIRONMENT }}/ovs_web_cert>data>value
+      private_key: __vault__::secret-odl-video/{{ ENVIRONMENT }}/ovs_web_cert>data>key
+  server:
+    extra_config:
+      shib_params:
+        source_path: salt://nginx/ng/files/nginx.conf
+        shib_request_set:
+          - $shib_remote_user $upstream_http_variable_remote_user
+          - $shib_eppn $upstream_http_variable_eppn
+          - $shib_mail $upstream_http_variable_mail
+          - $shib_displayname $upstream_http_variable_displayname
+        uwsgi_param:
+          - REMOTE_USER $shib_remote_user
+          - EPPN $shib_eppn
+          - MAIL $shib_mail
+          - DISPLAY_NAME $shib_displayname
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /opt/odl-video-service/
+              - ssl_certificate: /etc/nginx/ssl/ovs_web_cert.crt
+              - ssl_certificate_key: /etc/nginx/ssl/ovs_web_cert.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1
+                  - TLSv1.1
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /shibauthorizer:
+                  - internal: ''
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
+              - location /Shibboleth.sso:
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibresponder.sock'
+              - location /{{ ovs_login_path }}:
+                  - include: includes/shib_clear_headers
+                  - shib_request: /shibauthorizer
+                  - shib_request_use_headers: 'on'
+                  - include: conf.d/shib_params.conf
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
+              - location /status:
+                  - include: uwsgi_params
+                  - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
+              - location /:
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/odl-video-service.sock
+              - location ~* /static/(.*$):
+                  - expires: max
+                  - add_header: 'Access-Control-Allow-Origin *'
+                  - try_files:
+                      - $uri
+                      - $uri/
+                      - /staticfiles/$1
+                      - /staticfiles/$1/
+                      - =404

--- a/pillar/nginx/redash.sls
+++ b/pillar/nginx/redash.sls
@@ -6,87 +6,86 @@
 {% set login_path = 'remote_user/login' %}
 
 nginx:
-  ng:
-    install_from_source: True
-    source_version: 1.13.8
-    source_hash: 8410b6c31ff59a763abf7e5a5316e7629f5a5033c95a3a0ebde727f9ec8464c5
-    certificates:
-      odl_wildcard:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    server:
-      extra_config:
-        shib_params:
-          source_path: salt://nginx/ng/files/nginx.conf
-          shib_request_set:
-            - $shib_remote_user $upstream_http_variable_remote_user
-            - $shib_eppn $upstream_http_variable_eppn
-            - $shib_mail $upstream_http_variable_mail
-            - $shib_displayname $upstream_http_variable_displayname
-          uwsgi_param:
-            - REMOTE_USER $shib_remote_user
-            - EPPN $shib_eppn
-            - MAIL $shib_mail
-            - DISPLAY_NAME $shib_displayname
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /opt/redash/
-                - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
-                     :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
-                     :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\
-                     :ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384\
-                     :ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256\
-                     :DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256\
-                     :AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 8.8.8.8
-                - location /shibauthorizer:
-                    - internal: ''
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
-                - location /Shibboleth.sso:
-                    - include: fastcgi_params
-                    - include: includes/shib_fastcgi_params
-                    - fastcgi_pass: 'unix:/run/shibresponder.sock'
-                - location /{{ login_path }}:
-                    - include: includes/shib_clear_headers
-                    - shib_request: /shibauthorizer
-                    - shib_request_use_headers: 'on'
-                    - include: conf.d/shib_params.conf
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock
-                - location /:
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock
+  install_from_source: True
+  source_version: 1.13.8
+  source_hash: 8410b6c31ff59a763abf7e5a5316e7629f5a5033c95a3a0ebde727f9ec8464c5
+  certificates:
+    odl_wildcard:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  server:
+    extra_config:
+      shib_params:
+        source_path: salt://nginx/files/nginx.conf
+        shib_request_set:
+          - $shib_remote_user $upstream_http_variable_remote_user
+          - $shib_eppn $upstream_http_variable_eppn
+          - $shib_mail $upstream_http_variable_mail
+          - $shib_displayname $upstream_http_variable_displayname
+        uwsgi_param:
+          - REMOTE_USER $shib_remote_user
+          - EPPN $shib_eppn
+          - MAIL $shib_mail
+          - DISPLAY_NAME $shib_displayname
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /opt/redash/
+              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
+                   :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
+                   :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\
+                   :ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384\
+                   :ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256\
+                   :DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256\
+                   :AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 8.8.8.8
+              - location /shibauthorizer:
+                  - internal: ''
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibauthorizer.sock'
+              - location /Shibboleth.sso:
+                  - include: fastcgi_params
+                  - include: includes/shib_fastcgi_params
+                  - fastcgi_pass: 'unix:/run/shibresponder.sock'
+              - location /{{ login_path }}:
+                  - include: includes/shib_clear_headers
+                  - shib_request: /shibauthorizer
+                  - shib_request_use_headers: 'on'
+                  - include: conf.d/shib_params.conf
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock
+              - location /:
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock

--- a/pillar/nginx/reddit.sls
+++ b/pillar/nginx/reddit.sls
@@ -6,64 +6,63 @@ reddit:
   api_access_token: {{ access_token }}
 
 nginx:
-  ng:
-    install_from_ppa: True
-    certificates:
-      odl.mit.edu:
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-    servers:
-      managed:
-        default:
-          enabled: False
-          deleted: True
-          config: None
-        reddit:
-          enabled: True
-          config:
-            - map $http_upgrade $connection_upgrade:
-                - default: upgrade
-                - "''": close
-            - server:
-                - server_name: {{ server_domain_name }}
-                - listen:
-                    - 443
-                    - ssl
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
-                - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_protocols:
-                    - TLSv1.2
-                - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
-                     :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
-                     :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\
-                     :ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384\
-                     :ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256\
-                     :DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256\
-                     :AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 8.8.8.8
-                - location /health:
-                    - proxy_pass: http://127.0.0.1:8001/health
-                    - proxy_set_header: Host $http_host
-                    - proxy_http_version: 1.1
-                    - proxy_set_header: X-Forwarded-For $remote_addr
-                - location /:
-                    - 'if ($http_x_access_token != {{ access_token }})':
-                        - return: 403
-                    - proxy_pass: http://127.0.0.1:8001
-                    - proxy_set_header: Host $http_host
-                    - proxy_http_version: 1.1
-                    - proxy_set_header: X-Forwarded-For $remote_addr
-                    - proxy_pass_header: Server
-                    {# allow websockets through if desired #}
-                    - proxy_set_header: Upgrade $http_upgrade
-                    - proxy_set_header: Connection $connection_upgrade
-                - location /media/:
-                    - expires: max
-                    - alias: /var/www/media/
+  install_from_ppa: True
+  certificates:
+    odl.mit.edu:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      default:
+        enabled: False
+        deleted: True
+        config: None
+      reddit:
+        enabled: True
+        config:
+          - map $http_upgrade $connection_upgrade:
+              - default: upgrade
+              - "''": close
+          - server:
+              - server_name: {{ server_domain_name }}
+              - listen:
+                  - 443
+                  - ssl
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_protocols:
+                  - TLSv1.2
+              - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
+                   :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
+                   :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\
+                   :ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384\
+                   :ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256\
+                   :DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256\
+                   :AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 8.8.8.8
+              - location /health:
+                  - proxy_pass: http://127.0.0.1:8001/health
+                  - proxy_set_header: Host $http_host
+                  - proxy_http_version: 1.1
+                  - proxy_set_header: X-Forwarded-For $remote_addr
+              - location /:
+                  - 'if ($http_x_access_token != {{ access_token }})':
+                      - return: 403
+                  - proxy_pass: http://127.0.0.1:8001
+                  - proxy_set_header: Host $http_host
+                  - proxy_http_version: 1.1
+                  - proxy_set_header: X-Forwarded-For $remote_addr
+                  - proxy_pass_header: Server
+                  {# allow websockets through if desired #}
+                  - proxy_set_header: Upgrade $http_upgrade
+                  - proxy_set_header: Connection $connection_upgrade
+              - location /media/:
+                  - expires: max
+                  - alias: /var/www/media/

--- a/pillar/nginx/starcellbio.sls
+++ b/pillar/nginx/starcellbio.sls
@@ -6,69 +6,68 @@
 {% set ovs_login_path = 'login' %}
 
 nginx:
-  ng:
-    install_from_ppa: True
-    certificates:
-      starcellbio:
-        {% if ENVIRONMENT == 'production-apps' %}
-        public_cert: __vault__::secret-starteam/global/starcellbio/ssl>data>cert
-        private_key: __vault__::secret-starteam/global/starcellbio/ssl>data>key
-        {% else %}
-        public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
-        private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
-        {% endif %}
-    servers:
-      managed:
-        {{ app_name }}:
-          enabled: True
-          config:
-            - server:
-                - server_name: {{ server_domain_names|tojson }}
-                - listen:
-                    - 80
-                - listen:
-                    - '[::]:80'
-                - location /:
-                    - return: 301 https://$host$request_uri
-            - server:
-                - server_name: {{ server_domain_names }}
-                - listen:
-                    - 443
-                    - ssl
-                    - default
-                - listen:
-                    - '[::]:443'
-                    - ssl
-                - root: /opt/{{ app_name }}/
-                - ssl_certificate: /etc/nginx/ssl/starcellbio.crt
-                - ssl_certificate_key: /etc/nginx/ssl/starcellbio.key
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1
-                    - TLSv1.1
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location /status:
-                    - return: 200
-                - location /:
-                    - include: uwsgi_params
-                    - uwsgi_ignore_client_abort: 'on'
-                    - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock
-                - location ~* /static/(.*$):
-                    - expires: max
-                    - add_header: 'Access-Control-Allow-Origin *'
-                    - try_files:
-                        - $uri
-                        - $uri/
-                        - /staticfiles/$1
-                        - /staticfiles/$1/
-                        - =404
+  install_from_ppa: True
+  certificates:
+    starcellbio:
+      {% if ENVIRONMENT == 'production-apps' %}
+      public_cert: __vault__::secret-starteam/global/starcellbio/ssl>data>cert
+      private_key: __vault__::secret-starteam/global/starcellbio/ssl>data>key
+      {% else %}
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+      {% endif %}
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen:
+                  - 80
+              - listen:
+                  - '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names }}
+              - listen:
+                  - 443
+                  - ssl
+                  - default
+              - listen:
+                  - '[::]:443'
+                  - ssl
+              - root: /opt/{{ app_name }}/
+              - ssl_certificate: /etc/nginx/ssl/starcellbio.crt
+              - ssl_certificate_key: /etc/nginx/ssl/starcellbio.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1
+                  - TLSv1.1
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /status:
+                  - return: 200
+              - location /:
+                  - include: uwsgi_params
+                  - uwsgi_ignore_client_abort: 'on'
+                  - uwsgi_pass: unix:/var/run/uwsgi/{{ app_name }}.sock
+              - location ~* /static/(.*$):
+                  - expires: max
+                  - add_header: 'Access-Control-Allow-Origin *'
+                  - try_files:
+                      - $uri
+                      - $uri/
+                      - /staticfiles/$1
+                      - /staticfiles/$1/
+                      - =404

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -24,8 +24,8 @@ base:
     - edx.xqwatcher
   'roles:amps-redirect':
     - match: grain
-    - nginx.ng
-    - nginx.ng.certificates
+    - nginx
+    - nginx.certificates
   'roles:backups':
     - match: grain
     - backups.backup
@@ -79,8 +79,8 @@ base:
     - utils.file_limits
     - pgbouncer
     - reddit
-    - nginx.ng
-    - nginx.ng.certificates
+    - nginx
+    - nginx.certificates
   'roles:cassandra':
     - match: grain
     - cassandra
@@ -90,7 +90,7 @@ base:
     - node
     - django
     - uwsgi
-    - nginx.ng
+    - nginx
   'roles:edx-video-pipeline':
     - match: grain
     - edx.run_ansible
@@ -125,7 +125,7 @@ base:
     - utils.mitca_pem
     - utils.configure_debian_source_repos
     - utils.logrotate
-    - nginx.ng
+    - nginx
     - elastic-stack.elastalert
     - datadog.plugins
     - monit
@@ -141,7 +141,7 @@ base:
     - match: compound
     - elasticsearch
     - elasticsearch.plugins
-    - nginx.ng
+    - nginx
   'G@roles:elasticsearch and P@environment:mitx(pro)?-(qa|production)':
     - match: compound
     - elasticsearch
@@ -201,8 +201,8 @@ base:
   'roles:ocw-origin':
     - match: grain
     - utils.configure_debian_source_repos
-    - nginx.ng
-    - nginx.ng.certificates
+    - nginx
+    - nginx.certificates
     - letsencrypt
     - fluentd
     - fluentd.plugins
@@ -234,8 +234,8 @@ base:
     - apps.ocw.mirror
     - apps.ocw.sync_repo
     - utils.logrotate
-    - nginx.ng
-    - nginx.ng.certificates
+    - nginx
+    - nginx.certificates
   'P@roles:ocw-(cms|db|origin|mirror) and G@ocw-environment:production':
     - datadog
   'roles:sandbox':


### PR DESCRIPTION
See https://github.com/mitodl/nginx-formula/pull/2
This should only be merged after that PR is merged.

#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/980

#### What's this PR do?

* Change salt/top.sls to reference restructured nginx formula, which removes the `ng` state.

* Remove the `ng` property of various pillar files, which changes their indentation.
