### PR TITLE
Fix fluentd regex and monitor edX unregistered task errors

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -445,3 +445,23 @@ elastic_stack:
                 filter:
                   - term:
                       fluentd_tag: edx.cms
+      - name: edx_unregistered_task
+        settings:
+          name: edX task failing
+          description: >-
+            A task has failed due to a mismatch in the source code between the
+            app and worker node.
+          type: frequency
+          index: logstash-mitx*-production*
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - opsgenie
+          alert_text: "Source code mismatch between edX app and worker nodes"
+          filter:
+            - bool:
+                must:
+                  - query_string:
+                      default_field: message
+                      query: (received unregistered task) AND (message has been ignored)

--- a/pillar/fluentd/mitx.sls
+++ b/pillar/fluentd/mitx.sls
@@ -46,7 +46,7 @@ fluentd:
             - pos_file: /edx/var/log/supervisor/cms-stderr.pos
             - format: multiline
             - format_firstline: '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/'
-            - format1: '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:,\d{3}| [+\-]\d{4}\])? (?<message>.*)/'
+            - format1: '/\[?\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:,\d{3}:?| [+\-]\d{4}\])? (?<message>.*)/'
             - multiline_flush_interval: '5s'
         - directive: source
           attrs:


### PR DESCRIPTION
This PR does two things:
* It improves a regex in our FluentD configuration so that it parses a new timestamp format that's mixed in with the other formats we've already parsed.
* It adds an Elastalert alert for "Received unregistered task" messages that result from the code on the worker and app server being out of sync.

See https://trello.com/c/qZBWIpSf/57-add-an-elastalert-for-unregistered-tasks-in-edx

I've checked the regular expressions with rubular.com against the following sample lines:

(Already-handled)
```
2019-10-23 11:58:32,696 WARNING 7812 [enterprise.utils] utils.py:50 - Could not import Registry from third_party_auth.provider
```

(New line that is currently generating FluentD error messages)
```
[2020-03-11 13:55:03,108: ERROR/MainProcess] Received unregistered task of type 
```