### PR TITLE
Change ODL video log location for FluentD

### DIFF
--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -120,7 +120,7 @@ django:
     ODL_VIDEO_FROM_EMAIL: MIT ODL Video <odl-video-support@mit.edu>
     ODL_VIDEO_LOG_LEVEL: {{ env_data.log_level }}
     ODL_VIDEO_SUPPORT_EMAIL: MIT ODL Video <odl-video-support@mit.edu>
-    ODL_VIDEO_LOG_FILE: /var/log/odl-video-service.log
+    ODL_VIDEO_LOG_FILE: /var/log/odl-video/django.log
     REDIS_URL: redis://ovs-{{ env_data.env_name }}-redis.service.consul:6379/0
     SECRET_KEY: __vault__::secret-{{ business_unit }}/{{ ENVIRONMENT }}/django-secret-key>data>value
     SENTRY_DSN: __vault__::secret-{{ business_unit }}/global/sentry-dsn>data>value

--- a/pillar/apps/odlvideo.sls
+++ b/pillar/apps/odlvideo.sls
@@ -120,6 +120,7 @@ django:
     ODL_VIDEO_FROM_EMAIL: MIT ODL Video <odl-video-support@mit.edu>
     ODL_VIDEO_LOG_LEVEL: {{ env_data.log_level }}
     ODL_VIDEO_SUPPORT_EMAIL: MIT ODL Video <odl-video-support@mit.edu>
+    ODL_VIDEO_LOG_FILE: /var/log/odl-video-service.log
     REDIS_URL: redis://ovs-{{ env_data.env_name }}-redis.service.consul:6379/0
     SECRET_KEY: __vault__::secret-{{ business_unit }}/{{ ENVIRONMENT }}/django-secret-key>data>value
     SENTRY_DSN: __vault__::secret-{{ business_unit }}/global/sentry-dsn>data>value

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -42,8 +42,8 @@ fluentd:
             - '@type': tail
             - enable_watch_timer: 'false'
             - tag: odlvideo.uwsgi
-            - path: /var/log/odl-video-service.log
-            - pos_file: /var/log/odl-video-service.log.pos
+            - path: /var/log/odl-video/django.log
+            - pos_file: /var/log/odl-video/django.log.pos
             - nested_directives:
                 - directive: parse
                   attrs:

--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -42,8 +42,8 @@ fluentd:
             - '@type': tail
             - enable_watch_timer: 'false'
             - tag: odlvideo.uwsgi
-            - path: /var/log/uwsgi/apps/odl-video-service.log
-            - pos_file: /var/log/uwsgi/apps/odl-video-service.log.pos
+            - path: /var/log/odl-video-service.log
+            - pos_file: /var/log/odl-video-service.log.pos
             - nested_directives:
                 - directive: parse
                   attrs:

--- a/pillar/logrotate/odlvideo.sls
+++ b/pillar/logrotate/odlvideo.sls
@@ -1,0 +1,10 @@
+logrotate:
+  odlvideo:
+    name: /var/log/odl-video/django.log
+    options:
+      - rotate 7
+      - daily
+      - copytruncate
+      - notifempty
+      - compress
+      - delaycompress

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -94,6 +94,7 @@ base:
     - shibboleth
     - shibboleth.odlvideo
     - fluentd.odlvideo
+    - logrotate.odlvideo
   proxy-bootcamps-*:
     - heroku.bootcamps
   proxy-mitxpro-*:

--- a/salt/apps/odlvideo/configure.sls
+++ b/salt/apps/odlvideo/configure.sls
@@ -15,7 +15,7 @@ create_env_file_for_odlvideo:
 
 ensure_perms_of_odlvideo_app_log:
   file.managed:
-    - name: /var/log/odl-video-service.log
+    - name: /var/log/odl-video/django.log
     - user: deploy
     - group: deploy
     - mode: 0644

--- a/salt/apps/odlvideo/configure.sls
+++ b/salt/apps/odlvideo/configure.sls
@@ -12,3 +12,12 @@ create_env_file_for_odlvideo:
     - onchanges_in:
         - service: uwsgi_service_running
         - file: signal_odlvideo_deploy_complete
+
+ensure_perms_of_odlvideo_app_log:
+  file.managed:
+    - name: /var/log/odl-video-service.log
+    - user: deploy
+    - group: deploy
+    - mode: 0644
+    - onchanges_in:
+        - service: uwsgi_service_running

--- a/salt/apps/odlvideo/configure.sls
+++ b/salt/apps/odlvideo/configure.sls
@@ -13,6 +13,15 @@ create_env_file_for_odlvideo:
         - service: uwsgi_service_running
         - file: signal_odlvideo_deploy_complete
 
+ensure_perms_of_odlvideo_log_dir:
+  file.directory:
+    - name: /var/log/odl-video/
+    - user: deploy
+    - group: deploy
+    - dir_mode: 0755
+    - onchanges_in:
+        - service: uwsgi_service_running
+
 ensure_perms_of_odlvideo_app_log:
   file.managed:
     - name: /var/log/odl-video/django.log

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -125,6 +125,9 @@ base:
     - nginx-shibboleth
     - django
     - uwsgi
+  'roles:odl-video-service':
+    - match: grain
+    - utils.logrotate
   'roles:redash':
     - match: grain
     - utils.configure_debian_source_repos


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd

#### What's this PR do?

See https://github.com/mitodl/odl-video-service/pull/883

It changes the location of the log that's read by FluentD.

It ensures that the log file is writable by the `deploy` account, under which the Django app workers run.

I started to parameterize the logfile location, but I balked because I wasn't sure if that was necessary, and also because I recalled that it is hard to include pillar data from one pillar file in another pillar file.  Can you suggest any way to have the file path coded in only one place?
