### PR TITLE
Changed fluentd file from list to dict

### DIFF
--- a/pillar/fluentd/cas.sls
+++ b/pillar/fluentd/cas.sls
@@ -4,7 +4,7 @@
 
 fluentd:
   configs:
-    - name: auth_server
+    auth_server:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/consul.sls
+++ b/pillar/fluentd/consul.sls
@@ -4,7 +4,7 @@
 
 fluentd:
   configs:
-    - name: consul_server
+    consul_server:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/elasticsearch.sls
+++ b/pillar/fluentd/elasticsearch.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: elasticsearch_server
+    elasticsearch_server:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -28,7 +28,7 @@ fluentd:
         {{ cert.data.issuing_ca|indent(8) }}
       path: {{ ca_cert_path }}
   configs:
-     - name: fluentd_log
+     fluentd_log:
        settings:
           - directive: label
             directive_arg: '@FLUENT_LOG'

--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -4,7 +4,7 @@
 
 fluentd:
   configs:
-    - name: edx
+    edx:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/mongodb.sls
+++ b/pillar/fluentd/mongodb.sls
@@ -4,7 +4,7 @@
 
 fluentd:
   configs:
-    - name: mongodb_server
+    mongodb_server:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/ocw_cms.sls
+++ b/pillar/fluentd/ocw_cms.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: ocwcms
+    ocwcms:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/ocw_db.sls
+++ b/pillar/fluentd/ocw_db.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: ocwdb
+    ocwdb:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/ocw_mirror.sls
+++ b/pillar/fluentd/ocw_mirror.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: ocwmirror
+    ocwmirror:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: ocworigin
+    ocworigin:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: odlvideo
+    odlvideo:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/rabbitmq.sls
+++ b/pillar/fluentd/rabbitmq.sls
@@ -5,7 +5,7 @@
 
 fluentd:
   configs:
-    - name: rabbitmq_server
+    rabbitmq_server:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -3,7 +3,7 @@
 
 fluentd:
   configs:
-    - name: reddit
+    reddit:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/server_operations_qa.sls
+++ b/pillar/fluentd/server_operations_qa.sls
@@ -38,14 +38,14 @@ fluentd:
       port: 9001
       token: __vault__::secret-operations/{{ ENVIRONMENT }}/mailgun_webhooks_token>data>value
   configs:
-    - name: monitor_agent
+    monitor_agent:
       settings:
         - directive: source
           attrs:
             - '@type': monitor_agent
             - bind: 127.0.0.1
             - port: 24220
-    - name: fluentd_server_log
+    fluentd_log:
       settings:
         - directive: label
           directive_arg: '@FLUENT_LOG'
@@ -77,7 +77,7 @@ fluentd:
                         attrs:
                           - flush_interval: '10s'
                           - flush_thread_count: 2
-    - name: elasticsearch
+    elasticsearch:
       settings:
         - directive: source
           attrs:

--- a/pillar/fluentd/xqwatcher.sls
+++ b/pillar/fluentd/xqwatcher.sls
@@ -4,7 +4,7 @@
 
 fluentd:
   configs:
-    - name: xqwatcher
+    xqwatcher:
       settings:
         - directive: source
           attrs:


### PR DESCRIPTION
#### What's this PR do?
In order to be able to specify common fluentd config files in `init.sls` and the specific files, we needed to change the file type from list to dict. This change is in conjunction with a change submitted to the fluentd formula.

Note: The one thing I'm not 100% sure about is the change to `server_operations_qa.sls` filename. I made it the same as the filename specified in `init.sls` as I'm expecting that the configs in the server config overwrite the contents of init, but could be wrong and it might throw a duplicate key error.

