### PR TITLE
Add /status route to OCW next build server Caddy

### DIFF
--- a/pillar/caddy/ocw_build.sls
+++ b/pillar/caddy/ocw_build.sls
@@ -71,3 +71,13 @@ caddy:
                       handle:
                         - handler: file_server
                           root: /opt/ocw/open-learning-course-data
+                - handler: subroute
+                  routes:
+                    - match:
+                        - header_regexp:
+                            X-Monitor-Token: __vault__::secret-open-courseware/{{ ENVIRONMENT }}/monitoring>data>token
+                        - path:
+                            - /status
+                      handle:
+                        - handler: static_response
+                          body: OK

--- a/pillar/caddy/ocw_build.sls
+++ b/pillar/caddy/ocw_build.sls
@@ -74,8 +74,6 @@ caddy:
                 - handler: subroute
                   routes:
                     - match:
-                        - header_regexp:
-                            X-Monitor-Token: __vault__::secret-open-courseware/{{ ENVIRONMENT }}/monitoring>data>token
                         - path:
                             - /status
                       handle:


### PR DESCRIPTION
Add a `/status` route to the Caddy configuration for the OCW Next build machine, so that uptime monitoring services have something to hit that has only one concern -- reporting service uptime.

The issue with hitting `/` instead is that we currently have it set to serve `index.html` from the document root of the `hugo-course-publisher` output. The problem is that hugo-course-publisher is designed to clear that out when it does a build, so we get a lot of false negatives from a monitoring service when it hits that and index.html is missing. Besides, the site is really hosted from the S3 bucket, so we probably don't need or don't want to serve the site from `/` anymore.
