### PR TITLE
Remove ADMISSION_* settings that are no longer used

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -69,8 +69,6 @@ heroku:
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/read-write-delete-ol-bootcamps-app-{{ env_data.env_name }}>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'ol-bootcamps-app-{{ env_data.env_name }}'
     BOOTCAMP_ADMIN_EMAIL: cuddle-bunnies@mit.edu
-    BOOTCAMP_ADMISSION_BASE_URL: {{ env_data.BOOTCAMP_ADMISSION_BASE_URL }}
-    BOOTCAMP_ADMISSION_KEY: __vault__::secret-{{ business_unit }}/{{ env_data.vault_env_path }}/admissions/admission_key>data>value
     BOOTCAMP_DB_DISABLE_SSL: True
     BOOTCAMP_ECOMMERCE_BASE_URL: {{ env_data.BOOTCAMP_ECOMMERCE_BASE_URL }}
     BOOTCAMP_EMAIL_HOST: __vault__::secret-operations/global/mit-smtp>data>relay_host


### PR DESCRIPTION
#### What are the relevant tickets?
[PR#569](https://github.com/mitodl/bootcamp-ecommerce/pull/569)

#### What's this PR do?
Removes `ADMISSION_*` settings that are no longer used. This PR can be removed once the referenced PR above is deployed to production.
