### PR TITLE
Sync all modules before installing consul

### DIFF
--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -141,6 +141,12 @@ reload_pillar_data_on_edx_nodes:
     - require:
         - salt: populate_mine_with_edx_node_data
 
+saltutil_sync_all:
+  salt.function:
+    - name: saltutil.sync_all
+    - tgt: 'P@roles:(edx-base|edx-base-worker) and G@environment:{{ ENVIRONMENT }}'
+    - tgt_type: compound
+
 {# Deploy Consul agent first so that the edx deployment can use provided DNS endpoints #}
 deploy_consul_agent_to_edx_nodes:
   salt.state:


### PR DESCRIPTION
#### What's this PR do?
`build_ami` state run fails the first time trying to install consul because it hadn't synced our modules. So we then have to sync those and run the build again and if we're lucky, it works. This change syncs the modules prior to trying to install consul.