### PR TITLE
Changed OVS url for datadog healthcheck

### DIFF
--- a/pillar/datadog/http-check-integration.sls
+++ b/pillar/datadog/http-check-integration.sls
@@ -84,9 +84,8 @@ datadog:
             tags:
               - mitxpro-production
           - name: odl-video-service-production
-            url: 'https://video.odl.mit.edu/status?token=production-apps'
+            url: 'https://video.odl.mit.edu/static/hash.txt'
             tls_verify: true
-            content_match: 'up'
             check_certificate_expiration: true
             days_warning: 30
             days_critical: 15


### PR DESCRIPTION
#### What's this PR do?
Noticed a lot of false alerts being generated by the OVS Datadog http health check. I made the change to match what we currently have setup as a health check endpoint on the ALB. Think that's more accurate and should cut stop the incoming false alerts.

