### PR TITLE
Add a Kibana instance

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -445,3 +445,11 @@ elastic_stack:
                 filter:
                   - term:
                       fluentd_tag: edx.cms
+
+datadog:
+  integrations:
+    process:
+      settings:
+        instances:
+          - name: elastalert
+            search_string: ['elastalert']

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -681,7 +681,7 @@ environments:
           - webapp
       kibana:
         app: kibana
-        num_instances: 1
+        num_instances: 2
         domains:
           - logs.odl.mit.edu
         business_unit: operations


### PR DESCRIPTION
Add a Kibana instance, which will give us more than one Elastalert
agent, for better alerting reliability.

It will also give us a hot standby for Kibana.

