### PR TITLE
Added nginx as proxy to tika

### DIFF
--- a/pillar/nginx/tika.sls
+++ b/pillar/nginx/tika.sls
@@ -1,0 +1,45 @@
+{% set server_domain_name = 'tika-{}.odl.mit.edu'.format(salt.grains.get('environment')) %}
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+{% set access_token = salt.vault.read('secret-operations/{}/tika/access-token'.format(ENVIRONMENT)).data.value %}
+
+nginx:
+  install_from_ppa: True
+  certificates:
+    odl.mit.edu:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      default:
+        enabled: False
+        deleted: True
+        config: None
+      tika:
+        enabled: True
+        config:
+          - map $http_upgrade $connection_upgrade:
+              - default: upgrade
+              - "''": close
+          - server:
+              - server_name: {{ server_domain_name }}
+              - listen: '443 ssl'
+              - listen: '[::]:443 ssl'
+              - ssl_certificate: /etc/nginx/ssl/odl.mit.edu.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl.mit.edu.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
+              - ssl_ciphers: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305\
+                   :ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256\
+                   :ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /:
+                  - 'if ($http_x_access_token != {{ access_token }})':
+                      - return: 403
+                  - proxy_pass: http://127.0.0.1:9998
+                  - proxy_set_header: Host $http_host
+                  - proxy_http_version: 1.1
+                  - proxy_set_header: X-Forwarded-For $remote_addr
+                  - proxy_pass_header: Server

--- a/pillar/nginx/tika.sls
+++ b/pillar/nginx/tika.sls
@@ -1,3 +1,4 @@
+{% set app_name = 'tika' %}
 {% set server_domain_name = 'tika-{}.odl.mit.edu'.format(salt.grains.get('environment')) %}
 {% set ENVIRONMENT = salt.grains.get('environment') %}
 {% set access_token = salt.vault.read('secret-operations/{}/tika/access-token'.format(ENVIRONMENT)).data.value %}
@@ -10,16 +11,9 @@ nginx:
       private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
   servers:
     managed:
-      default:
-        enabled: False
-        deleted: True
-        config: None
-      tika:
+      {{ app_name }}
         enabled: True
         config:
-          - map $http_upgrade $connection_upgrade:
-              - default: upgrade
-              - "''": close
           - server:
               - server_name: {{ server_domain_name }}
               - listen: '443 ssl'

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -256,6 +256,10 @@ base:
   'G@roles:rabbitmq and P@environment:(mitx-production|production-apps)':
     - match: compound
     - datadog.rabbitmq-integration
+  'roles:tika':
+    - match: grain
+    - nginx
+    - nginx.tika
   'roles:ocw-cms':
     - match: grain
     - logrotate.ocw_cms

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -971,9 +971,9 @@ environments:
       tika:
         app: tika
         business_unit: mit-open
-        domains:
-          - tika-rc-apps.odl.mit.edu
         num_instances: 2
+        security_groups:
+          - webapp
     backends:
       pki:
         - cassandra

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -198,6 +198,7 @@ base:
     - etl.mitx
   'roles:tika':
     - match: grain
+    - nginx
     - tika
   'roles:ocw-origin':
     - match: grain


### PR DESCRIPTION
#### What's this PR do?
Since Tika instances will need to be accessible from Heroku and because it's not ideal to have them  publicly accessible by anyone, we ended up having to add Nginx to those instances to act as a proxy and check for an API token when calling the Tika service.
This PR includes the Nginx config, the needed changes to the top files and the changes to the environment settings file whereby I added a sec group and removed the domain name since we'll be using an AWS ALB to front those instances.

Note: Nginx pillar config was mostly copied from the reddit one with some mods.