### PR TITLE
Added nginx to front alcali

### DIFF
--- a/pillar/nginx/alcali.sls
+++ b/pillar/nginx/alcali.sls
@@ -1,0 +1,48 @@
+{% set app_name = 'alcali' %}
+{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set ENVIRONMENT = salt.grains.get('environment', 'operations') %}
+{% set env_data = env_settings.environments[ENVIRONMENT] %}
+{% set server_domain_names = env_data.purposes[app_name].domains %}
+
+nginx:
+  install_from_ppa: True
+  certificates:
+    odl.mit.edu:
+      public_cert: __vault__::secret-operations/global/odl_wildcard_cert>data>value
+      private_key: __vault__::secret-operations/global/odl_wildcard_cert>data>key
+  servers:
+    managed:
+      {{ app_name }}:
+        enabled: True
+        config:
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen: 80
+              - listen: '[::]:80'
+              - location /:
+                  - return: 301 https://$host$request_uri
+          - server:
+              - server_name: {{ server_domain_names|tojson }}
+              - listen: '443 ssl default_server'
+              - listen: '[::]:443 ssl'
+              - ssl_certificate: /etc/nginx/ssl/odl_wildcard.crt
+              - ssl_certificate_key: /etc/nginx/ssl/odl_wildcard.key
+              - ssl_stapling: 'on'
+              - ssl_stapling_verify: 'on'
+              - ssl_session_timeout: 1d
+              - ssl_session_tickets: 'off'
+              - ssl_protocols: 'TLSv1.2 TLSv1.3'
+              - ssl_ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256\
+                  :DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384\
+                  :ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256\
+                  :ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256"
+              - ssl_prefer_server_ciphers: 'on'
+              - resolver: 1.1.1.1
+              - location /:
+                  - proxy_pass: http://127.0.0.1:8000
+                  - proxy_http_version: 1.1
+                  - proxy_set_header: 'Connection "upgrade"'
+                  - proxy_set_header: Upgrade $http_upgrade
+                  - proxy_set_header: Host $http_host
+                  - proxy_set_header: X-Forwarded-For $remote_addr
+                  - proxy_pass_header: Server

--- a/pillar/nginx/alcali.sls
+++ b/pillar/nginx/alcali.sls
@@ -41,8 +41,6 @@ nginx:
               - location /:
                   - proxy_pass: http://127.0.0.1:8000
                   - proxy_http_version: 1.1
-                  - proxy_set_header: 'Connection "upgrade"'
-                  - proxy_set_header: Upgrade $http_upgrade
                   - proxy_set_header: Host $http_host
                   - proxy_set_header: X-Forwarded-For $remote_addr
                   - proxy_pass_header: Server

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -75,6 +75,8 @@ base:
     - consul.mongodb
   alcali*:
     - apps.alcali
+    - nginx
+    - nginx.alcali
   dremio*:
     - dremio
     - nginx

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -72,6 +72,7 @@ base:
     - nginx
   alcali*:
     - alcali
+    - nginx
   'roles:consul_server':
     - match: grain
     - consul


### PR DESCRIPTION
#### What's this PR do?
Adds Nginx as a reverse proxy for alcali as the default install uses gunicorn as a web server.
