### PR TITLE
Mods for fluentd qa server and pki

### DIFF
--- a/pillar/fluentd/server_operations_qa.sls
+++ b/pillar/fluentd/server_operations_qa.sls
@@ -1,7 +1,7 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
 {% set mailgun_webhooks_token = salt.vault.read('secret-operations/{}/mailgun_webhooks_token'.format(ENVIRONMENT)).data.value %}
 {% set es_hosts = 'operations-elasticsearch.query.consul' %}
-{% set cert = salt.vault.cached_write('pki-intermediate-operations/issue/fluentd-server', common_name='{}'.format(es_hosts)) %}
+{% set cert = salt.vault.cached_write('pki-intermediate-operations/issue/fluentd-server', common_name='operations-fluentd.query.consul') %}
 {% set fluentd_cert_path = '/etc/fluent/fluentd.crt' %}
 {% set fluentd_key_path = '/etc/fluent/fluentd.key' %}
 {% set ca_cert_path = '/etc/fluent/ca.crt' %}

--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -6,6 +6,7 @@
 {% set locality = 'Cambridge' %}
 {% set street_address = '77 Massachusetts Ave' %}
 {% set postal_code = '02139' %}
+{% set fluentd_aggregators = 'operations-fluentd.query.consul' %}
 
 vault:
   roles:
@@ -18,7 +19,7 @@ vault:
       options:
         {% if type == 'server' %}
         server_flag: True
-        allowed_domains: "{{ app }}.service.consul, nearest-{{ app }}.query.consul, {{ app }}-master.service.consul, {{ app }}.service.operations.consul"
+        allowed_domains: "{{ app }}.service.consul, nearest-{{ app }}.query.consul, {{ fluentd_aggregators }}, {{ app }}-master.service.consul, {{ app }}.service.operations.consul"
         {% else %}
         client_flag: True
         allowed_domains: "{{ app }}.*.{{ env_name }}"


### PR DESCRIPTION
#### What's this PR do?
This is a basic first pass for the fluentd qa changes for enabling TLS using our pki infra. Additionally, some of the other changes are related to the newer version of fluentd. Last but not least, since this is a pillar file for the qa aggregators, I took out the tracking log shipping to s3 since we only need to do that for production.