### PR TITLE
Add netdata ports to "master-ssh" security groups

### DIFF
--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -420,6 +420,12 @@ create_master_ssh_security_group:
           to_port: 22
           cidr_ip:
             - 10.0.0.0/22
+        # netdata:
+        - ip_protocol: tcp
+          from_port: 19999
+          to_port: 19999
+          cidr_ip:
+            - 10.0.0.0/22
     - require:
         - boto_vpc: create_{{ ENVIRONMENT }}_vpc
 

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -27,6 +27,13 @@ create_master_ssh_security_group:
           cidr_ip:
             - 10.0.0.0/22
             - 10.1.0.0/22
+        # netdata:
+        - ip_prodocol: tcp
+          from_port: 19999
+          to_port: 19999
+          cidr_ip:
+            - 10.0.0.0/22
+            - 10.0.0.0/22
     - tags:
         Name: master-ssh-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}

--- a/salt/orchestrate/aws/security_groups.sls
+++ b/salt/orchestrate/aws/security_groups.sls
@@ -33,7 +33,7 @@ create_master_ssh_security_group:
           to_port: 19999
           cidr_ip:
             - 10.0.0.0/22
-            - 10.0.0.0/22
+            - 10.1.0.0/22
     - tags:
         Name: master-ssh-{{ ENVIRONMENT }}
         business_unit: {{ BUSINESS_UNIT }}


### PR DESCRIPTION
Add rules to allow access on Netdata's port, to the existing "master-ssh" security groups. This allows us to access Netdata via SSH tunnels.
