### PR TITLE
Add mitxpro redirect

### DIFF
--- a/pillar/letsencrypt/amps_redirect.sls
+++ b/pillar/letsencrypt/amps_redirect.sls
@@ -1,0 +1,7 @@
+
+letsencrypt:
+  overrides:
+    email: 'odl-devops@mit.edu'
+    common_name: 'amps-web.amps.ms.mit.edu'
+    subject_alternative_names:
+      - mitxpro.mit.edu

--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -27,8 +27,8 @@ nginx:
               - listen:
                   - '[::]:443'
                   - ssl
-              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
-              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
+              - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
               - ssl_stapling: 'on'
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d

--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -17,10 +17,11 @@ nginx:
               - server_name: amps-web.amps.ms.mit.edu
               - listen:
                   - 80
+                  - default_server
               - listen:
                   - 443
                   - ssl
-                  - default
+                  - default_server
               - listen:
                   - '[::]:80'
               - listen:
@@ -89,4 +90,3 @@ nginx:
                   - return: 301 https://video.odl.mit.edu/videos/7a11f55dd99d49349f377d2d87f0aef2/?start=341
               - location /:
                   - return: 301 https://docs.google.com/forms/d/e/1FAIpQLSdvkI2cPG1iMM4gN_KyKem4fNLh4irWzrmjX-JhcFXa51su5g/viewform?fbzx=2658557852628862500
-

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -1,0 +1,40 @@
+nginx:
+  ng:
+    servers:
+      managed:
+        mitxpro-redirect:
+          enabled: True
+          config:
+            - server:
+              - server_name: mitxpro.mit.edu
+              - listen:
+                  - 80
+              - listen:
+                  - 443
+                  - ssl
+              - listen:
+                - '[::]:80'
+                - '[::]:443'
+                - ssl
+                # The certificate uses subject alternative names, including mitxpro.mit.edu.
+                - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
+                - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
+                - ssl_stapling: 'on'
+                - ssl_stapling_verify: 'on'
+                - ssl_session_timeout: 1d
+                - ssl_session_tickets: 'off'
+                - ssl_protocols:
+                    - TLSv1.2
+                    - TLSv1.3
+                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+                - ssl_prefer_server_ciphers: 'on'
+                - resolver: 1.1.1.1
+                - location ~ /.well-known:
+                  - allow: all
+                - location /certificates/
+                  - rewrite ^(.*)$ https://courses.edx.org$1 permanent
+                - location /
+                  - return: 301 https://xpro.mit.edu/

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -34,6 +34,6 @@ nginx:
               - location /.well-known/
                 - alias: /usr/share/nginx/html/.well-known/
               - location /certificates/
-                - return 301 https://courses.edx.org$request_uri
+                - return: 301 https://courses.edx.org$request_uri
               - location /
                 - return: 301 https://xpro.mit.edu/

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -31,8 +31,8 @@ nginx:
                   :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 1.1.1.1
-              - location ~ /.well-known:
-                - allow: all
+              - location /.well-known/
+                - alias: /usr/share/nginx/html/.well-known/
               - location /certificates/
                 - rewrite ^(.*)$ https://courses.edx.org$1 permanent
               - location /

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -1,40 +1,39 @@
 nginx:
-  ng:
-    servers:
-      managed:
-        mitxpro-redirect:
-          enabled: True
-          config:
-            - server:
-              - server_name: mitxpro.mit.edu
-              - listen:
-                  - 80
-              - listen:
-                  - 443
-                  - ssl
-              - listen:
-                - '[::]:80'
-                - '[::]:443'
+  servers:
+    managed:
+      mitxpro-redirect:
+        enabled: True
+        config:
+          - server:
+            - server_name: mitxpro.mit.edu
+            - listen:
+                - 80
+            - listen:
+                - 443
                 - ssl
-                # The certificate uses subject alternative names, including mitxpro.mit.edu.
-                - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
-                - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
-                - ssl_stapling: 'on'
-                - ssl_stapling_verify: 'on'
-                - ssl_session_timeout: 1d
-                - ssl_session_tickets: 'off'
-                - ssl_protocols:
-                    - TLSv1.2
-                    - TLSv1.3
-                - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
-                    :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
-                    :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
-                    :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
-                - ssl_prefer_server_ciphers: 'on'
-                - resolver: 1.1.1.1
-                - location ~ /.well-known:
-                  - allow: all
-                - location /certificates/
-                  - rewrite ^(.*)$ https://courses.edx.org$1 permanent
-                - location /
-                  - return: 301 https://xpro.mit.edu/
+            - listen:
+              - '[::]:80'
+              - '[::]:443'
+              - ssl
+              # The certificate uses subject alternative names, including mitxpro.mit.edu.
+              - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
+              - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols:
+                  - TLSv1.2
+                  - TLSv1.3
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location ~ /.well-known:
+                - allow: all
+              - location /certificates/
+                - rewrite ^(.*)$ https://courses.edx.org$1 permanent
+              - location /
+                - return: 301 https://xpro.mit.edu/

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -31,9 +31,9 @@ nginx:
                   :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 1.1.1.1
-              - location /.well-known/
+              - location /.well-known/:
                 - alias: /usr/share/nginx/html/.well-known/
-              - location /certificates/
+              - location /certificates/:
                 - return: 301 https://courses.edx.org$request_uri
-              - location /
+              - location /:
                 - return: 301 https://xpro.mit.edu/

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -34,6 +34,6 @@ nginx:
               - location /.well-known/
                 - alias: /usr/share/nginx/html/.well-known/
               - location /certificates/
-                - rewrite ^(.*)$ https://courses.edx.org$1 permanent
+                - return 301 https://courses.edx.org$request_uri
               - location /
                 - return: 301 https://xpro.mit.edu/

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -24,8 +24,8 @@ base:
     - edx.xqwatcher
   'roles:amps-redirect':
     - match: grain
+    - letsencrypt
     - nginx
-    - nginx.certificates
   'roles:backups':
     - match: grain
     - backups.backup


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/mitxpro/issues/1370

#### What's this PR do?

It adds an Nginx virtual host for redirecting mitxpro.mit.edu to xpro.mit.edu. The virtual host is added to the same Nginx server that is used for `amps-web.amps.ms.mit.edu`. I have added a letsencrypt certificate for mitxpro.

