### PR TITLE
Added Akismet configuration for Open

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -3,6 +3,7 @@
 
 {% set env_dict = {
     'ci': {
+      'AKISMET_BLOG_URL': 'https://discussions-ci.odl.mit.edu',
       'app_log_level': 'INFO',
       'app_name': 'odl-open-discussions-ci',
       'CLOUDFRONT_DIST': 'd28ic9ywb63ioi',
@@ -33,6 +34,7 @@
       'vault_env_path': 'rc-apps'
       },
     'rc': {
+      'AKISMET_BLOG_URL': 'https://discussions-rc.odl.mit.edu',
       'app_log_level': 'INFO',
       'app_name': 'odl-open-discussions-rc',
       'CLOUDFRONT_DIST': 'd1d3xcwjqmwwj2',
@@ -63,6 +65,7 @@
       'vault_env_path': 'rc-apps'
       },
     'production': {
+      'AKISMET_BLOG_URL': 'https://open.mit.edu',
       'app_log_level': 'INFO',
       'app_name': 'odl-open-discussions',
       'CLOUDFRONT_DIST': 'd2mcnjhkvrfuy2',
@@ -108,6 +111,8 @@ heroku:
   app_name: {{ env_data.app_name }}
   api_key: __vault__::secret-operations/global/heroku/api_key>data>value
   config_vars:
+    AKISMET_API_KEY: __vault__::secret-operations/{{ env_data.env_name }}/{{ business_unit }}/akismet>data>api_key
+    AKISMET_BLOG_URL: {{ env_data.AKISMET_BLOG_URL }}
     ALGOLIA_API_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/algolia>data>api_key
     ALGOLIA_APP_ID: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/algolia>data>app_id
     ALLOWED_HOSTS: '["*"]'


### PR DESCRIPTION
#### What are the relevant tickets?
Part of https://github.com/mitodl/open-discussions/issues/3062

#### What's this PR do?
Adds configuration necessary for spam checking via Akismet introduced in https://github.com/mitodl/open-discussions/pull/3063

#### How should this be manually tested?
Configuration is applied to necessary environments and then tested with test data.

#### Any background context you want to provide?

I added `AKISMET_BLOG_URL` as an additional value in `env_dict` since this value needs to match what is configured in the Akismet account. In practice this will be the same as the domain name for the app, but keep it as a separate value future-proofs this against an accidental breakage if the app moves.
