### PR TITLE
Add venv_bin param to edX Ansible virtualenv state

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -46,3 +46,5 @@ edx:
       - python3-virtualenv
       - nfs-common
       - postfix
+
+  venv_bin: /usr/lib/python3/dist-packages/virtualenv.py

--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -56,6 +56,7 @@ create_ansible_virtualenv:
   virtualenv.managed:
     - name: {{ venv_path }}
     - requirements: {{ repo_path }}/requirements.txt
+    - venv_bin: {{ salt.pillar.get('edx:venv_bin', 'virtualenv') }}
     - require:
       - git: clone_edx_configuration
       - file: replace_nginx_static_asset_template_fragment


### PR DESCRIPTION
Add new `venv_bin' parameter to the `create_ansible_virtualenv` state in
salt/edx/run_ansible.sls. The OS package for python3-virtualenv doesn't
install a `virtualenv' binary, and we need to specify the path to
`virtualenv.py`.

This is intended to fix the following error:
`salt.exceptions.CommandExecutionError: Unable to run command '['virtualenv', '/tmp/edx_config/venv']' [...] reason: command not found`