### PR TITLE
Add Datadog HTTP check for OCW CMS

### DIFF
--- a/pillar/datadog/http-check-integration.sls
+++ b/pillar/datadog/http-check-integration.sls
@@ -133,3 +133,12 @@ datadog:
             days_critical: 15
             tags:
               - mitxpro
+          - name: ocw-cms-production
+            url: 'https://ocwcms.mit.edu/acl_users/credentials_cookie_auth/require_login'
+            tls_verify: true
+            check_certificate_expiration: true
+            days_warning: 30
+            days_critical: 15
+            timeout: 60
+            tags:
+              - ocw-cms-production


### PR DESCRIPTION
This adds a Datadog HTTP Check for the OCW CMS.  Is this adequate? These appear to run on the Kibana server, so I added a rule to allow it in the security group that the CMS belongs to.
