### PR TITLE
Adding Caddy config for proxying Salt API

### DIFF
--- a/pillar/caddy/init.sls
+++ b/pillar/caddy/init.sls
@@ -1,0 +1,29 @@
+caddy:
+  install_from_repo: True
+  enable_api: False
+  config:
+    logging:
+      sink:
+        writer:
+          output: file
+          filename: /var/log/caddy/caddy-sink.log
+          roll: True
+          roll_size_mb: 10
+          roll_gzip: True
+      logs:
+        writer:
+          output: file
+          filename: /var/log/caddy/caddy.log
+          roll: True
+          roll_size_mb: 10
+          roll_gzip: True
+        encoder:
+          format: json
+        level: WARN
+    storage:
+      module: file_system
+      root: /var/lib/caddy/
+    apps:
+      http:
+        http_port: 80
+        https_port: 443

--- a/pillar/caddy/master.sls
+++ b/pillar/caddy/master.sls
@@ -1,0 +1,18 @@
+{% set ENVIRONMENT = salt.grains.get('environment', 'operations') %}
+
+caddy:
+  config:
+    apps:
+      http:
+        servers:
+          salt_api:
+            listen: ':443'
+            routes:
+              - match:
+                  {% if 'qa' in ENVIRONMENT %}
+                  - host: salt-qa.odl.mit.edu
+                  {% else %}
+                  - host: salt-production.odl.mit.edu
+                  {% endif %}
+                handle:
+                  - reverse_proxy: 127.0.0.1:8080

--- a/pillar/master/config.sls
+++ b/pillar/master/config.sls
@@ -53,6 +53,7 @@ salt_master:
         - https://github.com/mitodl/dremio-formula
         - https://github.com/mitodl/alcali-formula
         - https://github.com/mitodl/mysql-formula
+        - https://github.com/mitodl/caddy-formula
     ext_pillar:
       git_pillar_provider: gitpython
       git_pillar_base: {{ git_ref }}

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -40,6 +40,7 @@ base:
     - master.config
     - elastic_stack.beats
     - master.api
+    - caddy.master
   master-operations-production:
     - master.production_schedule
     # - master.extra_config

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -42,6 +42,7 @@ base:
     - master_utils.libgit
     - heroku.proxy_config
     - elastic-stack.beats
+    - caddy
   'G@roles:master and P@environment:operations(-qa)?':
     - match: compound
     - master.aws


### PR DESCRIPTION
----
#### What's this PR do?
In order to allow for exposing the Salt API to the internet we want to put it behind a reverse proxy and enable TLS. To fill that need I would like to start migrating to using Caddy as it enables a lot of convenient features, such as built in Let's Encrypt and a composable JSON config format.