### PR TITLE
Add enhanced Sentry support for edX apps

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -134,8 +134,6 @@ edx:
       - name: git+https://github.com/Stanford-Online/xblock-in-video-quiz@release/v0.1.7#egg=xblock-in-video-quiz
         extra_args: -e
       - name: xblock-image-modal==0.4.2
-      # Python client for Sentry
-      - name: raven
       # edX EOX core plugin for Sentry
       - name: eox-core[sentry]
       - name: git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf

--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -136,6 +136,8 @@ edx:
       - name: xblock-image-modal==0.4.2
       # Python client for Sentry
       - name: raven
+      # edX EOX core plugin for Sentry
+      - name: eox-core[sentry]
       - name: git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf
         extra_args: -e
       # edx-proctoring fork to accomodate ProctorTrack
@@ -198,6 +200,8 @@ edx:
         readPreference: "nearest"
       SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: __vault__::secret-residential/{{ environment }}/{{ purpose }}/saml-sp-cert>data>key
       SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: __vault__::secret-residential/{{ environment }}/{{ purpose }}/saml-sp-cert>data>value
+      EOX_CORE_SENTRY_INTEGRATION_DSN: __vault__::secret-residential/{{ environment }}{{ purpose }}/sentry>data>dsn
+      EOX_CORE_SENTRY_IGNORED_ERRORS: []
 
     EDXAPP_CMS_ENV_EXTRA:
       ADDL_INSTALLED_APPS:

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -39,9 +39,8 @@ edx:
       - name: git+https://github.com/edx/ubcpi.git@3c4b2cdc9f595ab8cdb436f559b56f36638313b6#egg=ubcpi-xblock
         extra_args: -e
       - name: git+https://github.com/mitodl/edx-git-auto-export.git@v0.2#egg=edx-git-auto-export
-      # Python client for Sentry
-      - name: raven
-
+      # edX EOX core plugin for Sentry
+      - name: eox-core[sentry]
     ### Koa settings ###
     # Related keys/values can be removed once all envs are on Koa
     # EDXAPP_ENABLE_VIDEO_UPLOAD_PIPELINE: True
@@ -92,6 +91,9 @@ edx:
         ENABLE_THIRD_PARTY_AUTH: True
         ALLOW_PUBLIC_ACCOUNT_CREATION: True
         SKIP_EMAIL_VALIDATION: True
+      EOX_CORE_SENTRY_INTEGRATION_DSN: __vault__::secret-residential/{{ environment }}{{ purpose }}/sentry>data>dsn
+      EOX_CORE_SENTRY_IGNORED_ERRORS: []
+
     EDXAPP_CMS_ENV_EXTRA:
       ADDL_INSTALLED_APPS:
         - git_auto_export


### PR DESCRIPTION
Add enhanced Sentry support for the MITx and xPro edX applications, with the `EOX core` plugin.

See https://github.com/eduNEXT/eox-core

Is this redundant with the existing `raven` dependency?
