### PR TITLE
Add csrf cookie in residential nginx config

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -97,7 +97,7 @@ run_ansible:
     - env:
         HOME: /root
 
-update_max_upload_size_for_lms:
+update_max_upload_size_and_set_csrf_for_lms:
   file.replace:
     - name: /etc/nginx/sites-enabled/lms
     - pattern: 'client_max_body_size\s+\d+M;'
@@ -105,11 +105,16 @@ update_max_upload_size_for_lms:
     - backup: False
     - require:
         - cmd: run_ansible
+  file.line:
+    - name: /etc/nginx/sites-enabled/lms
+    - mode: ensure
+    - content: add_header Set-Cookie "csrftoken=resetmit; Domain=.mit.edu; Expires=1/January/2019 00:00:00";
+    - after: P3P*
   service.running:
     - name: nginx
     - reload: True
     - onchanges:
-        - file: update_max_upload_size_for_lms
+        - file: update_max_upload_size_and_set_csrf_for_lms
 
 {% if 'edx-base-worker' not in salt.grains.get('roles') %}
 {% if 'edx-worker' in salt.grains.get('roles') and not 'qa' in salt.grains.get('environment') %}

--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -97,7 +97,7 @@ run_ansible:
     - env:
         HOME: /root
 
-update_max_upload_size_and_set_csrf_for_lms:
+update_max_upload_for_lms:
   file.replace:
     - name: /etc/nginx/sites-enabled/lms
     - pattern: 'client_max_body_size\s+\d+M;'
@@ -105,16 +105,21 @@ update_max_upload_size_and_set_csrf_for_lms:
     - backup: False
     - require:
         - cmd: run_ansible
+
+set_expired_csrf_token_for_lms
   file.line:
     - name: /etc/nginx/sites-enabled/lms
     - mode: ensure
     - content: add_header Set-Cookie "csrftoken=resetmit; Domain=.mit.edu; Expires=1/January/2019 00:00:00";
     - after: P3P*
+
+reload_nginx_config
   service.running:
     - name: nginx
     - reload: True
     - onchanges:
-        - file: update_max_upload_size_and_set_csrf_for_lms
+        - file: update_max_upload_for_lms
+        - file: set_expired_csrf_token_for_lms
 
 {% if 'edx-base-worker' not in salt.grains.get('roles') %}
 {% if 'edx-worker' in salt.grains.get('roles') and not 'qa' in salt.grains.get('environment') %}


### PR DESCRIPTION
#### What's this PR do?
Adds a config to Nginx to set an expired csrf token with a domain set to `.mit.edu`. This is meant to overwrite some students having that csrf token set and causing them issues by logging them out of residential as that's the token used instead of the one set by the more specific one set by the residential platform.