### PR TITLE
Changed xPro VPC name to match new naming

### DIFF
--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -206,7 +206,7 @@ environments:
   mitxpro-qa:
     business_unit: mitxpro
     network_prefix: '10.6'
-    vpc_name: MITxPro QA
+    vpc_name: xPro QA
     vpc_peers:
       - operations-qa
     secret_backends:
@@ -298,7 +298,7 @@ environments:
   mitxpro-production:
     business_unit: mitxpro
     network_prefix: '10.8'
-    vpc_name: MITxPro Production
+    vpc_name: xPro Production
     vpc_peers:
       - mitodl-operations-services
     provider_services:


### PR DESCRIPTION
#### What's this PR do?
xPro VPC names have changed since the import into Pulumi, so we just needed to reflect the change in the env_settings file.
