### PR TITLE
Added max file upload size setting to bootcamps

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -131,6 +131,7 @@ heroku:
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
     MAILGUN_URL: https://api.mailgun.net/v3/{{ env_data.MAILGUN_SENDER_DOMAIN }}
+    MAX_FILE_UPLOAD_MB: 10
     NEW_RELIC_APP_NAME: Bootcamp {{ env_data.env_name }}
     NODE_MODULES_CACHE: False
     PGBOUNCER_DEFAULT_POOL_SIZE: 50


### PR DESCRIPTION
#### What are the relevant tickets?
Bootcamp PR: https://github.com/mitodl/bootcamp-ecommerce/pull/996
PR amending that setting and nginx config: https://github.com/mitodl/bootcamp-ecommerce/pull/1004

#### What's this PR do?
Adds a setting for the max file upload size (currently users can only upload resumes). This will be 10MB for all environments
