### PR TITLE
Retry conditional system_site_packages for virtualenv

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -56,7 +56,7 @@ create_ansible_virtualenv:
   virtualenv.managed:
     - name: {{ venv_path }}
     - requirements: {{ repo_path }}/requirements.txt
-    - system_site_packages: False
+    - system_site_packages: {{ 'juniper' in grains.get('edx_codename', "") }}
     - no_setuptools: True
     - require:
       - git: clone_edx_configuration


### PR DESCRIPTION
Retry what was attempted in commit
2aa0515126c7a8a1cefb1f5cc2aec051262f180e, but with a default value that
allows the template to be rendered if the `edx_codename' grain is
undefined.
