### PR TITLE
Reinstate Ansible interpreter, deps for edX next_residential

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -4,6 +4,7 @@
 
 edx:
   ansible_vars:
+    ansible_python_interpreter: "/usr/bin/env python"
     EDXAPP_EXTRA_MIDDLEWARE_CLASSES: [] # Worth keeping track of in case we need to take advantage of it
     EDXAPP_ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: False
 
@@ -49,3 +50,7 @@ edx:
       - python-virtualenv
       - nfs-common
       - postfix
+
+python_dependencies:
+  python_libs:
+    - virtualenv


### PR DESCRIPTION
In the next_residential pillar for the edX application, reinstate the ansible_python_interpreter variable and the `virtualenv` Python dependency. We want the Python interpreter to be 3.5 again and we want `virtualenv` installed from pip.
