### PR TITLE
Fix OCW Mirror Nginx pillar rendering

### DIFF
--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -52,7 +52,7 @@ nginx:
               - ssl_client_certificate: /etc/ssl/certs/mitca.pem
               - ssl_verify_client: 'on'
               - set $authorized: 'no'
-              - if ($ssl_client_s_dn ~ "emailAddress=(tmacey|pdpinch|shaidar|ichuang|gsidebo|mkdavies|gschneel|mattbert|nlevesq|ferdial|maxliu|annagav|mbrdlove|jmartis)@MIT.EDU"):
+              - if ($ssl_client_s_dn ~ "emailAddress=(tmacey|pdpinch|shaidar|ichuang|gsidebo|mkdavies|gschneel|mattbert|nlevesq|ferdial|maxliu|annagav|mbrdlove|jmartis|abeglova|gumaerc)@MIT.EDU"):
                 - set $authorized: 'yes'
               - if ($authorized !~ "yes"):
                 - return: 403

--- a/pillar/nginx/ocw_mirror.sls
+++ b/pillar/nginx/ocw_mirror.sls
@@ -15,7 +15,7 @@
 {% set OCW_ENVIRONMENT = salt.grains.get('ocw-environment') %}
 {% set OCW_DEPLOYMENT = salt.grains.get('ocw-deployment') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
-{% set server_domain_names = env_data.purposes[app_name].domains[OCW_ENVIRONMENT][OCW_DEPLOYMENT] %}
+{% set server_domain_names = env_data.purposes[app_name].domains %}
 
 
 nginx:

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -1053,9 +1053,7 @@ environments:
         app: nginx
         business_unit: open-courseware
         domains:
-          production:
-            production:
-              - ocw-rsync.odl.mit.edu
+          - ocw-rsync.odl.mit.edu
 
 business_units:
   - bootcamps


### PR DESCRIPTION
Fix the Nginx pillar for OCW's mirror servers. Though there is a "qa" minion for the ocw-mirror role, its Nginx configuration is superficial, because the only reason for the "qa" mirror to exist is to verify that mirror publishing scripts work. The QA mirror isn't accessed over HTTP. Therefore, there only has to be one "production" Nginx configuration that actually works.

I'm keeping an nginx configuration on `ocw-qa-cms-2` because it's still a good idea for making sure that rendering works. It just doesn't need to have the correct domain name. Is this a bad idea?

Without the modification in this commit, there is a Jinja2 rendering error about a dict having no 'qa' attribute. That's because the ocw-environment grain on the QA minion is "qa" and there's no such property of `environments:ocw:purposes:ocw-mirror`.

