### PR TITLE
Make production logging Elasticsearch conf like QA

### DIFF
--- a/pillar/elastic_stack/elasticsearch/logging_production.sls
+++ b/pillar/elastic_stack/elasticsearch/logging_production.sls
@@ -4,16 +4,14 @@ elastic_stack:
   elasticsearch:
     configuration_settings:
       cluster.name: {{ ENVIRONMENT }}
-      discovery.zen.minimum_master_nodes: 3
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       gateway.recover_after_nodes: 3
       gateway.expected_nodes: 5
       gateway.recover_after_time: 5m
-      discovery:
-        zen.hosts_provider: ec2
       cloud.node.auto_attributes: true
       network.host: [_eth0_, _lo_]
       path.data: /var/lib/elasticsearch/data
+      discovery.seed_providers: ec2
     plugins:
       - name: discovery-ec2
       - name: repository-s3


### PR DESCRIPTION
Change some settings in the Operations Elasticsearch (logging) cluster's configuration to bring it in-line with the one on QA, which we set up first, and which we know works as desired.
