### PR TITLE
add OCW prod domain to CORS list for Open

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -91,7 +91,8 @@
       'SOCIAL_AUTH_MICROMASTERS_LOGIN_URL': 'https://micromasters.mit.edu/login/edxorg/?next=/discussions/',
       'SOCIAL_AUTH_SAML_SP_ENTITY_ID': 'https://discussions.odl.mit.edu/saml/metadata',
       'TIKA_SERVER_ENDPOINT': 'https://tika-production-apps.odl.mit.edu',
-      'vault_env_path': 'production-apps'
+      'vault_env_path': 'production-apps',
+      'OCW_NEXT_URL': 'ocw-beta.odl.mit.edu'
       }
 } %}
 {% set env_data = env_dict[environment] %}


### PR DESCRIPTION
#### What are the relevant tickets?

part of getting production OCW deployed.

#### What's this PR do?

We need to add domains to a CORS allow-list in order to make requests to the Open APIs from them. This does that for production.

#### How should this be manually tested?

read through it?