### PR TITLE
Added null to proctoring backend

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -142,7 +142,8 @@ edx:
       MUST_BE_VERIFIED_TRACK: false
 
     EDXAPP_PROCTORING_BACKENDS:
-      DEFAULT: "proctortrack"
+      DEFAULT: "null"
+      "null": {}
       "proctortrack":
         client_id: __vault__::secret-{{ business_unit }}/{{ environment }}/proctortrack>data>client_id
         client_secret: __vault__::secret-{{ business_unit }}/{{ environment }}/proctortrack>data>client_secret


### PR DESCRIPTION
#### What's this PR do?
Instructor dashboard on courses that doesn't use PT are receiving 500 since "null" value is no longer defined. This add it back
