### PR TITLE
Create file when tracking data is uploaded

### DIFF
--- a/salt/backups/backup_tracking.sls
+++ b/salt/backups/backup_tracking.sls
@@ -18,3 +18,7 @@ upload_tar_to_s3:
     - local_file: {{ edx_tracking_local_folder }}/edx_tracking_{{ instance_id }}.tgz
     - key: {{ aws_creds.secret_key }}
     - keyid: {{ aws_creds.access_key}}
+
+tracking_data_uploaded:
+  file.touch:
+    - name: {{ edx_tracking_local_folder }}/tracking_uploaded.txt


### PR DESCRIPTION
#### What's this PR do?
Minor tweak to generate a file once tracking data has been zipped and uploaded to S3. Currently to check if those logs have been backed up prior to terminating an instance, we need to manually inspect S3. This just helps inspect it from the salt-master.


