### PR TITLE
Install edx-proctoring from fork

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -136,6 +136,8 @@ edx:
       - name: raven
       - name: git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf
         extra_args: -e
+      # edx-proctoring fork to accomodate ProctorTrack
+      - name: git+https://github.com/mitodl/edx-proctoring.git@mitx/juniper#egg=edx_proctoring
 
     # Start ProctorTrack settings
     EDXAPP_PROCTORING_SETTINGS:


### PR DESCRIPTION
#### What's this PR do?
We forked the `edx-proctoring` library to add the necessary changes for ProctorTrack. This change install the library from our fork on residential instances.
