### PR TITLE
Added ELASTICSEARCH_INDEXING_CHUNK_SIZE key and set nginx value

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -125,6 +125,8 @@ heroku:
     EDX_API_URL: https://api.edx.org/catalog/v1/catalogs/10/courses
     ELASTICSEARCH_HTTP_AUTH: __vault__::secret-{{ business_unit }}/{{ env_data.env_name }}/elasticsearch>data>http_auth
     ELASTICSEARCH_INDEX: {{ env_data.ELASTICSEARCH_INDEX}}
+    # This should match the nginx config client_max_body_size in apps_es.sls
+    ELASTICSEARCH_INDEXING_CHUNK_SIZE: 75
     ELASTICSEARCH_URL: {{ env_data.ELASTICSEARCH_URL}}
     EMBEDLY_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/embedly_key>data>value
     FEATURE_ANONYMOUS_ACCESS: True

--- a/pillar/nginx/apps_es.sls
+++ b/pillar/nginx/apps_es.sls
@@ -24,7 +24,7 @@ nginx:
                   - proxy_pass: http://127.0.0.1:9200$request_uri
                   - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                   - proxy_pass_header: 'X-Api-Key'
-                  - client_max_body_size: '20m'
+                  - client_max_body_size: '75m'
               - location /_search/scroll:
                   - proxy_pass: http://127.0.0.1:9200$request_uri
                   - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'


### PR DESCRIPTION
#### What's this PR do?
- Added `ELASTICSEARCH_INDEXING_CHUNK_SIZE` as it was missing from Heroku config in addition to a comment that the value for it should match what's set in nginx
- Set the nginx `client_max_body_size` to the same value as the chunk_size
