### PR TITLE
Fix Canvas integration settings

### DIFF
--- a/pillar/edx/ansible_vars/next_residential.sls
+++ b/pillar/edx/ansible_vars/next_residential.sls
@@ -2,10 +2,10 @@
 {% set environment = salt.grains.get('environment', 'mitx-qa') %}
 edx:
   ansible_vars:
-    CANVAS_BASE_URL: https://mit.test.instructure.com
-    CANVAS_ACCESS_TOKEN: __vault__::secret-{{ business_unit }}/{{ environment}}/canvas-access-token>data>value
     EDXAPP_EXTRA_MIDDLEWARE_CLASSES: [] # Worth keeping track of in case we need to take advantage of it
     EDXAPP_ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: False
     EDXAPP_LMS_ENV_EXTRA:
+      CANVAS_BASE_URL: https://mit.test.instructure.com
+      CANVAS_ACCESS_TOKEN: __vault__::secret-{{ business_unit }}/{{ environment}}/canvas-access-token>data>value
       FEATURES:
         ENABLE_CANVAS_INTEGRATION: True


### PR DESCRIPTION
#### What's this PR do?
Canvas settings were being removed when config refresh was running as they don't appear to have been placed under the right heading. This should fix the issue.
