### PR TITLE
Updating cloud profiles to use AMD instance types

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/alcali.conf
+++ b/salt/orchestrate/aws/cloud_profiles/alcali.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 alcali:
   provider: mitx
-  size: t3.small
+  size: t3a.small
   image: sdb://consul/debian_ami_id
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/amps-redirect.conf
+++ b/salt/orchestrate/aws/cloud_profiles/amps-redirect.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 amps-redirect:
   provider: mitx
-  size: t3.micro
+  size: t3a.micro
   image: ami-628ad918
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/backup_host.conf
+++ b/salt/orchestrate/aws/cloud_profiles/backup_host.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 backup_host:
   provider: mitx
-  size: r4.large
+  size: r5a.large
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e') }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/bookkeeper.conf
+++ b/salt/orchestrate/aws/cloud_profiles/bookkeeper.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 bookkeeper:
   provider: mitx
-  size: r5.xlarge
+  size: r5a.xlarge
   image: ami-04d70e069399af2e9 # Debian 10
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/cassandra.conf
+++ b/salt/orchestrate/aws/cloud_profiles/cassandra.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 cassandra:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: ami-cee00cb4
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/consul.conf
+++ b/salt/orchestrate/aws/cloud_profiles/consul.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 consul:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: ami-04d70e069399af2e9 # Debian 10
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/dremio.conf
+++ b/salt/orchestrate/aws/cloud_profiles/dremio.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 dremio:
   provider: mitx
-  size: r5.xlarge
+  size: r5a.xlarge
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id') or 'ami-0f9e7e8867f55fd8e' }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 edx-worker:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: {{ salt.sdb.get('sdb://consul/edx_worker_ami_id')|default('ami-973d0681', True) }}
   ssh_username: ubuntu
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/edx.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 edx:
   provider: mitx
-  size: r4.large
+  size: r5a.large
   image: {{ salt.sdb.get('sdb://consul/edx_ami_id')|default('ami-973d0681', True) }}
   ssh_username: ubuntu
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/edx_base.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx_base.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 edx_base:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id')|default('ami-020a9a7369c26052b') }}
   ssh_username: ubuntu
   ssh_interface: private_ips
@@ -20,7 +20,7 @@ edx_base:
 
 edx_worker_base:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id') }}
   ssh_username: ubuntu
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
+++ b/salt/orchestrate/aws/cloud_profiles/elasticsearch.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 elasticsearch:
   provider: mitx
-  size: r5.xlarge
+  size: r5a.xlarge
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id') or 'ami-0f9e7e8867f55fd8e' }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/fluentd.conf
+++ b/salt/orchestrate/aws/cloud_profiles/fluentd.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 fluentd:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/kibana.conf
+++ b/salt/orchestrate/aws/cloud_profiles/kibana.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 kibana:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
   ssh_username: admin
   iam_profile: kibana-instance-role

--- a/salt/orchestrate/aws/cloud_profiles/mitx-cas.conf
+++ b/salt/orchestrate/aws/cloud_profiles/mitx-cas.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 mitx-cas:
   provider: mitx
-  size: t3.small
+  size: t3a.small
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-8c9bdaf3', True) }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/mongodb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/mongodb.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 mongodb:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   # image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
   # We need to use Debian 9 ("Stretch") for MongoDB 3.6. MongoDB only supplies
   # version 3.6 packages for Debian 8 and 9.

--- a/salt/orchestrate/aws/cloud_profiles/ocw-origin.conf
+++ b/salt/orchestrate/aws/cloud_profiles/ocw-origin.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 ocw-origin:
   provider: mitx
-  size: m4.large
+  size: m5a.large
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-03006931f694ea7eb') }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/odl-video-service.conf
+++ b/salt/orchestrate/aws/cloud_profiles/odl-video-service.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 odl-video-service:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: ami-0f9e7e8867f55fd8e
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
+++ b/salt/orchestrate/aws/cloud_profiles/rabbitmq.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 rabbitmq:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/redash.conf
+++ b/salt/orchestrate/aws/cloud_profiles/redash.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 redash:
   provider: mitx
-  size: m5.xlarge
+  size: m5a.xlarge
   image: sdb://consul/debian_ami_id
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/reddit.conf
+++ b/salt/orchestrate/aws/cloud_profiles/reddit.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 reddit:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: ami-cee00cb4
   ssh_username: ubuntu
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/sandbox.conf
+++ b/salt/orchestrate/aws/cloud_profiles/sandbox.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 sandbox:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id') }}
   ssh_username: ubuntu
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/scylladb.conf
+++ b/salt/orchestrate/aws/cloud_profiles/scylladb.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 scylladb:
   provider: mitx
-  size: t3.large
+  size: t3a.large
   image: ami-4567933f
   ssh_username: centos
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/starcellbio.conf
+++ b/salt/orchestrate/aws/cloud_profiles/starcellbio.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 starcellbio:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: {{ salt.sdb.get('sdb://consul/debian_ami_id')|default('ami-0f9e7e8867f55fd8e', True) }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/tika.conf
+++ b/salt/orchestrate/aws/cloud_profiles/tika.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 tika:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: sdb://consul/debian_ami_id
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/xqwatcher.conf
+++ b/salt/orchestrate/aws/cloud_profiles/xqwatcher.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 xqwatcher:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: {{ salt.sdb.get('sdb://consul/xenial_ami_id') }}
   ssh_username: admin
   ssh_interface: private_ips

--- a/salt/orchestrate/aws/cloud_profiles/zookeeper.conf
+++ b/salt/orchestrate/aws/cloud_profiles/zookeeper.conf
@@ -1,7 +1,7 @@
 # -*- mode: yaml; coding: utf-8; -*-
 zookeeper:
   provider: mitx
-  size: t3.medium
+  size: t3a.medium
   image: ami-04d70e069399af2e9 # Debian 10
   ssh_username: admin
   ssh_interface: private_ips


### PR DESCRIPTION
AMD instance types are more cost effective, so moving to use those where possible. Also updated older generation types to improve cost


----

#### What's this PR do?
Changes instance types in cloud profiles to use more cost effective options.