### PR TITLE
Change mailgun domain for OVS

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -106,7 +106,7 @@ django:
     GA_TRACKING_ID: {{ env_data.ga_id }}
     LECTURE_CAPTURE_USER: {{ salt.sdb.get('sdb://consul/odl-video-service/lecture-capture-user') }}
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
-    MAILGUN_URL: https://api.mailgun.net/v3/video.odl.mit.edu
+    MAILGUN_URL: https://api.mailgun.net/v3/video-mail.odl.mit.edu
     MIT_WS_CERTIFICATE: __vault__::secret-odl-video/global/mit-application-certificate>data>certificate
     MIT_WS_PRIVATE_KEY: __vault__::secret-odl-video/global/mit-application-certificate>data>private_key
     ODL_VIDEO_ADMIN_EMAIL: cuddle_bunnies@mit.edu


### PR DESCRIPTION
#### What's this PR do?
As part of the work of moving the OVS app behind an ALB, we ran into an issue whereby we couldn't change the A record of `video.odl.mit.edu` that's pointing to an EC2 instance to a CNAME since that name has MX and TXT records pointing to mailgun. Created a new mailgun domain and added those records to Route 53 so that it doesn't conflict with `video.odl.mit.edu`. 
This minor change points to the newly created maligun domain.

