### PR TITLE
Added ca_chain config for fluentd

### DIFF
--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -1,8 +1,15 @@
+{% set ca_chain_content = '__vault__::secret-operations/global/pki/ca_chain>data>value' %}
+
 fluentd:
   overrides:
     version: "1.8.0"
     user: root
     group: root
+  pki:
+    ca_chain:
+      content: |
+        {{ ca_chain_content|indent(8) }}
+      path: '/usr/local/share/ca-certificates/ca_chain.crt'
 
 beacons:
   service:


### PR DESCRIPTION
#### What's this PR do?
In order not to simplify our work with PKI and not have to include the entire chain in the fluentd client config, we opted to add the chain to the local ca store. This change, in conjunction with one to fluentd-formula will write the ca_chain.crt file to the trusted store path and update that config.

