### PR TITLE
Update security group names in Kibana orchestration

### DIFF
--- a/salt/orchestrate/operations/services/kibana.sls
+++ b/salt/orchestrate/operations/services/kibana.sls
@@ -30,9 +30,9 @@ generate_{{ app_name }}_cloud_map_file:
         release_id: {{ salt.sdb.get('sdb://consul/{{ app_name }}/{{ ENVIRONMENT }}/release-id')|default('v1') }}
         securitygroupid:
           - {{ salt.boto_secgroup.get_group_id(
-            'webapp-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'webapp-odl-vpn-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}

--- a/salt/orchestrate/operations/services/kibana.sls
+++ b/salt/orchestrate/operations/services/kibana.sls
@@ -32,7 +32,7 @@ generate_{{ app_name }}_cloud_map_file:
           - {{ salt.boto_secgroup.get_group_id(
             'webapp-odl-vpn-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
-            'salt_master-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
+            'master-ssh-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
           - {{ salt.boto_secgroup.get_group_id(
             'consul-agent-{}'.format(ENVIRONMENT), vpc_name=VPC_NAME) }}
         subnetids: {{ subnet_ids|tojson }}


### PR DESCRIPTION
I hope that this will fix a problem I'm seeing running the Kibana orchestration.

It's failing silently on `load_pillar_data_on_kibana_nodes`.

The rendered cloud map file is missing security groups that the old Kibana server belongs to:

```
         SecurityGroupId:


            - sg-03b82776





            - sg-5e6bbc2f


 
```

