### PR TITLE
Change name of FluentD tag for ODL Video Django log

### DIFF
--- a/pillar/fluentd/odlvideo.sls
+++ b/pillar/fluentd/odlvideo.sls
@@ -38,10 +38,10 @@ fluentd:
                     - expression: '^(?<time>\d+\/\d+\/\d+\s\d+:\d+:\d+)\s(?<level_name>\[.*])\s(?<message>.*)'
         - directive: source
           attrs:
-            - '@id': odlvideo_uwsgi_log
+            - '@id': odlvideo_application_log
             - '@type': tail
             - enable_watch_timer: 'false'
-            - tag: odlvideo.uwsgi
+            - tag: odlvideo.application
             - path: /var/log/odl-video/django.log
             - pos_file: /var/log/odl-video/django.log.pos
             - nested_directives:


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd

#### What's this PR do?

Changes the FluentD tag used for the new Django log file.

This is a tiny change, but I just wanted to make sure it doesn't go against any of our naming conventions.
