### PR TITLE
Adding Caddy config to handle GitHub webhooks

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -1,6 +1,6 @@
 
 ocw-next:
-  website_bucket: ocw-beta-production-course-site
+  website_bucket: ocw-website-applications-production
   source_data_bucket: open-learning-course-data-production
   search_api_url: //open.mit.edu/api/v0/search/
   ocw_to_hugo_git_ref: release

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -1,6 +1,6 @@
 
 ocw-next:
-  website_bucket: ocw-beta-qa-course-site
+  website_bucket: ocw-website-applications-qa
   source_data_bucket: open-learning-course-data-rc
   search_api_url: //discussions-rc.odl.mit.edu/api/v0/search/
   ocw_to_hugo_git_ref: release-candidate

--- a/pillar/caddy/ocw_build.sls
+++ b/pillar/caddy/ocw_build.sls
@@ -1,0 +1,74 @@
+{% set app_name = 'ocw-build' %}
+{% set env_settings = salt.cp.get_url("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml", dest=None)|load_yaml %}
+{% set ENVIRONMENT = salt.grains.get('environment', 'applications-qa') %}
+{% set env_data = env_settings.environments[ENVIRONMENT] %}
+{% set business_unit = env_data.purposes[app_name].business_unit %}
+{% set server_domain_names = env_data.purposes[app_name].domains %}
+{% set env_map = {
+    'applications-qa': {
+        'target_branch': 'release-candidate'
+    },
+    'applications-production': {
+        'target_branch': 'release'
+    }
+} %}
+
+caddy:
+  install_from_repo: False
+  custom_build:
+    os: linux
+    arch: amd64
+    plugins:
+      - github.com/abiosoft/caddy-exec
+      - github.com/abiosoft/caddy-hmac
+      - github.com/abiosoft/caddy-json-parse
+  config:
+    apps:
+      http:
+        servers:
+          ocw_build:
+            listen:
+              - ':443'
+            routes:
+              - match:
+                  - host: {{ server_domain_names|to_json }
+                handle:
+                - handler: subroute
+                  routes:
+                  - match:
+                      - header_regexp:
+                          X-Hub-Signature:
+                            pattern: '[a-z0-9]+\=([a-z0-9]+)'
+                        path:
+                          - /build-content-webhook
+                    handle:
+                      - handler: subroute
+                        routes:
+                          - handle:
+                              - algorithm: sha1
+                                handler: hmac
+                                secret: __vault__:gen_if_missing:secret-operations/global/github-hmac-secret-string>data>value
+                          - handle:
+                              - handler: json_parse
+                      - match:
+                          - expression: {hmac.signature} == {http.regexp.1}
+                          - expression: {json.ref}.endswith('{{ env_map[ENVIRONMENT]["target_branch"] }}')
+                        handle:
+                          - handler: exec
+                            command: salt-call
+                            args:
+                              - state.sls
+                              - apps.ocw.nextgen_build_pull_data,apps.ocw.nextgen_build_install,apps.ocw.nextgen_build_publish
+                - handler: file_server
+                  root: /home/ocw/hugo-course-publisher/dist/
+                  index_names:
+                    - index.html
+                    - index.htm
+                - handler: subroute
+                  routes:
+                    - match:
+                        - path:
+                            - /coursemedia
+                      handle:
+                        - handler: file_server
+                          root: /home/ocw/open-learning-course-data

--- a/pillar/caddy/ocw_build.sls
+++ b/pillar/caddy/ocw_build.sls
@@ -5,10 +5,10 @@
 {% set business_unit = env_data.purposes[app_name].business_unit %}
 {% set server_domain_names = env_data.purposes[app_name].domains %}
 {% set env_map = {
-    'applications-qa': {
+    'rc-apps': {
         'target_branch': 'release-candidate'
     },
-    'applications-production': {
+    'production-apps': {
         'target_branch': 'release'
     }
 } %}

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -350,12 +350,12 @@ base:
     - fluentd.ocw_db
   'P@roles:ocw-(cms|db|origin|mirror) and G@ocw-environment:production':
     - datadog
-  'G@roles:ocw-build and G@environment:applications-production':
+  'G@roles:ocw-build and G@environment:production-apps':
     - match: compound
     - apps.ocw-next-production
     - caddy
     - caddy.ocw_build
-  'G@roles:ocw-build and G@environment:applications-qa':
+  'G@roles:ocw-build and G@environment:rc-apps':
     - match: compound
     - apps.ocw-next-qa
     - caddy

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -353,6 +353,10 @@ base:
   'G@roles:ocw-build and G@environment:applications-production':
     - match: compound
     - apps.ocw-next-production
+    - caddy
+    - caddy.ocw_build
   'G@roles:ocw-build and G@environment:applications-qa':
     - match: compound
     - apps.ocw-next-qa
+    - caddy
+    - caddy.ocw_build

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -145,6 +145,22 @@ sandbox_mitxpro_versions: &sandbox_mitxpro_versions
 
 
 environments:
+  applications-qa:
+    purposes:
+      ocw-build:
+        app: ocw-build
+        num_instances: 1
+        domains:
+          - ocw-build-qa.odl.mit.edu
+        business_unit: open-courseware
+  applications-production:
+    purposes:
+      ocw-build:
+        app: ocw-build
+        num_instances: 1
+        domains:
+          - ocw-build.odl.mit.edu
+        business_unit: open-courseware
   data-qa:
     business_unit: data
     network_prefix: '10.2'
@@ -160,9 +176,6 @@ environments:
         domains:
           - pipelines-qa.odl.mit.edu
         business_unit: data
-        security_groups:
-          - webapp-odl-vpn
-        size: r5a.large
   data-production:
     business_unit: data
     network_prefix: '10.3'

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -899,6 +899,12 @@ environments:
     vpc_peers:
       - mitodl-operations-services
     purposes:
+      ocw-build:
+        app: ocw-build
+        num_instances: 1
+        domains:
+          - ocw-build.odl.mit.edu
+        business_unit: open-courseware
       odl-video-service:
         app: odl-video-service
         num_instances: 3
@@ -1030,6 +1036,12 @@ environments:
     vpc_peers:
       - operations-qa
     purposes:
+      ocw-build:
+        app: ocw-build
+        num_instances: 1
+        domains:
+          - ocw-build-qa.odl.mit.edu
+        business_unit: open-courseware
       odl-video-service:
         app: odl-video-service
         business_unit: odl-video-service

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -298,3 +298,4 @@ base:
     - node
     - apps.ocw.nextgen_build_install
     - apps.ocw.nextgen_build_pull_data
+    - caddy


### PR DESCRIPTION
Added configuration for installation of Caddy and relevant config in order to allow for automated deployment and publishing for changes on ocw-to-hugo and hugo-course-publisher.