### PR TITLE
Add documentation for edX release process

### DIFF
--- a/docs/runbooks/mitx_residential_upgrade.md
+++ b/docs/runbooks/mitx_residential_upgrade.md
@@ -41,39 +41,39 @@ Though we build our AMIs from the `mitx/<release codename>` branch, we also keep
 First, a branch is created in our repository for the `mitx/<code name>` release branch for our AMIs:
 
 ```
-git checkout -b mitx/juniper upstream/open-release/juniper.rc1
-git push -u origin mitx/juniper
+git checkout -b mitx/koa upstream/open-release/koa.master
+git push -u origin mitx/koa
 ```
 
-This is usually branched off of edX's first release candidate branch for the relevant release codename.
+This is usually branched off of edX's first `.master` branch for the relevant release codename.
 
 #### The pull and rebase
 
-When a new version is approaching maturity, edX cuts release candidate branches and we update our AMI release branch with the changes from these branches. Here is an example with the Juniper Release Candidate 3 branch.
+When a new version is approaching maturity, edX cuts release candidate branches and we update our AMI release branch with the changes from these branches. Here is an example with a theoretical Koa Release Candidate 3 branch.
 
 First, we check out our AMI release branch:
 
 ```
-git checkout mitx/juniper
+git checkout mitx/koa
 ```
 
 This command should only show our ODL patches to the edX code:
 
 ```
-git log origin/mitx/juniper --not upstream/open-release/juniper.rc3
+git log origin/mitx/koa --not upstream/open-release/koa.rc3
 ```
 
 We then pull in their changes, rebasing ours on top:
 
 ```
-git pull --rebase upstream open-release/juniper.rc3
+git pull --rebase upstream open-release/koa.rc3
 
-git push -f   # push mitx/juniper to our Git origin
+git push -f origin HEAD  # push mitx/juniper to our Git origin
 ```
 
-We also want to push our copies of their `open-release` branches, in case we want to issue PRs against them in the future.
+Sometimes we want to push copies of their `open-release` branches, in case we want to issue PRs against them in the future. We don't necessarily do this right away when we perform an upgrade, but here is what we do if the time comes to issue patches.
 
 ```
-git checkout -b open-release/juniper.rc3 upstream/open-release/juniper.rc3
+git checkout -b open-release/koa.rc3 upstream/open-release/koa.rc3
 git push -u origin open-release/juniper.rc3
 ```

--- a/docs/runbooks/mitx_residential_upgrade.md
+++ b/docs/runbooks/mitx_residential_upgrade.md
@@ -9,7 +9,7 @@ MITx Residential upgrade typically takes place twice a year following OpenedX's 
 - Update S3 `upgrading.mitx.mit.edu` bucket maintenance html page to reflect maintenance time
 
 ### Tech prep
-- Build edxapp and worker AMIs
+- Build edxapp and worker AMIs (see below)
 - Deploy EC2 instances from AMIs
 - Smoke-test deployed instances
 - Shutdown all supervisor services
@@ -23,3 +23,57 @@ MITx Residential upgrade typically takes place twice a year following OpenedX's 
 - Remove old instances from ELB
 - Verify that site is up and functional by running some manual tests
 - Change DNS back to point to ELB
+
+## Creating AMIs
+
+New AMIs are built from the latest Git release branch in our [mitodl/edx-platform](https://github.com/mitodl/edx-platform) repo. This release branch is the edX code plus some patches of our own, specific to our organization; created by rebasing on top of their branch for a particular release.
+
+edX release branches as they appear in edX's upstream repository are named starting with `open-release`; so, for example, the Juniper Release Candidate 3 branch is `upstream/open-release/juniper.rc3` (where my edX upstream repo is named `upstream`).
+
+Our release branches are named starting with `mitx/`, so our edX Juniper release branch, from which our AMIs are built, is `origin/mitx/juniper` (where my MITx origin repo is named `origin`).
+
+Though we build our AMIs from the `mitx/<release codename>` branch, we also keep copies of edX's `open-release` branches for convenience in issuing pull requests against the corresponding branches in `upstream`.
+
+### Updating Git branches
+
+#### The "mitx" release branch
+
+First, a branch is created in our repository for the `mitx/<code name>` release branch for our AMIs:
+
+```
+git checkout -b mitx/juniper upstream/open-release/juniper.rc1
+git push -u origin mitx/juniper
+```
+
+This is usually branched off of edX's first release candidate branch for the relevant release codename.
+
+#### The pull and rebase
+
+When a new version is approaching maturity, edX cuts release candidate branches and we update our AMI release branch with the changes from these branches. Here is an example with the Juniper Release Candidate 3 branch.
+
+First, we check out our AMI release branch:
+
+```
+git checkout mitx/juniper
+```
+
+This command should only show our ODL patches to the edX code:
+
+```
+git log origin/mitx/juniper --not upstream/open-release/juniper.rc3
+```
+
+We then pull in their changes, rebasing ours on top:
+
+```
+git pull --rebase upstream open-release/juniper.rc3
+
+git push -f   # push mitx/juniper to our Git origin
+```
+
+We also want to push our copies of their `open-release` branches, in case we want to issue PRs against them in the future.
+
+```
+git checkout -b open-release/juniper.rc3 upstream/open-release/juniper.rc3
+git push -u origin open-release/juniper.rc3
+```


### PR DESCRIPTION
Add documentation for creating AMIs and managing Git branches, with
regard to upgrading MITx to a new release.
