### PR TITLE
OCW chalkradio redirects

### DIFF
--- a/pillar/letsencrypt/amps_redirect.sls
+++ b/pillar/letsencrypt/amps_redirect.sls
@@ -5,3 +5,6 @@ letsencrypt:
     common_name: 'amps-web.amps.ms.mit.edu'
     subject_alternative_names:
       - mitxpro.mit.edu
+      - chalkradiopodcast.com
+      - chalkradiopodcast.org
+      - chalkradiopodcast.net

--- a/pillar/nginx/chalkradio_redirect.sls
+++ b/pillar/nginx/chalkradio_redirect.sls
@@ -1,0 +1,33 @@
+nginx:
+    servers:
+    managed:
+      chalkradio-redirect:
+        enabled: True
+        config:
+          - server:
+              - server_name: chalkradiopodcast.com chalkradiopodcast.org chalkradiopodcast.net
+              - listen: 80
+              - listen: '443 ssl'
+              - listen: '[::]:80'
+              - listen: '[::]:443 ssl'
+              # The certificate uses subject alternative names.
+              - ssl_certificate: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/cert.pem
+              - ssl_certificate_key: /etc/letsencrypt/live/amps-web.amps.ms.mit.edu/privkey.pem
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
+              - ssl_ciphers: >-
+                  TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:
+                  TLS_AES_128_GCM_SHA256:DHE-RSA-AES256-GCM-SHA384:
+                  DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:
+                  ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:
+                  DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:
+                  ECDHE-RSA-AES128-SHA256
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /.well-known/:
+                - alias: /usr/share/nginx/html/.well-known/
+              - location /:
+                - return: 301 https://ocw.mit.edu/educator/chalk-radio-podcast/

--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -24,6 +24,8 @@ nginx:
                   :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
               - ssl_prefer_server_ciphers: 'on'
               - resolver: 1.1.1.1
+              - location /.well-known/:
+                - alias: /usr/share/nginx/html/.well-known/
               - location /certificates/:
                 - return: 301 https://courses.edx.org$request_uri
               - location /:


### PR DESCRIPTION
See https://odl.zendesk.com/agent/tickets/44331

I'm adding these to amps-redirect because this is already a place where we manage assorted redirects, and it seems likely that one of us would look there if we need to maintain them.
