### PR TITLE
Add ODL Video uWSGI log to be read by FluentD

### DIFF
--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -36,5 +36,19 @@ fluentd:
                   attrs:
                     - '@type': regexp
                     - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
+        - directive: source
+          attrs:
+            - '@id': odlvideo_uwsgi_log
+            - '@type': tail
+            - enable_watch_timer: 'false'
+            - tag: odlvideo.uwsgi
+            - path: /var/log/uwsgi/apps/odl-video-service.log
+            - pos_file: /var/log/uwsgi/apps/odl-video-service.log.pos
+            - nested_directives:
+                - directive: parse
+                  attrs:
+                    - '@type': json
+                    - json_parser: json
+                    - keep_time_key: 'true'
         - {{ record_tagging |yaml() }}
         - {{ tls_forward() }}


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd

#### What's this PR do?

It adds ODL Video's uWSGI log file to be picked up by FluentD and sent to ELK.

This should not be released until https://github.com/mitodl/odl-video-service/pull/865 is merged and deployed and ODL Video's uWSGI log is actually getting written in JSON format.
