### PR TITLE
Fix ALLOWED_HOSTS for bootcamps

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -56,7 +56,7 @@ heroku:
   app_name: {{ env_data.app_name }}
   api_key: __vault__::secret-operations/global/heroku/api_key>data>value
   config_vars:
-    ALLOWED_HOSTS: '[*]'
+    ALLOWED_HOSTS: '["*"]'
     BOOTCAMP_ADMIN_EMAIL: cuddle-bunnies@mit.edu
     BOOTCAMP_ADMISSION_BASE_URL: {{ env_data.BOOTCAMP_ADMISSION_BASE_URL }}
     BOOTCAMP_ADMISSION_KEY: __vault__::secret-{{ business_unit }}/{{ env_data.vault_env_path }}/>admissions>admission_key>data>value


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes the `ALLOWED_HOSTS` value to quote the wildcard so that the app will parse it.

#### How should this be manually tested?
- Verify in CI/RC that you're getting a Bad Request error trying to hit the site
- Apply this in CI/RC and verify the site is reachable now