### PR TITLE
Modified python path to absolute one

### DIFF
--- a/salt/edx/migration.sls
+++ b/salt/edx/migration.sls
@@ -1,4 +1,4 @@
-{% set edxapp_bin = '/edx/bin/python.edxapp' %}
+{% set edxapp_bin = '/edx/app/edxapp/venvs/edxapp/bin/python' %}
 {% set migrations = ['lms', 'cms'] %}
 
 {% for migration in migrations %}


### PR DESCRIPTION
#### What's this PR do?
In Koa, the `/edx/bin/python.edxapp` symlink no longer exists. This PR uses the absolute python path and should work for Koa and previous releases.

As a side note, we also might want to consider using the migrations scripts that exists in `/edx/bin`
