### PR TITLE
Added tls_forward macro to accomodate env without consul

### DIFF
--- a/pillar/fluentd/cas.sls
+++ b/pillar/fluentd/cas.sls
@@ -53,4 +53,4 @@ fluentd:
         - {{ auth_log_filter('grep', 'agent', '/Amazon Route 53 Health Check Service/', '**') }}
         - {{ auth_log_filter('grep', 'ident', '/CRON/') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/consul.sls
+++ b/pillar/fluentd/consul.sls
@@ -18,4 +18,4 @@ fluentd:
         - {{ auth_log_filter('grep', 'ident', 'consul', 'consul.server', 'regexp') }}
         - {{ auth_log_filter('grep', 'ident', '/CRON/') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/elasticsearch.sls
+++ b/pillar/fluentd/elasticsearch.sls
@@ -20,4 +20,4 @@ fluentd:
         - {{ auth_log_source('syslog.auth', '/var/log/auth.log') }}
         - {{ auth_log_filter('grep', 'ident', '/CRON/') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -121,4 +121,4 @@ fluentd:
         - {{ auth_log_filter('grep', 'message', '/heartbeat/', 'edx.lms.stderr') }}
         - {{ auth_log_filter('grep', 'ident', '/CRON/') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/mongodb.sls
+++ b/pillar/fluentd/mongodb.sls
@@ -17,4 +17,4 @@ fluentd:
         - {{ auth_log_source('syslog.auth', '/var/log/auth.log') }}
         - {{ auth_log_filter('grep', 'ident', '/CRON/') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/ocw_cms.sls
+++ b/pillar/fluentd/ocw_cms.sls
@@ -75,4 +75,4 @@ fluentd:
                   - format2: '/ - \w+ - (?<log_level>[A-Z]+) - (?<message>.*)/'
 {% endif %}
         - {{ record_tagging | yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward('log-input.odl.mit.edu') }}

--- a/pillar/fluentd/ocw_db.sls
+++ b/pillar/fluentd/ocw_db.sls
@@ -19,4 +19,4 @@ fluentd:
                   - '@type': regexp
                   - expression: '^(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}) \[(?<level_name>.*?)\] (?<message>.*)'
         - {{ record_tagging | yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward('log-input.odl.mit.edu') }}

--- a/pillar/fluentd/ocw_mirror.sls
+++ b/pillar/fluentd/ocw_mirror.sls
@@ -34,4 +34,4 @@ fluentd:
                   - format1: '/^--(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})--/'
                   - format2: '/\s+(?<url>.*?)\s+(?<message>.*)/'
         - {{ record_tagging | yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward('log-input.odl.mit.edu') }}

--- a/pillar/fluentd/ocw_origin.sls
+++ b/pillar/fluentd/ocw_origin.sls
@@ -37,4 +37,4 @@ fluentd:
                   - '@type': regexp
                   - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ record_tagging | yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward('log-input.odl.mit.edu') }}

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -37,4 +37,4 @@ fluentd:
                     - '@type': regexp
                     - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/rabbitmq.sls
+++ b/pillar/fluentd/rabbitmq.sls
@@ -21,4 +21,4 @@ fluentd:
         - {{ auth_log_source('syslog.auth', '/var/log/auth.log') }}
         - {{ auth_log_filter('grep', 'ident', 'CRON') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/reddit.sls
+++ b/pillar/fluentd/reddit.sls
@@ -65,4 +65,4 @@ fluentd:
                     - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - {{ auth_log_filter('grep', 'user_agent', '/ELB-HealthChecker/', 'reddit.nginx.access') }}
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}

--- a/pillar/fluentd/tls_forward.jinja
+++ b/pillar/fluentd/tls_forward.jinja
@@ -1,4 +1,5 @@
-{% set tls_forward = {
+{% macro tls_forward(host='operations-fluentd.query.consul') %}
+{%- set tls_forward = {
     'directive': 'match',
     'directive_arg': '**',
     'attrs': [
@@ -13,11 +14,13 @@
         {'nested_directives': [
             {'directive': 'server',
              'attrs': [
-                 {'host': 'operations-fluentd.query.consul'},
+                 {'host': host},
                  {'port': 5001 },
                  ]
             }
         ]
         }
     ]
-} %}
+} -%}
+{{ tls_forward|yaml() }}
+{% endmacro %}

--- a/pillar/fluentd/xqwatcher.sls
+++ b/pillar/fluentd/xqwatcher.sls
@@ -39,4 +39,4 @@ fluentd:
             - pos_file: /edx/var/log/supervisor/xqwatcher-stdout.log.pos
             - format: 'none'
         - {{ record_tagging |yaml() }}
-        - {{ tls_forward |yaml() }}
+        - {{ tls_forward }}


### PR DESCRIPTION
#### What's this PR do?
We aren't running a consul cluster in the OCW VPC and for fluentd clients to work they need to be able to resolve `operations-fluent.query.consul`. This PR gives us the ability to override the static consul setting in the `tls_forward.jinja` so that we can pass a resolvable in pillar for OCW fluentd configs.