### PR TITLE
Tune reddit memory usage beacon

### DIFF
--- a/pillar/reddit.sls
+++ b/pillar/reddit.sls
@@ -250,4 +250,4 @@ pgbouncer:
 
 beacons:
   memusage:
-    - percent: 95%
+    - percent: 89%


### PR DESCRIPTION
Tune the beacon that is used for the reactor that restarts Reddit processes when the used memory gets to a certain  percentage. This is being tuned to align with our updated Datadog monitor.
