### PR TITLE
Doubled residential capacity

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -639,10 +639,10 @@ environments:
           <<: *current_residential_versions_rp
         instances:
           edx:
-            number: 9
+            number: 18
             type: r5.large
           edx-worker:
-            number: 3
+            number: 6
             type: t3.xlarge
           analytics:
             number: 1


### PR DESCRIPTION
#### What's this PR do?
This past Friday (10/9) we experienced CPU overload on our residential instances resulting in service deterioration. The increased load appeared to be a result of a quiz taken by learners enrolled in the 8.01L course. Initial investigation shows that there were two CPU load spikes with the first being at 1:35pm on the residential instances and the next one coming almost an hour later at 2:30pm on the worker instances (screenshot below). So far through exploring logs, it appears that the likely culprit is related to an increased usage of sandboxes in that particular course despite there being a low number of learners (80 as far as we have been told) enrolled in that course. I'll continue to look into this, however in the meantime the recommendation has been to double the capacity to handle the weekly scheduled Friday quiz.

<img width="440" alt="Screen Shot 2020-10-14 at 9 28 14 AM" src="https://user-images.githubusercontent.com/1447295/95997508-d9658f80-0e01-11eb-8e2f-6f542e47edc1.png">
 