### PR TITLE
Make newer OpenSSL accept 1024-bit MIT CA key

### DIFF
--- a/salt/utils/mitca_pem.sls
+++ b/salt/utils/mitca_pem.sls
@@ -2,3 +2,9 @@ create_mitca_pem_file:
   file.managed:
     - name: /etc/ssl/certs/mitca.pem
     - contents_pillar: mitca:pem_contents
+
+make_openssl_allow_1024_bit_ca_key:
+  file.replace:
+    - name: /etc/ssl/openssl.cnf
+    - pattern: CipherString=DEFAULT@SECLEVEL=2
+    - repl: CipherString=DEFAULT@SECLEVEL=1


### PR DESCRIPTION
For verifying client certificates, allow verification to proceed with MIT's 1024-bit CA key. Debian 10 uses a newer version of Openssl than Debian 9, and requires a 2048-bit CA key, by default, when it verifies client certificates. Applications like Kibana, in its Nginx configuration, verify client certificates, which is delegated to OpenSSL.

Without this change, we get the error `CA certificate key too weak` when we have info-level logging turned on in Nginx.

