### PR TITLE
Change pillar data for new nginx formula

### DIFF
--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -15,18 +15,10 @@ nginx:
         config:
           - server:
               - server_name: amps-web.amps.ms.mit.edu
-              - listen:
-                  - 80
-                  - default_server
-              - listen:
-                  - 443
-                  - ssl
-                  - default_server
-              - listen:
-                  - '[::]:80'
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '80 default_server'
+              - listen: '443 ssl default_server'
+              - listen: '[::]:80'
+              - listen: '[::]:443 ssl'
               - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
               - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
               - ssl_stapling: 'on'

--- a/pillar/nginx/amps_redirect.sls
+++ b/pillar/nginx/amps_redirect.sls
@@ -25,9 +25,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\

--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -5,26 +5,6 @@ nginx:
     config:
       http:
         access_log: !!null
-    extra_config:
-      logging:
-        log_format app_metrics: >-
-          'time=$time_iso8601
-          client=$remote_addr
-          method=$request_method
-          request="$request"
-          request_length=$request_length
-          status=$status
-          bytes_sent=$bytes_sent
-          body_bytes_sent=$body_bytes_sent
-          referer=$http_referer
-          user_agent="$http_user_agent"
-          upstream_addr=$upstream_addr
-          upstream_status=$upstream_status
-          request_time=$request_time
-          upstream_response_time=$upstream_response_time
-          upstream_connect_time=$upstream_connect_time
-          upstream_header_time=$upstream_header_time'
-        access_log: /var/log/nginx/access.log app_metrics
   dh_param:
     dhparam.pem: __vault__::secret-operations/{{ ENVIRONMENT }}/dhparam>data>value
   certificates:
@@ -38,12 +18,8 @@ nginx:
         config:
           - server:
               - server_name: elasticsearch-{{ ENVIRONMENT }}.odl.mit.edu
-              - listen:
-                  - 443
-                  - ssl
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl'
+              - listen: '[::]:443 ssl'
               - location ~ ^/(_alias|_aliases|discussions|micromasters|_refresh|_mapping):
                   - proxy_pass: http://127.0.0.1:9200$request_uri
                   - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'

--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -40,8 +40,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
+              - ssl_protocols: TLSv1.2
               - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 8.8.8.8

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -35,9 +35,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -46,15 +44,9 @@ nginx:
               - resolver: 1.1.1.1
               - location /:
                   - proxy_pass: http://localhost:5601/
-                  - proxy_set_header:
-                    - Host
-                    - $host
-                  - proxy_set_header:
-                    - X-Real-IP
-                    - $remote_addr
-                  - proxy_set_header:
-                    - X-Forwarded-For__vault__::secret-operations/global/mitca_ssl_cert>data>value
-                    - $remote_addr
+                  - proxy_set_header: 'Host $host'
+                  - proxy_set_header: 'X-Real-IP $remote_addr'
+                  - proxy_set_header: 'X-Forwarded-For__vault__::secret-operations/global/mitca_ssl_cert>data>value $remote_addr'
                   - proxy_headers_hash_bucket_size: 128
                   - proxy_read_timeout: 240s
               - ssl_client_certificate: /etc/ssl/certs/mitca.pem

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -46,7 +46,7 @@ nginx:
                   - proxy_pass: http://localhost:5601/
                   - proxy_set_header: 'Host $host'
                   - proxy_set_header: 'X-Real-IP $remote_addr'
-                  - proxy_set_header: 'X-Forwarded-For__vault__::secret-operations/global/mitca_ssl_cert>data>value $remote_addr'
+                  - proxy_set_header: "X-Forwarded-For {{ salt.vault.read('secret-operations/global/mitca_ssl_cert').data.value) }} $remote_addr"
                   - proxy_headers_hash_bucket_size: 128
                   - proxy_read_timeout: 240s
               - ssl_client_certificate: /etc/ssl/certs/mitca.pem

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -21,21 +21,14 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
               - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
               - ssl_stapling: 'on'

--- a/pillar/nginx/micromasters_es.sls
+++ b/pillar/nginx/micromasters_es.sls
@@ -52,8 +52,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
+              - ssl_protocols: TLSv1.2
               - ssl_ciphers: 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256'
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 8.8.8.8

--- a/pillar/nginx/micromasters_es.sls
+++ b/pillar/nginx/micromasters_es.sls
@@ -25,12 +25,8 @@ nginx:
               - server_name:
                   - micromasters-es.odl.mit.edu
                   - '""'
-              - listen:
-                  - 443
-                  - ssl
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl'
+              - listen: '[::]:443 ssl'
               - location /_cluster:
                   - allow: 127.0.0.1
                   - allow: 10.10.0.0/16

--- a/pillar/nginx/mitx_cas.sls
+++ b/pillar/nginx/mitx_cas.sls
@@ -39,21 +39,14 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domains[ENVIRONMENT] }} {# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domains[ENVIRONMENT] }}{# This is a hack to work around the way that shibboleth/init.sls is set up for entityID  (TMM 2018-07-24) #}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /opt/mitx-cas/
               - ssl_certificate: /etc/nginx/ssl/mitx_wildcard.crt
               - ssl_certificate_key: /etc/nginx/ssl/mitx_wildcard.key

--- a/pillar/nginx/mitx_cas.sls
+++ b/pillar/nginx/mitx_cas.sls
@@ -54,10 +54,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.1
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.1 TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -88,9 +85,4 @@ nginx:
               - location ~* /static/(.*$):
                   - expires: max
                   - add_header: 'Access-Control-Allow-Origin *'
-                  - try_files:
-                      - $uri
-                      - $uri/
-                      - /staticfiles/$1
-                      - /staticfiles/$1/
-                      - =404
+                  - try_files: '$uri $uri/ /staticfiles/$1  /staticfiles/$1/ =404'

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -17,9 +17,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -5,16 +5,11 @@ nginx:
         enabled: True
         config:
           - server:
-            - server_name: mitxpro.mit.edu
-            - listen:
-                - 80
-            - listen:
-                - 443
-                - ssl
-            - listen:
-              - '[::]:80'
-              - '[::]:443'
-              - ssl
+              - server_name: mitxpro.mit.edu
+              - listen: 80
+              - listen: '443 ssl'
+              - listen: '[::]:80'
+              - listen: '[::]:443 ssl'
               # The certificate uses subject alternative names, including mitxpro.mit.edu.
               - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
               - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem

--- a/pillar/nginx/ocw_mirror.sls
+++ b/pillar/nginx/ocw_mirror.sls
@@ -31,21 +31,14 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /data2/rsync
               - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
               - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key

--- a/pillar/nginx/ocw_mirror.sls
+++ b/pillar/nginx/ocw_mirror.sls
@@ -46,10 +46,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.1
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.1 TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -57,11 +54,5 @@ nginx:
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 1.1.1.1
               - location /:
-                  - try_files:
-                      - $uri
-                      - $uri/index.htm
-                      - =404
-                  - rewrite:
-                      - ^(/[^\.\?]+[^/])$
-                      - $1/
-                      - permanent
+                  - try_files: '$uri $uri/index.htm =404'
+                  - rewrite: '^(/[^\.\?]+[^/])$ $1/ permanent'

--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -50,10 +50,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.1
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.1 TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -63,14 +60,6 @@ nginx:
               - location /status:
                   - return: 200
               - location /:
-                  - try_files:
-                      - $uri
-                      - $uri/index.htm
-                      - =404
-                  - error_page:
-                      - '404'
-                      - /jsp/error.html
-                  - rewrite:
-                      - ^(/[^\.\?]+[^/])$
-                      - $1/
-                      - permanent
+                  - try_files: '$uri $uri/index.htm =404'
+                  - error_page: '404 /jsp/error.html'
+                  - rewrite: '^(/[^\.\?]+[^/])$ $1/ permanent'

--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -30,10 +30,8 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location ~ /.well-known:
                   - allow: all
               - location /courses/edx_courses.json:
@@ -43,13 +41,8 @@ nginx:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /var/www/ocw
               - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
               - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key

--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -49,11 +49,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1
-                  - TLSv1.1
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -87,9 +83,4 @@ nginx:
               - location ~* /static/(.*$):
                   - expires: max
                   - add_header: 'Access-Control-Allow-Origin *'
-                  - try_files:
-                      - $uri
-                      - $uri/
-                      - /staticfiles/$1
-                      - /staticfiles/$1/
-                      - =404
+                  - try_files: '$uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404'

--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -34,21 +34,14 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /opt/odl-video-service/
               - ssl_certificate: /etc/nginx/ssl/ovs_web_cert.crt
               - ssl_certificate_key: /etc/nginx/ssl/ovs_web_cert.key

--- a/pillar/nginx/redash.sls
+++ b/pillar/nginx/redash.sls
@@ -49,9 +49,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
               - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
                    :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
                    :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\

--- a/pillar/nginx/redash.sls
+++ b/pillar/nginx/redash.sls
@@ -34,21 +34,14 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /opt/redash/
               - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
               - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key

--- a/pillar/nginx/reddit.sls
+++ b/pillar/nginx/reddit.sls
@@ -25,12 +25,8 @@ nginx:
               - "''": close
           - server:
               - server_name: {{ server_domain_name }}
-              - listen:
-                  - 443
-                  - ssl
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl'
+              - listen: '[::]:443 ssl'
               - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
               - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
               - ssl_stapling: 'on'

--- a/pillar/nginx/reddit.sls
+++ b/pillar/nginx/reddit.sls
@@ -32,8 +32,7 @@ nginx:
               - ssl_stapling: 'on'
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
-              - ssl_protocols:
-                  - TLSv1.2
+              - ssl_protocols: TLSv1.2
               - ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256\
                    :ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384\
                    :DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\

--- a/pillar/nginx/starcellbio.sls
+++ b/pillar/nginx/starcellbio.sls
@@ -31,13 +31,8 @@ nginx:
                   - return: 301 https://$host$request_uri
           - server:
               - server_name: {{ server_domain_names }}
-              - listen:
-                  - 443
-                  - ssl
-                  - default
-              - listen:
-                  - '[::]:443'
-                  - ssl
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
               - root: /opt/{{ app_name }}/
               - ssl_certificate: /etc/nginx/ssl/starcellbio.crt
               - ssl_certificate_key: /etc/nginx/ssl/starcellbio.key

--- a/pillar/nginx/starcellbio.sls
+++ b/pillar/nginx/starcellbio.sls
@@ -23,10 +23,8 @@ nginx:
         config:
           - server:
               - server_name: {{ server_domain_names|tojson }}
-              - listen:
-                  - 80
-              - listen:
-                  - '[::]:80'
+              - listen: 80
+              - listen: '[::]:80'
               - location /:
                   - return: 301 https://$host$request_uri
           - server:
@@ -40,11 +38,7 @@ nginx:
               - ssl_stapling_verify: 'on'
               - ssl_session_timeout: 1d
               - ssl_session_tickets: 'off'
-              - ssl_protocols:
-                  - TLSv1
-                  - TLSv1.1
-                  - TLSv1.2
-                  - TLSv1.3
+              - ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2 TLSv1.3'
               - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
                   :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
                   :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
@@ -60,9 +54,4 @@ nginx:
               - location ~* /static/(.*$):
                   - expires: max
                   - add_header: 'Access-Control-Allow-Origin *'
-                  - try_files:
-                      - $uri
-                      - $uri/
-                      - /staticfiles/$1
-                      - /staticfiles/$1/
-                      - =404
+                  - try_files: '$uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404'


### PR DESCRIPTION
Change some list properties to string properties for the new version of `nginx-formula`. These are mostly `listen` directives, where the formula used to accept a list of the different parts of the line, but now wants a string representing the whole thing.

