### PR TITLE
Prevent fluentd pillar inclusion for devstack role

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -4,6 +4,7 @@ base:
     - common
     - environment_settings
   '* and not proxy-* and not G@roles:devstack'
+    - match: compound
     - fluentd
   'P@environment:(rc.*|.*-qa)':
     - match: compound

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -3,6 +3,7 @@ base:
     - match: compound
     - common
     - environment_settings
+  '* and not proxy-* and not G@roles:devstack'
     - fluentd
   'P@environment:(rc.*|.*-qa)':
     - match: compound


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/4Op8y52z/148-migrate-and-upgrade-micromasters-sandbox

#### What's this PR do?

Since the `devstack` role has been prevented from including FluentD states in `salt/top.sls`, prevent it also from including fluentd pillar data `in pillar/top.sls`. Otherwise, we get a pillar rendering error when doing a highstate.
