### PR TITLE
Specify python binary for virtualenv

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -3,6 +3,7 @@
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 
 edx:
+  python_executable: /usr/bin/python3.5
   ansible_vars:
     EDXAPP_EXTRA_MIDDLEWARE_CLASSES: [] # Worth keeping track of in case we need to take advantage of it
     EDXAPP_ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: False

--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -56,6 +56,7 @@ create_ansible_virtualenv:
   virtualenv.managed:
     - name: {{ venv_path }}
     - requirements: {{ repo_path }}/requirements.txt
+    - python: {{ salt.pillar.get('edx:python_executable', '/usr/bin/python') }}
     - require:
       - git: clone_edx_configuration
       - file: replace_nginx_static_asset_template_fragment


### PR DESCRIPTION
Does this look like a good way to get the`virtualenv.managed` state module to use Python 3.5?

I'm getting an error running it that states, `ERROR: Package 'setuptools' requires a different Python: 2.7.12 not in '>=3.5'`.