### PR TITLE
update OCW build to support new data template structure

### DIFF
--- a/salt/apps/ocw/nextgen_build_publish.sls
+++ b/salt/apps/ocw/nextgen_build_publish.sls
@@ -4,7 +4,7 @@ run_ocw_to_hugo:
   cmd.run:
     # Installing ocw-to-hugo without the `-g' switch leaves us without an
     # `ocw-to-hugo' executable, so we use the path to `index.js'
-    - name: node src/bin/index.js -i /opt/ocw/open-learning-course-data -o /opt/ocw/hugo-course-publisher/site/ --strips3 --staticPrefix /coursemedia
+    - name: node src/bin/index.js -i /opt/ocw/open-learning-course-data -o /opt/ocw/hugo-course-publisher/site/content --strips3 --staticPrefix /coursemedia
     # `cwd' is specified because it drops a log file here.
     - cwd: /opt/ocw/ocw-to-hugo
     - runas: caddy

--- a/salt/apps/ocw/nextgen_build_publish.sls
+++ b/salt/apps/ocw/nextgen_build_publish.sls
@@ -4,7 +4,7 @@ run_ocw_to_hugo:
   cmd.run:
     # Installing ocw-to-hugo without the `-g' switch leaves us without an
     # `ocw-to-hugo' executable, so we use the path to `index.js'
-    - name: node src/bin/index.js -i /opt/ocw/open-learning-course-data -o /opt/ocw/hugo-course-publisher/site/content --strips3 --staticPrefix /coursemedia
+    - name: node src/bin/index.js -i /opt/ocw/open-learning-course-data -o /opt/ocw/hugo-course-publisher/site/ --strips3 --staticPrefix /coursemedia
     # `cwd' is specified because it drops a log file here.
     - cwd: /opt/ocw/ocw-to-hugo
     - runas: caddy

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -102,6 +102,12 @@ if [ $? -ne 0 ]; then
     error_and_exit "Could not clear site/content directory"
 fi
 
+log_message "Clearing site/data/courses directory"
+rm -rf site/data/courses/*
+if [ $? -ne 0 ]; then
+    error_and_exit "Could not clear site/data/courses directory"
+fi
+
 log_message "Running ocw-to-hugo via import:ocw NPM target"
 npm run import:ocw
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/326

#### What's this PR do?
This PR updates the OCW build scripts to output to the proper path after the recent changes to store course metadata using Hugo Data Templates.  It also now clears out the `site/data/courses` folder before a fresh build in the same way it clears out `site/content`

#### How should this be manually tested?
Not certain how code is normally tested here.
