### PR TITLE
Added xpack to logging qa config

### DIFF
--- a/pillar/consul/elasticsearch.sls
+++ b/pillar/consul/elasticsearch.sls
@@ -9,5 +9,6 @@ consul:
           - logging
         {% endif %}
         check:
-          http: 'http://localhost:9200/'
+          tcp: 'localhost:9200'
           interval: 10s
+          timeout: 3s

--- a/pillar/elastic_stack/beats/init.sls
+++ b/pillar/elastic_stack/beats/init.sls
@@ -1,3 +1,5 @@
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+
 elastic_stack:
   beats:
     metricbeat:
@@ -16,8 +18,16 @@ elastic_stack:
           - add_cloud_metadata: ~
           - add_host_metadata: ~
         output.elasticsearch:
+          {% if 'operations-qa' in ENVIRONMENT %}
+          hosts:
+            - https://operations-elasticsearch.query.consul:9200
+          username: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/metricbeat_agent>data>user
+          password: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/metricbeat_agent>data>password
+          ssl.verification_mode: "none"
+          {% else %}
           hosts:
             - http://operations-elasticsearch.query.consul:9200
+          {% endif %}
           compression_level: 3
         setup.template.name: "metricbeat-%{[agent.version]}"
         setup.template.pattern: "metricbeat-%{[agent.version]}-*"

--- a/pillar/elastic_stack/kibana/init.sls
+++ b/pillar/elastic_stack/kibana/init.sls
@@ -1,10 +1,21 @@
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+
 elastic_stack:
   kibana:
     config:
+      {% if 'operations-qa' in ENVIRONMENT %}
+      elasticsearch.hosts:
+        - https://nearest-elasticsearch.query.consul:9200
+      elasticsearch.username: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch/kibana>data>es_kibana_username
+      elasticsearch.password: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch/kibana>data>es_kibana_password
+      xpack.security.encryptionKey: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch/kibana>data>es_kibana_encryption_key
+      {% else %}
       elasticsearch.hosts:
         - http://nearest-elasticsearch.query.consul:9200
+      {% endif %}
       elasticsearch.requestTimeout: 120000
       logging.dest: /var/log/kibana.log
+      elasticsearch.ssl.verificationMode: "none"
 
 beacons:
   service:

--- a/pillar/fluentd/server_operations_qa.sls
+++ b/pillar/fluentd/server_operations_qa.sls
@@ -66,6 +66,11 @@ fluentd:
                   - '@type': elasticsearch_dynamic
                   - logstash_format: 'true'
                   - hosts: {{ es_hosts }}
+                  - scheme: 'https'
+                  - ssl_version: TLSv1_2
+                  - user: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch_credentials>data>user
+                  - password: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch_credentials>data>password
+                  - ssl_verify: false
                   - logstash_prefix: 'logstash-${record.fetch("environment", "blank") != "blank" ? record.fetch("environment") : tag_parts[0]}'
                   - logstash_dateformat: '%Y.%W'
                   - include_tag_key: 'true'
@@ -133,6 +138,11 @@ fluentd:
                   - '@type': elasticsearch_dynamic
                   - logstash_format: 'true'
                   - hosts: {{ es_hosts }}
+                  - scheme: 'https'
+                  - ssl_version: TLSv1_2
+                  - user: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch_credentials>data>user
+                  - password: __vault__::secret-operations/{{ ENVIRONMENT }}/xpack/elasticsearch_credentials>data>password
+                  - ssl_verify: false
                   - logstash_prefix: 'logstash-${record.fetch("environment", "blank") != "blank" ? record.fetch("environment") : tag_parts[0]}'
                   - logstash_dateformat: '%Y.%W'
                   - include_tag_key: 'true'

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -49,6 +49,7 @@ nginx:
                   - proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
                   - proxy_headers_hash_bucket_size: 128
                   - proxy_read_timeout: 240s
+              {% if 'operations-qa' not in ENVIRONMENT %}
               - ssl_client_certificate: /etc/ssl/certs/mitca.pem
               - ssl_verify_client: 'on'
               - set $authorized: 'no'
@@ -56,3 +57,4 @@ nginx:
                 - set $authorized: 'yes'
               - if ($authorized !~ "yes"):
                 - return: 403
+              {% endif %}


### PR DESCRIPTION
#### What's this PR do?
This PR configures the use of the basic (free) xpack license to accomplish the following:
- TLS encryption between ES nodes in cluster
- TLS encryption between Kibana, fluentd aggregators, metricbeats agents, and ES cluster

##### Note: The following tasks need to happen before merging this PR:
- A PR should also be submitted against Elasticsearch formula to create the cert key and files referenced in pillar.
- Values added to sdb
- Keys/values added to vault

#### How should this be manually tested?
This has been manually tested on the existing logging QA cluster

#### Useful URLs
- https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-tls.html#tls-active-directory
- https://www.elastic.co/guide/en/kibana/current/configuring-tls.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html
- https://www.elastic.co/subscriptions
