### PR TITLE
Add Elastalert: edX S3ResponseError

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -500,9 +500,9 @@ elastic_stack:
                   - query_string:
                       default_field: message
                       query: S3ResponseError
-                filter:
-                  - term:
-                      fluentd_tag: edx.*
+                  - query_string:
+                      default_field: fluentd_tag
+                      query: edx.cms.* OR edx.lms.*
       - name: edx_unregistered_task
         settings:
           name: edX task failing

--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -475,6 +475,34 @@ elastic_stack:
                 filter:
                   - term:
                       fluentd_tag: edx.cms
+      - name: edx_s3_response_error
+        settings:
+          name: edX S3 Response Error
+          description: >-
+            An edX worker got an error from S3 while trying to export course
+            content to Git. This usually means that the uwsgi service needs to
+            be restarted so that Celery can pick up updated credentials.
+          index: logstash-mitx*-production*
+          type: frequency
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - slack
+          alert_text: "Automated git export failure"
+          slack_webhook_url: {{ slack_webhook_url }}
+          slack_channel_override: '#mitx-tech-notifs'
+          slack_username_override: Elastalert
+          slack_msg_color: "warning"
+          filter:
+            - bool:
+                must:
+                  - query_string:
+                      default_field: message
+                      query: S3ResponseError AND async_export_to_git
+                filter:
+                  - term:
+                      fluentd_tag: edx.cms.stderr
       - name: edx_unregistered_task
         settings:
           name: edX task failing

--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -502,7 +502,7 @@ elastic_stack:
                       query: S3ResponseError
                 filter:
                   - term:
-                      fluentd_tag: edx.cms.stderr
+                      fluentd_tag: edx.*
       - name: edx_unregistered_task
         settings:
           name: edX task failing

--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -480,8 +480,8 @@ elastic_stack:
           name: edX S3 Response Error
           description: >-
             An edX worker got an error from S3 while trying to export course
-            content to Git. This usually means that the uwsgi service needs to
-            be restarted so that Celery can pick up updated credentials.
+            content to Git. This may mean that the process needs to be
+            restarted, or the credentials might need to be refreshed.
           index: logstash-mitx*-production*
           type: frequency
           num_events: 1

--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -499,7 +499,7 @@ elastic_stack:
                 must:
                   - query_string:
                       default_field: message
-                      query: S3ResponseError AND async_export_to_git
+                      query: S3ResponseError
                 filter:
                   - term:
                       fluentd_tag: edx.cms.stderr


### PR DESCRIPTION
Add an Elastalert alert for when course content can not be exported to Git due to an S3 403 Forbidden error.
