### PR TITLE
Additions to deploy tika in rc-apps

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -968,6 +968,12 @@ environments:
         num_instances: 1
         security_groups:
           - webapp
+      tika:
+        app: tika
+        business_unit: mit-open
+        domains:
+          - tika-rc-apps.odl.mit.edu
+        num_instances: 2
     backends:
       pki:
         - cassandra

--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -13,7 +13,7 @@
 {% do security_groups.extend(['master-ssh', 'consul-agent']) %}
 {% set release_id = (salt.sdb.get('sdb://consul/' ~ app_name ~ '/' ~ ENVIRONMENT ~ '/release-id') or 'v1') %}
 {% set target_string = app_name ~ '-' ~ ENVIRONMENT ~ '-*-' ~ release_id %}
-{% set server_domain_names = env_data.purposes[app_name].domains|default([]) %}
+{% set server_domain_names = env_data.purposes[app_name].get('domains', []) %}
 
 load_{{ app_name }}_cloud_profile:
   file.managed:
@@ -112,7 +112,7 @@ update_mine_with_{{ app_name }}_node_data:
 {% for server_domain_name in server_domain_names %}
 {% for zone in zone_list %}
 {% if zone in server_domain_name %}
-register_{{ server_domain_names }}_nodes_with_dns:
+register_{{ server_domain_name }}_nodes_with_dns:
   boto_route53.present:
     - name: {{ server_domain_name }}
     - value: {{ hosts|tojson }}

--- a/salt/orchestrate/aws/cloud_profiles/tika.conf
+++ b/salt/orchestrate/aws/cloud_profiles/tika.conf
@@ -1,0 +1,17 @@
+# -*- mode: yaml; coding: utf-8; -*-
+tika:
+  provider: mitx
+  size: t3.medium
+  image: sdb://consul/debian_ami_id
+  ssh_username: admin
+  ssh_interface: private_ips
+  block_device_mappings:
+    - DeviceName: /dev/xvda
+      Ebs.VolumeSize: 20
+      Ebs.VolumeType: gp2
+  iam_profile: tika-instance-role
+  tag:
+    role: tika
+  grains:
+    roles:
+      - tika


### PR DESCRIPTION
#### What's this PR do?
- Adds Tika conf file
- Adds Tika config to rc-apps env
- Makes some changes to `deploy.sls` so that it can be used to also create route53 dns records in cases when a domain name(s) is/are specified in environment settings.

Note: I didn't add a sec_group as those instances should only be available to within the VPC to open instances.