### PR TITLE
Fix OCW Next webhook script logging if lock error

### DIFF
--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -20,7 +20,8 @@ error_and_exit() {
 
 mkdir $lock_dir
 if [ $? -ne 0 ]; then
-	error_and_exit "Can not acquire lock. Another run in-progress?"
+	echo "Can not acquire lock. Another run in-progress?" >&2
+	exit 1
 fi
 
 cat /dev/null > $LOG_FILE || error_and_exit "Can not initialize logfile"


### PR DESCRIPTION
Fix the OCW Next build server's webhook script so that it does not remove the lock directory if it's failing because a lock directory already exists!
