### PR TITLE
Add elastalert alert for SAML failure in LMS

### DIFF
--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -526,3 +526,30 @@ elastic_stack:
                   - query_string:
                       default_field: message
                       query: (received unregistered task) AND (message has been ignored)
+      - name: lms_saml_failure
+        settings:
+          name: SAML failure in LMS
+          description: >-
+            SAML authentication has failed in the edX LMS
+          type: frequency
+          num_events: 1
+          timeframe:
+            minutes: 5
+          alert:
+            - opsgenie
+          opsgenie_key: {{ opsgenie_key }}
+          opsgenie_priority: P2
+          opsgenie_alias: lms_saml_failure
+          alert_text: "SAML authentication has failed in the edX LMS"
+          filter:
+            - bool:
+                must:
+                  - query_string:
+                      default_field: message
+                      query: "Authentication with MIT Kerberos is currently unavailable"
+                  - query_string:
+                      default_field: fluentd_tag
+                      query: edx.lms.stderr
+                  - query_string:
+                      default_field: environment
+                      query: mitx-production

--- a/pillar/elastalert.sls
+++ b/pillar/elastalert.sls
@@ -530,7 +530,9 @@ elastic_stack:
         settings:
           name: SAML failure in LMS
           description: >-
-            SAML authentication has failed in the edX LMS
+            SAML authentication has failed in the edX LMS.
+            It is possible that the edx.refresh_saml_provider_metadata state has
+            not been succeeding, or needs to be run again.
           type: frequency
           num_events: 1
           timeframe:
@@ -540,7 +542,11 @@ elastic_stack:
           opsgenie_key: {{ opsgenie_key }}
           opsgenie_priority: P2
           opsgenie_alias: lms_saml_failure
-          alert_text: "SAML authentication has failed in the edX LMS"
+          alert_text: >-
+            SAML authentication has failed in the edX LMS.
+            The following Salt state is supposed to run on a schedule to refresh
+            SAML provider metadata. Does it need to be. run again?
+            https://github.com/mitodl/salt-ops/blob/main/salt/edx/refresh_saml_provider_metadata.sls
           filter:
             - bool:
                 must:


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/o9bAwz8Y/158-elastalert-for-saml-failure-in-lms

#### What's this PR do?

Adds an Elastalert alert for messages about authentication failures.


Is there anything that I could add to the description field to suggest to the recipient how to troubleshoot the issue?
