### PR TITLE
Moved jobma settings outside if conditional

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -67,6 +67,7 @@
 {% set env_data = env_dict[environment] %}
 {% set business_unit = 'bootcamps' %}
 {% set cybersource_creds = salt.vault.read('secret-' ~ business_unit ~ '/' ~ env_data.vault_env_path ~ '/cybersource').data %}
+{% set jobma = salt.vault.read('secret-' ~ business_unit ~ '/' ~ env_data.vault_env_path ~ '/jobma').data %}
 
 proxy:
   proxytype: heroku
@@ -120,6 +121,9 @@ heroku:
     HUBSPOT_PORTAL_ID: {{ env_data.HUBSPOT_PORTAL_ID }}
     HUBSPOT_CREATE_USER_FORM_ID: {{ env_data.HUBSPOT_CREATE_USER_FORM_ID }}
     HUBSPOT_FOOTER_FORM_GUID: {{ env_data.HUBSPOT_FOOTER_FORM_GUID }}
+    JOBMA_ACCESS_TOKEN: {{ jobma.access_token }}
+    JOBMA_BASE_URL: {{ jobma.base_url }}
+    JOBMA_WEBHOOK_ACCESS_TOKEN: {{ jobma.webhook_access_token }}
     MAILGUN_FROM_EMAIL: 'MIT Bootcamp <no-reply@{{ env_data.MAILGUN_SENDER_DOMAIN }}'
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
@@ -136,8 +140,4 @@ heroku:
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
     ZENDESK_HELP_WIDGET_ENABLED: True
     {% if env_data.env_name == 'ci' or env_data.env_name == 'rc' %}
-    {% set jobma = salt.vault.read('secret-' ~ business_unit ~ '/' ~ env_data.vault_env_path ~ '/jobma').data %}
-    JOBMA_ACCESS_TOKEN: {{ jobma.access_token }}
-    JOBMA_BASE_URL: {{ jobma.base_url }}
-    JOBMA_WEBHOOK_ACCESS_TOKEN: {{ jobma.webhook_access_token }}
     {% endif %}


### PR DESCRIPTION
#### What's this PR do?
Now that we have Jobma settings for production which I have added to vault, we no longer need to have settings under a conditional. I moved those settings into the main part, however I left the `if` conditional as I suspect we will be using it down the line and it might be easier to keep it there for devs when they submit PR's.
