### PR TITLE
Changed default datadog ports on fluentd aggregators

### DIFF
--- a/pillar/fluentd/server.sls
+++ b/pillar/fluentd/server.sls
@@ -25,6 +25,12 @@ schedule:
     args:
       - fluentd.config
 
+# Default datadog-agent port conflicts with fluentd
+datadog:
+  config:
+    expvar_port: 5004
+    cmd_port: 5005
+
 fluentd:
   persistent_directories: {{ fluentd_directories|tojson }}
   plugins:


### PR DESCRIPTION
#### What's this PR do?
By default, datadog-agent uses the same port as the one we're using for the fluentd aggregators. This PR changes the default ports for datadog-agent.
