### PR TITLE
Adding configuration for sentry log handler on master

### DIFF
--- a/pillar/master/config.sls
+++ b/pillar/master/config.sls
@@ -62,6 +62,12 @@ salt_master:
         host: fluentd.service.consul
         port: 9999
         version: 1
+      sentry_handler:
+        dsn: __vault__::secret-operations/global/saltstack-sentry-dsn>data>value
+        context:
+          - id
+          - environment
+          - saltversion
     reactors:
       reactor:
         - salt/beacon/*/inotify/*:

--- a/pillar/master/init.sls
+++ b/pillar/master/init.sls
@@ -33,6 +33,7 @@ salt_master:
       - python-consul
       - python-dateutil
       - pyyaml
+      - raven
       - requests
   ssl:
     cert_path: /etc/salt/ssl/certs/salt.odl.mit.edu.crt


### PR DESCRIPTION
We have situations where pillar data is failing due to various issues which gets missed due to the lack of processing on salt logs. This adds the Sentry log handler so that exceptions will be surfaced and we can keep better track of them.