### PR TITLE
Pointed ubcpi to edx fork

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -29,7 +29,8 @@ edx:
     EDXAPP_PRIVATE_REQUIREMENTS:
       - name: mitxpro-openedx-extensions==0.1.1
       - name: social-auth-mitxpro==0.3
-      - name: ubcpi-xblock==0.6.5
+      - name: git+https://github.com/edx/ubcpi.git@3c4b2cdc9f595ab8cdb436f559b56f36638313b6#egg=ubcpi-xblock
+        extra_args: -e
       - name: git+https://github.com/mitodl/edx-git-auto-export.git@v0.1#egg=edx-git-auto-export
       # Python client for Sentry
       - name: raven


### PR DESCRIPTION
#### What's this PR do?
Version `0.6.4` of ubcpi isn't compatible with python3 and the newer version has some [import issues](https://github.com/ubc/ubcpi/blob/0.6.5/ubcpi/ubcpi.py#L20). Switched to using the edx fork which we are using on residential running Juniper.

