### PR TITLE
set ENABLE_ORDER_RECEIPTS to True in production

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -79,7 +79,7 @@
       'MAILGUN_SENDER_DOMAIN': 'xpro-mail.odl.mit.edu',
       'MITXPRO_BASE_URL': 'https://xpro.mit.edu',
       'MITXPRO_SECURE_SSL_HOST': 'xpro.mit.edu',
-      'ENABLE_ORDER_RECEIPTS': False,
+      'ENABLE_ORDER_RECEIPTS': True,
       'vault_env_path': 'production-apps',
       'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 4


### PR DESCRIPTION
ENABLE_ORDER_RECEIPTS is a feature flag that should be removed once this feature is stable

#### What are the relevant tickets?

https://github.com/mitodl/mitxpro/issues/1435

#### What's this PR do?

Turns on Receipts in the xPRO dashboard, and also emails receipts. 

#### How should this be manually tested?

For an existing purchase, view the dashboard and confirm that links to receipts exist. 

Make a new purchase and confirm that a receipt email is sent. 

#### Any background context you want to provide?

Email receipts will have to be turned off in Cybersource once this feature is confirmed to be working. 

