### PR TITLE
Do not run Nginx role on OCW Mirror QA

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -275,6 +275,8 @@ base:
     - fluentd.ocw_mirror
     - apps.ocw
     - logrotate.ocw_mirror
+  'G@roles:ocw-mirror and G@ocw-environment:production':
+    - match: compound
     - nginx
     - nginx.ocw_mirror
   'roles:ocw-origin':

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -234,6 +234,8 @@ base:
     - apps.ocw.mirror
     - apps.ocw.sync_repo
     - utils.logrotate
+  'G@roles:ocw-mirror and G@ocw-environment:production':
+    - match: compound
     - nginx
     - nginx.certificates
   'P@roles:ocw-(cms|db|origin|mirror) and G@ocw-environment:production':


### PR DESCRIPTION
Only apply Nginx states to the production instance of OCW's Mirror server.
