### PR TITLE
Add netdata-formula & add to logging cluster

### DIFF
--- a/bootstrap/etc/salt/master
+++ b/bootstrap/etc/salt/master
@@ -24,6 +24,7 @@ gitfs_remotes:
   - https://github.com/mitodl/consul-formula
   - https://github.com/mitodl/vault-formula
   - https://github.com/mitodl/fluentd-formula
+  - https://github.com/mitodl/netdata-formula
   - https://github.com/mitodl/datadog-formula
 
 root_dir: bootstrap/

--- a/bootstrap/etc/salt/master
+++ b/bootstrap/etc/salt/master
@@ -24,7 +24,6 @@ gitfs_remotes:
   - https://github.com/mitodl/consul-formula
   - https://github.com/mitodl/vault-formula
   - https://github.com/mitodl/fluentd-formula
-  - https://github.com/mitodl/netdata-formula
   - https://github.com/mitodl/datadog-formula
 
 root_dir: bootstrap/

--- a/pillar/master/config.sls
+++ b/pillar/master/config.sls
@@ -46,6 +46,7 @@ salt_master:
         - https://github.com/mitodl/monit-formula
         - https://github.com/mitodl/elastic-stack-formula
         - https://github.com/mitodl/tika-formula
+        - https://github.com/mitodl/netdata-formula
     ext_pillar:
       git_pillar_provider: pygit2
       git_pillar_base: {{ git_ref }}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -13,6 +13,8 @@ base:
     - consul.dns_proxy
     - consul.tests
     - consul.tests.test_dns_setup
+  'P@environment:operations(-qa)?':
+    - netdata
   'roles:xqwatcher':
     - match: grain
     - edx.xqwatcher
@@ -49,7 +51,6 @@ base:
     - elastic-stack.elasticsearch
     - elastic-stack.elasticsearch.plugins
     - datadog.plugins
-    - netdata
   'roles:rabbitmq':
     - match: grain
     - rabbitmq

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -49,6 +49,7 @@ base:
     - elastic-stack.elasticsearch
     - elastic-stack.elasticsearch.plugins
     - datadog.plugins
+    - netdata
   'roles:rabbitmq':
     - match: grain
     - rabbitmq


### PR DESCRIPTION
Add recently-created `netdata-formula` and associate it with the Elasticsearch logging cluster, so that we can use that as a test case in QA.