### PR TITLE
Add netdata state to more environments

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -13,7 +13,9 @@ base:
     - consul.dns_proxy
     - consul.tests
     - consul.tests.test_dns_setup
-  'P@environment:operations(-qa)?':
+  'P@environment:(operations|mitx|mitxpro)(-qa)?':
+    - netdata
+  'P@environment:(rc|production)-apps':
     - netdata
   'roles:xqwatcher':
     - match: grain

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,6 +1,7 @@
 base:
   '*':
     - utils.install_libs
+    - netdata
   'not G@roles:devstack':
     - match: compound
     - utils.inotify_watches
@@ -13,10 +14,6 @@ base:
     - consul.dns_proxy
     - consul.tests
     - consul.tests.test_dns_setup
-  'P@environment:(operations|mitx|mitxpro)(-qa)?':
-    - netdata
-  'P@environment:(rc|production)-apps':
-    - netdata
   'roles:xqwatcher':
     - match: grain
     - edx.xqwatcher


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/salt-ops/issues/27

#### What's this PR do?

Adds the `netdata` state to more environments, as was done  earlier for `operations`.
