### PR TITLE
Install Node 12.x on OCW build machine

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -8,6 +8,7 @@ ocw-next:
 
 node:
   version: 12.18.4
-  install_from_ppa: True
-  ppa:
-    repository_url: https://deb.nodesource.com/node_12.x
+  pkg:
+    use_upstream_repo: True
+    archive:
+      uri: https://deb.nodesource.com/node_12.x

--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -9,4 +9,5 @@ ocw-next:
 node:
   version: 12.18.4
   pkg:
+    version: 12
     use_upstream_repo: True

--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -10,5 +10,3 @@ node:
   version: 12.18.4
   pkg:
     use_upstream_repo: True
-    archive:
-      uri: https://deb.nodesource.com/node_12.x

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -8,6 +8,7 @@ ocw-next:
 
 node:
   version: 12.18.4
-  install_from_ppa: True
-  ppa:
-    repository_url: https://deb.nodesource.com/node_12.x
+  pkg:
+    use_upstream_repo: True
+    archive:
+      uri: https://deb.nodesource.com/node_12.x

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -9,4 +9,5 @@ ocw-next:
 node:
   version: 12.18.4
   pkg:
+    version: 12
     use_upstream_repo: True

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -10,5 +10,3 @@ node:
   version: 12.18.4
   pkg:
     use_upstream_repo: True
-    archive:
-      uri: https://deb.nodesource.com/node_12.x

--- a/salt/apps/ocw/nextgen_build_install.sls
+++ b/salt/apps/ocw/nextgen_build_install.sls
@@ -14,6 +14,11 @@ manage_yarn_pkg_repo:
     - name: deb https://dl.yarnpkg.com/debian/ stable main
     - key_url: https://dl.yarnpkg.com/debian/pubkey.gpg
 
+manage_node_pkg_repo:
+  pkgrepo.managed:
+    - name: deb https://deb.nodesource.com/node_12.x buster main
+    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+
 ensure_os_package_prerequisites:
   pkg.installed:
     - refresh: True
@@ -24,6 +29,7 @@ ensure_os_package_prerequisites:
         - gcc
         - g++
         - make
+        - nodejs
         - yarn
         - jq
 

--- a/salt/apps/ocw/nextgen_build_install.sls
+++ b/salt/apps/ocw/nextgen_build_install.sls
@@ -14,11 +14,6 @@ manage_yarn_pkg_repo:
     - name: deb https://dl.yarnpkg.com/debian/ stable main
     - key_url: https://dl.yarnpkg.com/debian/pubkey.gpg
 
-manage_node_pkg_repo:
-  pkgrepo.managed:
-    - name: deb https://deb.nodesource.com/node_12.x buster main
-    - key_url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-
 ensure_os_package_prerequisites:
   pkg.installed:
     - refresh: True
@@ -29,7 +24,6 @@ ensure_os_package_prerequisites:
         - gcc
         - g++
         - make
-        - nodejs
         - yarn
         - jq
 


### PR DESCRIPTION
Install Node 12 instead of the default. The `ocw-to-hugo` and `hugo-course-publisher` apps need version 12, which can be different than the Debian distribution's version.
