### PR TITLE
Force Debian 9 ("Stretch") AMI for MongoDB 3.6

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/mongodb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/mongodb.conf
@@ -2,7 +2,11 @@
 mongodb:
   provider: mitx
   size: t3.medium
-  image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
+  # image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
+  # We need to use Debian 9 ("Stretch") for MongoDB 3.6. MongoDB only supplies
+  # version 3.6 packages for Debian 8 and 9.
+  # https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-debian/#install-mongodb-community-edition
+  image: ami-0cfac3931b2a799d1
   ssh_username: admin
   ssh_interface: private_ips
   block_device_mappings:


### PR DESCRIPTION
We need to use Debian 9 ("Stretch") for MongoDB 3.6. MongoDB only
supplies version 3.6 packages for Debian 8 and 9.
