### PR TITLE
Added pruning of backups to backup scripts

### DIFF
--- a/salt/backups/templates/backup_course_assets.sh
+++ b/salt/backups/templates/backup_course_assets.sh
@@ -8,6 +8,12 @@ mkdir -p /mnt/efs
 mountpoint /mnt/efs || mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ settings.efs_id }}.efs.us-east-1.amazonaws.com:/ /mnt/efs
 
 PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
+          remove-all-but-n-full 5 --archive-dir {{ cachedir }} \
+          --asynchronous-upload --s3-use-multiprocessing \
+          --tempdir /backups/tmp/ \
+          s3+http://odl-operations-backups/{{ settings.get('directory', 'course_assets') }}/
+
+PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
           --s3-use-server-side-encryption {{ backupdir }} \
           --archive-dir {{ cachedir }} --asynchronous-upload \
           --full-if-older-than 1W --s3-use-multiprocessing \

--- a/salt/backups/templates/backup_mongodb.sh
+++ b/salt/backups/templates/backup_mongodb.sh
@@ -6,6 +6,12 @@ set -e
 mkdir -p {{ backupdir }}
 mkdir -p {{ cachedir }}
 
+PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
+          remove-all-but-n-full 5 --archive-dir {{ cachedir }} \
+          --asynchronous-upload --s3-use-multiprocessing \
+          --tempdir /backups/tmp/ \
+          s3+http://odl-operations-backups/{{ settings.get('directory', 'mongodb') }}/
+
 /usr/bin/mongodump --host {{ settings.host }} \
                    --port {{ settings.get('port', 27017) }} \
                    --password={{ settings.password }} --username {{ settings.username }} \

--- a/salt/backups/templates/backup_mysql.sh
+++ b/salt/backups/templates/backup_mysql.sh
@@ -8,6 +8,12 @@ mkdir -p {{ cachedir }}
 
 cd /backups/
 
+PASSPHRASE={{ settings.duplicity_passphrase }} /usr/bin/duplicity \
+          remove-all-but-n-full 5 --archive-dir {{ cachedir }} \
+          --asynchronous-upload --s3-use-multiprocessing \
+          --tempdir /backups/tmp/ \
+          s3+http://odl-operations-backups/{{ settings.get('directory', 'mysql') }}
+
 /usr/bin/mydumper --host {{ settings.host }} \
                   --port {{ settings.get('port', 3306) }} \
                   --user {{ settings.username }} \


### PR DESCRIPTION
We have been keeping all backups which ends up ballooning the backup repo and slowing down backup/restore. This adds commands to prune old backups beyond 5 weeks to keep things in check.
