### PR TITLE
Fix for residential csrftoken issue

### DIFF
--- a/salt/edx/run_ansible.sls
+++ b/salt/edx/run_ansible.sls
@@ -106,12 +106,16 @@ update_max_upload_for_lms:
     - require:
         - cmd: run_ansible
 
-# set_expired_csrf_token_for_lms:
-#   file.line:
-#     - name: /etc/nginx/sites-enabled/lms
-#     - mode: ensure
-#     - content: 'add_header Set-Cookie "csrftoken=resetmit; Domain=.mit.edu; Expires=1/January/2019 00:00:00";'
-#     - after: P3P*
+# Added to resolve logout issues for some caused by a local site setting
+# a csrftoken with the .mit.edu domain. Expires and max-age are both set
+# as different browsers respond differently.
+
+set_expired_csrf_token_for_lms:
+  file.line:
+    - name: /etc/nginx/sites-enabled/lms
+    - mode: ensure
+    - content: 'add_header Set-Cookie "csrftoken=resetmit; Domain=.mit.edu; Expires=1/January/2019 00:00:00; max-age=-1";'
+    - after: P3P*
 
 reload_nginx_config:
   service.running:


### PR DESCRIPTION
#### What's this PR do?
Fixes the logout issues reported in residential due to a conflicting csrf token. This has now been tested on Chrome, Firefox, and Safari. It appears that Safari disregards the `Expires` key however responds to `max-age`. Also added a comment explaining why we've added this Nginx directive.
