### PR TITLE
Change elk version includes

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -7,7 +7,7 @@ base:
   'P@environment:(rc.*|.*-qa)':
     - match: compound
     - elastic_stack.version_qa
-  'not P@environment:(rc.*|.*-qa|ci)':
+  'not P@environment:(rc.*|.*-qa)':
     - match: compound
     - elastic_stack.version_production
   'roles:auth_server':

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -5,7 +5,7 @@ base:
     - environment_settings
     - fluentd
   'P@environment:(rc.*|.*-qa|ci)':
-    - match: copound
+    - match: compound
     - elastic_stack.version_qa
   'not P@environment:(rc.*|.*-qa|ci)':
     - match: compound

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -4,7 +4,7 @@ base:
     - common
     - environment_settings
     - fluentd
-  'P@environment:(rc.*|.*-qa|ci)':
+  'P@environment:(rc.*|.*-qa)':
     - match: compound
     - elastic_stack.version_qa
   'not P@environment:(rc.*|.*-qa|ci)':

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -4,6 +4,12 @@ base:
     - common
     - environment_settings
     - fluentd
+  'P@environment:(rc.*|.*-qa|ci)':
+    - match: copound
+    - elastic_stack.version_qa
+  'not P@environment:(rc.*|.*-qa|ci)':
+    - match: compound
+    - elastic_stack.version_production
   'roles:auth_server':
     - match: grain
     - fluentd.cas
@@ -22,12 +28,8 @@ base:
     - nginx.kibana
     - elastalert
     - logrotate.kibana
-  'G@roles:kibana and G@environment:operations-qa':
-    - match: compound
-    - elastic_stack.version_qa
   'G@roles:kibana and G@environment:operations':
     - match: compound
-    - elastic_stack.version_production
     - datadog.http-check-integration
     - datadog.elastalert-process-integration
   'roles:master':
@@ -191,13 +193,11 @@ base:
     - elasticsearch.mitx
   'G@roles:elasticsearch and G@environment:operations':
     - match: compound
-    - elastic_stack.version_production
     - elastic_stack.elasticsearch.logging_production
     - netdata.elasticsearch_logging
     - elastic_stack.beats
   'G@roles:elasticsearch and G@environment:operations-qa':
     - match: compound
-    - elastic_stack.version_qa
     - elastic_stack.elasticsearch.logging_qa
     - netdata.elasticsearch_logging
   'P@roles:(edx|edx-worker)$':


### PR DESCRIPTION
Include the pillar that defines the ELK stack version for all minions, depending only on whether they're in our QA or production inventory.

Now that we're trying to install Beats on most of our minions, we need the ELK version defined on them.
