### PR TITLE
Adding state and pillar to handle installing requirements to xqwatcher

### DIFF
--- a/pillar/edx/xqwatcher_600.sls
+++ b/pillar/edx/xqwatcher_600.sls
@@ -5,6 +5,9 @@
 {% set python3_version = 'python3.7' %}
 
 edx:
+  xqwatcher:
+    grader_requirements:
+      - numpy
   ansible_vars:
    XQWATCHER_COURSES:
     {% for purpose, purpose_data in env_data.purposes.items() %}

--- a/pillar/edx/xqwatcher_686_residential.sls
+++ b/pillar/edx/xqwatcher_686_residential.sls
@@ -5,6 +5,11 @@
 {% set python3_version = 'python3.7' %}
 
 edx:
+  xqwatcher:
+    grader_requirements:
+      - numpy
+      - torch: 1.4.0+cpu
+      - torchvision: 0.5.0+cpu
   ansible_vars:
     XQWATCHER_COURSES:
       - COURSE: mit-686x-mooc

--- a/salt/edx/xqwatcher.sls
+++ b/salt/edx/xqwatcher.sls
@@ -88,3 +88,8 @@ ensure_codejail_requirements_are_installed_for_{{  course.COURSE }}:
         HOME: /tmp
         USER: {{ course.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }}
 {% endfor %}
+
+ensure_grader_requirements_are_installed:
+  pip.installed:
+    - pkgs: {{ salt.pillar.get('edx:xqwatcher:grader_requirements', []) }}
+    - bin_env: /edx/app/xqwatcher/venvs/xqwatcher/bin/pip


### PR DESCRIPTION
There are two different sets of requirements for graders to work. One set that is used in the student submissions and one that is used by the grader code. Each of those are needed in different virtualenvs to get everything working. This PR adds a state to install packages into the xqueue-watcher virtualenv for the graders and the pillar values that we need for each of the courses.

#### What are the relevant tickets?
Trello ticket 

#### What's this PR do?
Handles installing grader dependencies in xqueue-watcher virtualenv