### PR TITLE
Add OCW CMS's web dir to OCW sync_repo state

### DIFF
--- a/salt/apps/ocw/sync_repo.sls
+++ b/salt/apps/ocw/sync_repo.sls
@@ -42,6 +42,19 @@ ensure_state_of_src_symlink:
     - target: /var/lib/ocwcms/plone/src
     - force: True
     - backupname: src_old
+
+sync_ocwcms_web_directory_for_cms:
+  rsync.synchronized:
+    - name: /var/www/html
+    - prepare: True
+    - source: /var/lib/ocwcms/web/
+    - delete: True
+    - update: True
+    - additional_opts:
+        - '-p'
+        - '-t'
+        - '-c'
+        - '--delay-updates'
 {% endif %}
 
 {% if 'ocw-origin' in roles %}


### PR DESCRIPTION
In the OCW sync_repo state, which deploys files to the OCW servers, update the behavior for the CMS servers to transfer static web files from the 'web' folder of the repo to the `/var/www/html` docroot directory on the server.

This is a different docroot folder than on the origin servers.

The "delete" option can be used with rsync, because, unlike on the origin servers,  there's no generated content (courses,  json files, rss feeds) that get put into that directory by other scripts.
