### PR TITLE
Condition to skip worker service restart on base

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -97,6 +97,7 @@ run_ansible:
     - env:
         HOME: /root
 
+{% if 'edx-base-worker' not in salt.grains.get('roles') %}
 {% if 'edx-worker' in salt.grains.get('roles') and not 'qa' in salt.grains.get('environment') %}
 restart_edx_worker_service:
   supervisord.running:
@@ -107,6 +108,7 @@ restart_edx_worker_service:
       - file: place_ansible_environment_configuration
     - require:
       - cmd: run_ansible
+{% endif %}
 {% endif %}
 
 {% if 'edx-analytics' in salt.grains.get('roles') %}


### PR DESCRIPTION
#### What's this PR do?
When running the `build_ami` state, `orchestrate.edx.build_ami.build_edx_base_nodes` fails when restarting the supervisord services on the worker instances as I believe it's timing out waiting for a response. The change here isn't a fix but a patch to sidestep the restart while building the ami.


