### PR TITLE
Fix issue with ocw instances and fluentd

### DIFF
--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -58,6 +58,7 @@ fluentd:
                           - host: log-input.odl.mit.edu
                           {% else %}
                           - host: operations-fluentd.query.consul
+                          {% endif %}
                           - port: 5001
 
 beacons:

--- a/pillar/fluentd/init.sls
+++ b/pillar/fluentd/init.sls
@@ -54,6 +54,9 @@ fluentd:
                     - nested_directives:
                       - directive: server
                         attrs:
+                          {% if 'ocw' in ENVIRONMENT %}
+                          - host: log-input.odl.mit.edu
+                          {% else %}
                           - host: operations-fluentd.query.consul
                           - port: 5001
 


### PR DESCRIPTION
#### What's this PR do?
OCW instances aren't running consul and thus need to have a resolvable host to communicate with.
