### PR TITLE
Adding pillar data and packer config for building Dagster AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Points of Interest
 `/pillar`: This directory contains all of the pillar data that is used to configure the various environments, applications, and infrastructure
 
 `/docs`: The documentation (such as it is) for various aspects of our infrastructure, runbooks, etc.
+
+`/packer`: This is where packer configuration files for the different systems we need to build and deploy are maintained. This also contains a subdirectory of minion configs to be used during build time.

--- a/packer/dagster.json
+++ b/packer/dagster.json
@@ -1,0 +1,62 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "if [ $(which apt-get) ];",
+        "then",
+        "    sudo apt-get update",
+        "    PKG_MANAGER='apt-get'",
+        "    PKGS='python3-dev git curl'",
+        "else",
+        "    PKG_MANAGER='yum'",
+        "    PKGS='python3-devel git curl'",
+        "fi",
+        "sudo $PKG_MANAGER -y install $PKGS",
+        "if [ $(which pip) ];",
+        "then",
+        "    echo ''",
+        "else",
+        "    curl -L 'https://bootstrap.pypa.io/get-pip.py' > get_pip.py",
+        "    sudo python3 get_pip.py",
+        "    rm get_pip.py",
+        "fi",
+        "sudo pip3 install gitpython"
+      ]
+    },
+    {
+      "local_state_tree": "salt",
+      "local_pillar_roots": "pillar",
+      "minion_config": "packer/minion_configs/dagster.conf",
+      "type": "salt-masterless"
+    }
+  ],
+  "builders": [
+    {
+      "ami_description": "Deployment image for Dagster server generated on {{timestamp}}",
+      "ami_name": "dagster",
+      "ami_virtualization_type": "hvm",
+      "force_deregister": true,
+      "ssh_username": "admin",
+      "type": "amazon-ebs",
+      "source_ami": "ami-05c0d7f3fffb419c8",
+      "snapshot_tags": {
+        "OU": "data",
+        "purpose": "data-pipeline",
+        "app": "dagster"
+      },
+      "run_volume_tags": {
+        "OU": "data",
+        "purpose": "data-pipeline",
+        "app": "dagster"
+      },
+      "tags": {
+        "OU": "data",
+        "purpose": "data-pipeline",
+        "app": "dagster"
+      },
+      "instance_type": "m5a.large",
+      "subnet_id": "subnet-0e4a9c3626ecc0868"
+    }
+  ]
+}

--- a/packer/minion_configs/dagster.conf
+++ b/packer/minion_configs/dagster.conf
@@ -1,0 +1,20 @@
+file_client: local
+
+fileserver_backend:
+  - git
+  - roots
+
+gitfs_provider: gitpython
+gitfs_base: main
+gitfs_remotes:
+  - https://github.com/mitodl/dagster-formula
+  - https://github.com/mitodl/fluentd-formula
+  - https://github.com/mitodl/consul-formula
+  - https://github.com/mitodl/nginx-formula
+
+
+grains:
+  roles:
+    - dagster
+  context: packer
+  environment: data-qa

--- a/pillar/apps/redash.sls
+++ b/pillar/apps/redash.sls
@@ -2,7 +2,7 @@
 {% set python_version = '2.7.14' %}
 {% set python_bin_dir = '/usr/local/pyenv/versions/{0}/bin'.format(python_version) %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'operations') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set purpose_data = env_data.purposes[app_name] %}
 {% set minion_id = salt.grains.get('id', '') %}

--- a/pillar/backups/mitx.sls
+++ b/pillar/backups/mitx.sls
@@ -1,6 +1,6 @@
 #!jinja|yaml|gpg
 
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% set duplicity_passphrase = '__vault__::secret-operations/global/duplicity-passphrase>data>value' %}

--- a/pillar/backups/restore.sls
+++ b/pillar/backups/restore.sls
@@ -1,6 +1,6 @@
 #!jinja|yaml|gpg
 
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% if environment == 'mitx-qa' %}

--- a/pillar/consul/apps.sls
+++ b/pillar/consul/apps.sls
@@ -1,6 +1,6 @@
 {# Definition of services in the rc-apps and production-apps environments #}
 {% set ENVIRONMENT = salt.grains.get('environment') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 
 consul:

--- a/pillar/consul/mitx.sls
+++ b/pillar/consul/mitx.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 
 consul:

--- a/pillar/consul/operations.sls
+++ b/pillar/consul/operations.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 
 {% set wan_nodes = [] %}

--- a/pillar/consul/server.sls
+++ b/pillar/consul/server.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set wan_nodes = [] %}
 {% for host, addr in salt.saltutil.runner(

--- a/pillar/dagster/init.sls
+++ b/pillar/dagster/init.sls
@@ -1,0 +1,50 @@
+# -*- mode: yaml -*-
+{% set environment = salt.grains.get('environment') %}
+
+dagster:
+  home: /opt/ol_data_pipelines
+  dagit:
+    path: /opt/ol_data_pipelines/bin
+    flags: -w etc/workspace.yaml
+  config:
+    instance:
+      scheduler:
+        module: dagster_cron.cron_scheduler
+        class: SystemCronScheduler
+      compute_logs:
+        module: dagster_aws.s3.compute_log_manager
+        class: S3ComputeLogManager
+        config:
+          bucket: dagster-{{ environment }}/compute-logs/
+      run_storage:
+        module: dagster_postgres.run_storage
+        class: PostgresRunStorage
+        config:
+          postgres_db:
+            username: __vault__:cache:postgres-{{ environment }}/creds/app
+            password: __vault__:cache:postgres-{{ environment }}/creds/app
+            hostname: dagster_db.service.{{ environment }}.consul
+            db_name: dagster
+            port: 5432
+      event_log_storage:
+        module: dagster_postgres.event_log
+        class: PostgresEventLogStorage
+        config:
+          postgres_db:
+            username: __vault__:cache:postgres-{{ environment }}/creds/app
+            password: __vault__:cache:postgres-{{ environment }}/creds/app
+            hostname: dagster_db.service.{{ environment }}.consul
+            db_name: dagster
+            port: 5432
+      schedule_storage:
+        module: dagster_postgres.schedule_storage
+        class: PostgresScheduleStorage
+        config:
+          postgres_db:
+            username: __vault__:cache:postgres-{{ environment }}/creds/app
+            password: __vault__:cache:postgres-{{ environment }}/creds/app
+            hostname: dagster_db.service.{{ environment }}.consul
+            db_name: dagster
+            port: 5432
+  pkg_sources:
+    - ol-data-pipelines: https://ol-eng-artifacts.s3.amazonaws.com/ol-data-pipelines/ol-data-pipelines_0.1.0_amd64.deb

--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}

--- a/pillar/edx/ansible_vars/ecommerce.sls
+++ b/pillar/edx/ansible_vars/ecommerce.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}

--- a/pillar/edx/ansible_vars/init.sls
+++ b/pillar/edx/ansible_vars/init.sls
@@ -3,7 +3,7 @@
 {# EDXAPP_LMS_SITE_NAME: lms.service.consul #}
 {# EDXAPP_CMS_SITE_NAME: cms.service.consul #}
 
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set purpose_suffix = purpose.replace('-', '_') %}

--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}

--- a/pillar/edx/ansible_vars/residential_qa.sls
+++ b/pillar/edx/ansible_vars/residential_qa.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}

--- a/pillar/edx/ansible_vars/theme.sls
+++ b/pillar/edx/ansible_vars/theme.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
 {% set environment = salt.grains.get('environment', 'xpro-qa') %}
 {% set env_data = env_settings.environments[environment] %}

--- a/pillar/edx/ansible_vars/video_pipeline.sls
+++ b/pillar/edx/ansible_vars/video_pipeline.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set roles = salt.grains.get('roles', 'video-pipeline') %}
 {% set business_unit = salt.grains.get('business_unit', 'residential') %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set business_unit = salt.grains.get('business_unit', 'mitxpro') %}
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
 {% set environment = salt.grains.get('environment', 'mitxpro-qa') %}

--- a/pillar/edx/init.sls
+++ b/pillar/edx/init.sls
@@ -1,5 +1,5 @@
 #!jinja|yaml
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set purpose_data = env_settings.environments[environment].purposes[purpose] %}

--- a/pillar/edx/sandbox.sls
+++ b/pillar/edx/sandbox.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set purpose = salt.grains.get('purpose', 'current-residential-live') %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}

--- a/pillar/edx/xqwatcher.sls
+++ b/pillar/edx/xqwatcher.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% set purpose = salt.grains.get('purpose', 'xqwatcher') %}

--- a/pillar/edx/xqwatcher_600.sls
+++ b/pillar/edx/xqwatcher_600.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% set xqwatcher_venv_base = '/edx/app/xqwatcher/venvs' %}

--- a/pillar/edx/xqwatcher_686_residential.sls
+++ b/pillar/edx/xqwatcher_686_residential.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[environment] %}
 {% set xqwatcher_venv_base = '/edx/app/xqwatcher/venvs' %}

--- a/pillar/elasticsearch/apps.sls
+++ b/pillar/elasticsearch/apps.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 

--- a/pillar/environment_settings.sls
+++ b/pillar/environment_settings.sls
@@ -1,4 +1,4 @@
 {# This file is for exposing the data in the YAML file via the Pillar system #}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 environments: {{ env_settings.environments|tojson }}
 business_units: {{ env_settings.business_units|tojson }}

--- a/pillar/letsencrypt/ocw_origin.sls
+++ b/pillar/letsencrypt/ocw_origin.sls
@@ -1,6 +1,6 @@
 {% set OCW_ENVIRONMENT = salt.grains.get('ocw-environment') %}
 {% set OCW_DEPLOYMENT = salt.grains.get('ocw-deployment') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_data = env_settings.environments.ocw %}
 {% set common_name = env_data.purposes['ocw-origin'].domains[OCW_ENVIRONMENT][OCW_DEPLOYMENT][0] %}
 

--- a/pillar/nginx/alcali.sls
+++ b/pillar/nginx/alcali.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'alcali' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes[app_name].domains %}

--- a/pillar/nginx/kibana.sls
+++ b/pillar/nginx/kibana.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'kibana' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes[app_name].domains %}

--- a/pillar/nginx/mitx_cas.sls
+++ b/pillar/nginx/mitx_cas.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'mitx-cas' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'mitx-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes['mitx-cas'].domains %}

--- a/pillar/nginx/ocw_mirror.sls
+++ b/pillar/nginx/ocw_mirror.sls
@@ -7,7 +7,7 @@
 #
 
 {% set app_name = 'ocw-mirror' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'ocw') %}
 #
 # FIXME: The ocw-environment and ocw-deployment grains are not created by Salt

--- a/pillar/nginx/ocw_origin.sls
+++ b/pillar/nginx/ocw_origin.sls
@@ -6,7 +6,7 @@
 #
 
 {% set app_name = 'ocw-origin' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'ocw') %}
 #
 # FIXME: The ocw-environment and ocw-deployment grains are not created by Salt

--- a/pillar/nginx/odlvideo.sls
+++ b/pillar/nginx/odlvideo.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'odl-video-service' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes['odl-video-service'].domains %}

--- a/pillar/nginx/redash.sls
+++ b/pillar/nginx/redash.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'redash' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes[app_name].domains %}

--- a/pillar/nginx/starcellbio.sls
+++ b/pillar/nginx/starcellbio.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'starcellbio' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set server_domain_names = env_data.purposes[app_name].domains %}

--- a/pillar/rabbitmq/mitx.sls
+++ b/pillar/rabbitmq/mitx.sls
@@ -1,6 +1,6 @@
 #!jinja|yaml|gpg
 
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment') %}
 {% set BUSINESS_UNIT = salt.grains.get('business_unit', 'residential') %}
 

--- a/pillar/rabbitmq/xpro.sls
+++ b/pillar/rabbitmq/xpro.sls
@@ -1,6 +1,6 @@
 #!jinja|yaml|gpg
 
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.grains.get('environment') %}
 {% set BUSINESS_UNIT = salt.grains.get('business_unit', 'residential') %}
 

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -3,7 +3,7 @@ base:
     - match: compound
     - common
     - environment_settings
-  '* and not proxy-* and not G@roles:devstack':
+  '* and not proxy-* and not G@roles:devstack and not G@context:packer':
     - match: compound
     - fluentd
   'P@environment:(rc.*|.*-qa)':
@@ -44,6 +44,11 @@ base:
     # - master.extra_config
   master-operations-qa:
     - master.qa_schedule
+  'roles:dagster':
+    - match: grain
+    - dagster
+    - nginx
+    - nginx.dagster
   'roles:fluentd':
     - match: grain
     - fluentd

--- a/pillar/vault/roles/apps.sls
+++ b/pillar/vault/roles/apps.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set SIX_MONTHS = '4368h' %}
 vault:
   roles:

--- a/pillar/vault/roles/aws.sls
+++ b/pillar/vault/roles/aws.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 
 vault:
   roles:

--- a/pillar/vault/roles/mitx.sls
+++ b/pillar/vault/roles/mitx.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set SIX_MONTHS = '4368h' %}
 
 vault:

--- a/pillar/vault/roles/pki.sls
+++ b/pillar/vault/roles/pki.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ttl = '2880h' %} # FOUR MONTHS
 {% set ou = 'Open Learning' %}
 {% set org = 'Massachusetts Institute of Technology' %}

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -145,6 +145,42 @@ sandbox_mitxpro_versions: &sandbox_mitxpro_versions
 
 
 environments:
+  data-qa:
+    business_unit: data
+    network_prefix: '10.2'
+    vpc_name: ol-data-qa
+    vpc_peers:
+      - operations-qa
+      - mitx-qa
+      - mitxpro-qa
+    purposes:
+      dagster:
+        app: dagster
+        num_instances: 1
+        domains:
+          - pipelines-qa.odl.mit.edu
+        business_unit: data
+        security_groups:
+          - webapp-odl-vpn
+        size: r5a.large
+  data-production:
+    business_unit: data
+    network_prefix: '10.3'
+    vpc_name: ol-data-production
+    vpc_peers:
+      - operations
+      - mitx-production
+      - mitxpro-production
+    purposes:
+      dagster:
+        app: dagster
+        num_instances: 1
+        domains:
+          - pipelines.odl.mit.edu
+        business_unit: data
+        security_groups:
+          - webapp-odl-vpn
+        size: r5a.large
   mitxpro-qa:
     business_unit: mitxpro
     network_prefix: '10.6'

--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set app_name = salt.environ.get('APP_NAME') %}

--- a/salt/orchestrate/aws/app_elb.sls
+++ b/salt/orchestrate/aws/app_elb.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set app_name = salt.environ.get('APP_NAME') %}

--- a/salt/orchestrate/aws/elasticache.sls
+++ b/salt/orchestrate/aws/elasticache.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
-{% set env_data = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_data = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_settings = env_data.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}

--- a/salt/orchestrate/aws/mitx.sls
+++ b/salt/orchestrate/aws/mitx.sls
@@ -3,7 +3,7 @@
 # Make sure that instance profiles exist for node types so that
 # they can be granted access via permissions attached to those
 # profiles because it's easier than managing IAM keys
-{% set env_data = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_data = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
 {% set env_settings = env_data.environments[ENVIRONMENT] %}
 {% set PURPOSE_PREFIX = salt.environ.get('PURPOSE_PREFIX', 'current-residential') %}

--- a/salt/orchestrate/aws/mitx_elb.sls
+++ b/salt/orchestrate/aws/mitx_elb.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set PURPOSES = salt.environ.get('PURPOSES', 'current-residential-live,current-residential-draft').split(',') %}

--- a/salt/orchestrate/aws/mitxpro_autoscaling.sls
+++ b/salt/orchestrate/aws/mitxpro_autoscaling.sls
@@ -1,5 +1,5 @@
 {% for app_name in ['edxapp', 'edx-worker'] %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitxpro-production') %}
 {% set purpose = salt.grains.get('purpose', 'xpro-production') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}

--- a/salt/orchestrate/aws/operations.sls
+++ b/salt/orchestrate/aws/operations.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_data.vpc_name) %}

--- a/salt/orchestrate/aws/rds.sls
+++ b/salt/orchestrate/aws/rds.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT') %}
-{% set env_dict = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_dict = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_settings = env_dict.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}

--- a/salt/orchestrate/aws/s3_buckets/edx.sls
+++ b/salt/orchestrate/aws/s3_buckets/edx.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% for env in ['mitxpro-qa', 'mitxpro-production', 'mitx-qa', 'mitx-production'] %}
 {% set env_data = env_settings.environments[env] %}
 {% for purpose in env_data.purposes %}

--- a/salt/orchestrate/aws/xpro_elb.sls
+++ b/salt/orchestrate/aws/xpro_elb.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitxpro-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set PURPOSES = salt.environ.get('PURPOSES', 'xpro-qa').split(',') %}

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -1,6 +1,6 @@
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT') %}
 {% set PURPOSE = salt.environ.get('PURPOSE', 'current-residential-draft') %}
-{% set env_dict = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_dict = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_settings = env_dict.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}

--- a/salt/orchestrate/edx/cloudfront.sls
+++ b/salt/orchestrate/edx/cloudfront.sls
@@ -1,5 +1,5 @@
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT') %}
-{% set env_dict = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_dict = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_settings = env_dict.environments[ENVIRONMENT] %}
 {% set VPC_NAME = salt.environ.get('VPC_NAME', env_settings.vpc_name) %}
 {% set BUSINESS_UNIT = salt.environ.get('BUSINESS_UNIT', env_settings.business_unit) %}

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set PURPOSES = salt.environ.get('PURPOSES', 'current-residential-draft,current-residential-live').split(',') %}

--- a/salt/orchestrate/edx/mitx_analytics.sls
+++ b/salt/orchestrate/edx/mitx_analytics.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set PURPOSE = salt.environ.get('PURPOSE', 'current-residential-draft') %}

--- a/salt/orchestrate/edx/mysql_schemas.sls
+++ b/salt/orchestrate/edx/mysql_schemas.sls
@@ -1,7 +1,7 @@
 #!jinja|yaml
 
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT') %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set environment = salt.pillar.get('environments:{}'.format(ENVIRONMENT)) %}
 {% set purposes = environment.purposes %}
 

--- a/salt/orchestrate/edx/xqwatcher.sls
+++ b/salt/orchestrate/edx/xqwatcher.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'mitx-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set app_name = 'xqwatcher' %}

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/operations/services/fluentd.sls
+++ b/salt/orchestrate/operations/services/fluentd.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set app_name = salt.environ.get('APP_NAME', 'fluentd') %}

--- a/salt/orchestrate/operations/services/kibana.sls
+++ b/salt/orchestrate/operations/services/kibana.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set app_name = salt.environ.get('APP_NAME', 'kibana') %}

--- a/salt/orchestrate/reddit/init.sls
+++ b/salt/orchestrate/reddit/init.sls
@@ -1,5 +1,5 @@
 {% set app_name = 'reddit' %}
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/cassandra.sls
+++ b/salt/orchestrate/services/cassandra.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/consul.sls
+++ b/salt/orchestrate/services/consul.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/elasticsearch.sls
+++ b/salt/orchestrate/services/elasticsearch.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set purpose_data = env_data.purposes.elasticsearch|default({}) %}

--- a/salt/orchestrate/services/mongodb.sls
+++ b/salt/orchestrate/services/mongodb.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/pulsar.sls
+++ b/salt/orchestrate/services/pulsar.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set purpose_data = env_data.purposes.pulsar|default({}) %}

--- a/salt/orchestrate/services/rabbitmq.sls
+++ b/salt/orchestrate/services/rabbitmq.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/scylladb.sls
+++ b/salt/orchestrate/services/scylladb.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'rc-apps') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set VPC_NAME = env_data.vpc_name %}

--- a/salt/orchestrate/services/zookeeper.sls
+++ b/salt/orchestrate/services/zookeeper.sls
@@ -1,4 +1,4 @@
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set ENVIRONMENT = salt.environ.get('ENVIRONMENT', 'operations-qa') %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
 {% set purpose_data = env_data.purposes.zookeeper|default({}) %}

--- a/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
+++ b/salt/reactors/mitxpro/edxapp_ec2_autoscale.sls
@@ -2,7 +2,7 @@
 {% set instanceid = payload['Message']|load_json %}
 {% set ENVIRONMENT = 'mitxpro-production' %}
 {% set PURPOSE = 'xpro-production' %}
-{% set env_dict = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_dict = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 {% set env_settings = env_dict.environments[ENVIRONMENT] %}
 {% set purposes = env_settings.purposes %}
 {% set edx_codename = purposes[PURPOSE].versions.codename %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -70,6 +70,10 @@ base:
     - match: grain
     - pulsar
     - pulsar.tests
+  'roles:dagster':
+    - match: grain
+    - dagster
+    - nginx
   dremio*:
     - dremio
     - nginx

--- a/salt/vault/secret_backends.sls
+++ b/salt/vault/secret_backends.sls
@@ -1,6 +1,6 @@
 {% set SIX_MONTHS = '4368h' %}
 {% set pki_ttl = '8760h' %} # ONE_YEAR
-{% set env_settings = salt.cp.get_file_str("salt://environment_settings.yml")|load_yaml %}
+{% set env_settings = salt.cp.get_file_str("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml")|load_yaml %}
 
 enable_transit_secret_backend:
   vault.secret_backend_enabled:


### PR DESCRIPTION
In order to simplify our build and release process I would like to introduce Packer as our interface for creating deployable images. This PR bootstraps that effort with configuration and changes needed to get a Dagster AMI built.


----

#### What are the relevant tickets?
https://trello.com/c/1fdWL6ju/130-deploy-dagster-to-production

#### What's this PR do?
Adds a Packer configuration for building a Dagster AMI

#### How should this be manually tested?
Run `packer build packer/dagster.json` from the salt-ops directory

#### Any background context you want to provide?
We have typically used the Salt orchestration system for building and deploying instances, but it has historically been an error prone and manual process. This is a step in the direction of decomposing some of our process to rely on more best of breed tools and then integrating them to build a more stable whole.