### PR TITLE
Adding config for Bootcamps access to S3

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -65,6 +65,9 @@ heroku:
   api_key: __vault__::secret-operations/global/heroku/api_key>data>value
   config_vars:
     ALLOWED_HOSTS: '["*"]'
+    AWS_ACCESS_KEY_ID:  __vault__:cache:aws-mitx/creds/read-write-delete-ol-bootcamps-app-{{ env_data.env_name }}>data>access_key
+    AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/read-write-delete-ol-bootcamps-app-{{ env_data.env_name }}>data>secret_key
+    AWS_STORAGE_BUCKET_NAME: 'ol-bootcamps-app-{{ env_data.env_name }}'
     BOOTCAMP_ADMIN_EMAIL: cuddle-bunnies@mit.edu
     BOOTCAMP_ADMISSION_BASE_URL: {{ env_data.BOOTCAMP_ADMISSION_BASE_URL }}
     BOOTCAMP_ADMISSION_KEY: __vault__::secret-{{ business_unit }}/{{ env_data.vault_env_path }}/>admissions>admission_key>data>value

--- a/salt/orchestrate/aws/s3_buckets/bootcamps.sls
+++ b/salt/orchestrate/aws/s3_buckets/bootcamps.sls
@@ -1,13 +1,13 @@
 {% for env in ['rc', 'ci', 'production'] %}
-xpro-app-{{ env }}:
+ol-bootcamps-app-{{ env }}:
   boto_s3_bucket.present:
-    - Bucket: xpro-app-{{ env }}
+    - Bucket: ol-bootcamps-app-{{ env }}
     - Versioning:
         Status: Enabled
     - region: us-east-1
     - Tagging:
-        OU: mitxpro
-        business_unit: mitxpro
-        Department: mitxpro
+        OU: bootcamps
+        business_unit: bootcamps
+        Department: bootcamps
         Environment: {{ env }}
 {% endfor %}


### PR DESCRIPTION
----

#### What's this PR do?
Adds config to Heroku for accessing S3 to be used for Wagtail uploads, as well as adding logic to create the necessary buckets.

#### Any background context you want to provide?
The Wagtail code for bootcamps was copied from xPRO but the necessary settings didn't get set up yet. This should resolve that, allowing media uploads to function properly.