### PR TITLE
Add retry capability to OCW next webhook script

### DIFF
--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -6,25 +6,36 @@ SOURCE_DATA_DIR=/opt/ocw/open-learning-course-data
 MARKDOWN_DIR=/opt/ocw/hugo-course-publisher/site/content
 SITE_OUTPUT_DIR=/opt/ocw/hugo-course-publisher/dist/  # Should end in '/'
 WEBSITE_BUCKET={{ website_bucket }}
+# lock_dir ensures that only one run of this script happens at once.
 lock_dir=/tmp/webhook-publish-lock
+# If retry_file is present, the script will run itself again to catch changes
+# that came in during the period of the current run.
+retry_file=/tmp/webhook-publish-retry
+
 
 log_message() {
     echo `date +'%Y-%m-%d %H:%M:%S'` $1 | tee -a ${LOG_FILE}
 }
 
 error_and_exit() {
-	log_message $1
-	rm -rf $lock_dir
-	exit 1
+    log_message $1
+    rm -rf $lock_dir
+    exit 1
 }
 
 mkdir $lock_dir
 if [ $? -ne 0 ]; then
-	echo "Can not acquire lock. Another run in-progress?" >&2
-	exit 1
+    echo "Can not acquire lock. Another run in-progress?" >&2
+    touch $retry_file
+    exit 1
 fi
 
-cat /dev/null > $LOG_FILE || error_and_exit "Can not initialize logfile"
+if [ ! -e $retry_file ]; then
+    cat /dev/null > $LOG_FILE || error_and_exit "Can not initialize logfile"
+else
+	# Do not initialize the logfile if this is a re-run
+	rm $retry_file
+fi
 
 log_message "Pulling ocw-to-hugo"
 cd /opt/ocw/ocw-to-hugo
@@ -40,7 +51,7 @@ yarn install --pure-lockfile \
 log_message "Pulling source data"
 aws s3 sync s3://$SOURCE_DATA_BUCKET/ $SOURCE_DATA_DIR --delete --only-show-errors
 if [ $? -ne 0 ]; then
-	error_and_exit "Failed to pull source data"
+    error_and_exit "Failed to pull source data"
 fi
 
 log_message "Running ocw-to-hugo"
@@ -48,14 +59,14 @@ cd /opt/ocw/ocw-to-hugo
 node src/bin/index.js -i $SOURCE_DATA_DIR -o $MARKDOWN_DIR \
     --strips3 --staticPrefix /coursemedia
 if [ $? -ne 0 ]; then
-	error_and_exit "Failed to run ocw-to-hugo. See logs in /opt/ocw/ocw-to-hugo"
+    error_and_exit "Failed to run ocw-to-hugo. See logs in /opt/ocw/ocw-to-hugo"
 fi
 
 log_message "Running hugo-course-publisher"
 cd /opt/ocw/hugo-course-publisher
 npm run build 2>&1 > /opt/ocw/hugo-course-publisher.log
 if [ $? -ne 0 ]; then
-	error_and_exit "Failed to run hugo-course-publisher. See /opt/ocw/hugo-course-publisher.log"
+    error_and_exit "Failed to run hugo-course-publisher. See /opt/ocw/hugo-course-publisher.log"
 fi
 
 log_message "Syncing to S3 bucket"
@@ -63,17 +74,23 @@ log_message "Syncing to S3 bucket"
 # prevent the site from getting copied into a subdirectory ...
 echo "$SITE_OUTPUT_DIR" | grep -q '/$'
 if [ $? -ne 0 ]; then
-	log_message "WARNING: appending '/' to $SITE_OUTPUT_DIR"
-	SITE_OUTPUT_DIR=$SITE_OUTPUT_DIR/
+    log_message "WARNING: appending '/' to $SITE_OUTPUT_DIR"
+    SITE_OUTPUT_DIR=$SITE_OUTPUT_DIR/
 fi
 aws s3 sync $SITE_OUTPUT_DIR s3://$WEBSITE_BUCKET/ \
     --delete --only-show-errors 2>&1 > /opt/ocw/website-sync.log
 if [ $? -ne 0 ]; then
-	error_and_exit "Failed to sync to S3 bucket. See /opt/ocw/website-sync.log"
+    error_and_exit "Failed to sync to S3 bucket. See /opt/ocw/website-sync.log"
 fi
 
 # TODO: Hit Fastly API to flush cache!
 
-rmdir $lock_dir
 log_message "Done"
+
+if [ -e $retry_file ]; then
+    rmdir $lock_dir
+    exec $0
+else
+    rmdir $lock_dir
+
 exit 0

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -92,5 +92,6 @@ if [ -e $retry_file ]; then
     exec $0
 else
     rmdir $lock_dir
+fi
 
 exit 0


### PR DESCRIPTION
Add some simple "retry" functionality to the Caddy webhook script.

Have it run itself again if it looks like another invocation came along in the middle of the current run. This could mean that there's another code commit that needs to make it to the server.

Also replace some tab characters with space-character sequences.

