### PR TITLE
Added setting for SAML base URL in Bootcamps

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -109,6 +109,7 @@ heroku:
     {% if env_data.env_name == 'production' %}
     {% set pg_creds = salt.vault.cached_read('postgresql-bootcamps/creds/app', cache_prefix='heroku-bootcamp') %}
     BOOTCAMP_ECOMMERCE_EMAIL: __vault__::secret-{{ business_unit }}/production-apps/>cybersource>data>email
+    BOOTCAMP_ECOMMERCE_SAML_BASE_URL: https://bootcamps.mit.edu
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/bootcamp_ecommerce
     ENABLE_STUNNEL_AMAZON_RDS_FIX: true
     HIREFIRE_TOKEN: __vault__::secret-{{ business_unit }}/production-apps/hirefire_token>data>value


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/bootcamp-ecommerce/pull/1034

#### What's this PR do?
Adds a production setting for the SAML base URL in Bootcamps (only needed for production – we can use the default base URL in other envs)
