### PR TITLE
Add OS package dependency data to next_residential pillar

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -42,8 +42,7 @@ edx:
       - libssl-dev
       - python3.5
       - python3.5-dev
-      - python-pip
-      - python-virtualenv
+      - python3-pip
+      - python3-virtualenv
       - nfs-common
       - postfix
-      - memcached

--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -32,3 +32,18 @@ edx:
       - name: raven
       - name: git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf
         extra_args: -e
+
+  dependencies:
+    os_packages:
+      - git
+      - libmysqlclient-dev
+      - mariadb-client-10.0
+      - landscape-common
+      - libssl-dev
+      - python3.5
+      - python3.5-dev
+      - python-pip
+      - python-virtualenv
+      - nfs-common
+      - postfix
+      - memcached


### PR DESCRIPTION
Add `edx:dependencies:os_packages` to `pillar/edx/ansible_vars/next_residential.sls` to try to get the AMI build orchestration to create a virtualenv with python 3.5 instead of 2.7.
