### PR TITLE
Added default config for data path

### DIFF
--- a/pillar/elastic_stack/elasticsearch/init.sls
+++ b/pillar/elastic_stack/elasticsearch/init.sls
@@ -6,5 +6,7 @@ elastic_stack:
       cluster.name: {{ ENVIRONMENT }}
       discovery.ec2.tag.escluster: {{ ENVIRONMENT }}
       network.host: ['_eth0:ipv4_', '_lo:ipv4_']
+      path:
+        data: /var/lib/elasticsearch/data
     plugins:
       - name: discovery-ec2

--- a/pillar/elasticsearch/init.sls
+++ b/pillar/elasticsearch/init.sls
@@ -5,6 +5,8 @@ elasticsearch:
   lookup:
     elastic_stack: True
     configuration_settings:
+      path:
+        data: /var/lib/elasticsearch/data
       discovery:
         zen.hosts_provider: ec2
       cluster.name: {{ ENVIRONMENT }}


### PR DESCRIPTION
The data path for elasticsearch is not being set by default and in some cases results in the data being stored on the root drive.