### PR TITLE
Fix grain deletion error

### DIFF
--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -217,9 +217,13 @@ delete_{{ grain }}_from_grains:
   salt.function:
     - tgt: 'edx*{{ ENVIRONMENT}}*base'
     - tgt_type: compound
-    - name: grains.delkey
-    - arg:
-        - {{ grain }}
+    - name: state.single
+    - arg: 
+      - grains.absent
+    - kwarg:
+        {{ grain }}
+        force: True
+        destructive: True
     - require_in:
         - boto_ec2: snapshot_edx_app_{{ ENVIRONMENT }}_node
         - boto_ec2: snapshot_edx_worker_{{ ENVIRONMENT }}_node

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -221,7 +221,7 @@ delete_{{ grain }}_from_grains:
     - arg: 
       - grains.absent
     - kwarg:
-        {{ grain }}
+        name: {{ grain }}
         force: True
         destructive: True
     - require_in:


### PR DESCRIPTION
#### What's this PR do?
`build_ami` state was failing on the `grains.delkey` function with the following error:

`The key 'roles' exists but is a dict or a list. Use 'force=True' to overwrite.`

This changes the function to using the `grains.absent` state and force the removal of keys and values.