### PR TITLE
Fix bad X-Forwarded-For header in Kibana Nginx config

### DIFF
--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -46,7 +46,7 @@ nginx:
                   - proxy_pass: http://localhost:5601/
                   - proxy_set_header: 'Host $host'
                   - proxy_set_header: 'X-Real-IP $remote_addr'
-                  - proxy_set_header: "X-Forwarded-For {{ salt.vault.read('secret-operations/global/mitca_ssl_cert').data.value }} $remote_addr"
+                  - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                   - proxy_headers_hash_bucket_size: 128
                   - proxy_read_timeout: 240s
               - ssl_client_certificate: /etc/ssl/certs/mitca.pem


### PR DESCRIPTION
Fix a bad value written into an Nginx `proxy_set_header` directive for the `X-Forwarded-For` header. The bad value (with the contents of a TLS CA certificate) must have been the result of a bad copy-and-paste operation, in commit c3ab7c399b94d53ca9a9c8d725a990a9152a09ae ("Update Elastic Stack pillars and states").
