### PR TITLE
Handle git history rewrites in OCW build script

### DIFF
--- a/salt/apps/ocw/nextgen_build_install.sls
+++ b/salt/apps/ocw/nextgen_build_install.sls
@@ -81,3 +81,4 @@ install_caddy_webhook_script:
         source_data_bucket: {{ ocw_next.source_data_bucket }}
         fastly_api_token: {{ ocw_next.fastly_api_token }}
         fastly_service_id: {{ ocw_next.fastly_service_id }}
+        hugo_course_publisher_git_ref: {{ ocw_next.hugo_course_publisher_git_ref }}

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -19,6 +19,7 @@ SITE_OUTPUT_DIR=/opt/ocw/hugo-course-publisher/dist/  # Should end in '/'
 WEBSITE_BUCKET={{ website_bucket }}
 FASTLY_API_TOKEN={{ fastly_api_token }}
 FASTLY_SERVICE_ID={{ fastly_service_id }}
+HUGO_COURSE_PUBLISHER_GIT_REF={{ hugo_course_publisher_git_ref }}
 # lock_dir ensures that only one run of this script happens at once.
 lock_dir=/tmp/webhook-publish-lock
 # If retry_file is present, the script will run itself again to catch changes
@@ -65,7 +66,8 @@ cd /opt/ocw/hugo-course-publisher \
 
 orig_commit=`git rev-parse HEAD`
 log_message "Pulling hugo-course-publisher"
-git pull || error_and_exit "Can not pull hugo-course-publisher"
+git fetch && git reset --hard $HUGO_COURSE_PUBLISHER_GIT_REF \
+    || error_and_exit "Can not pull hugo-course-publisher"
 new_commit=`git rev-parse HEAD`
 log_message "$orig_commit -> $new_commit"
 


### PR DESCRIPTION
In the OCW Next build script, handle rewrites of branch histories by doing a fetch and then a hard reset on the working copy.  The branching strategy for the release-candidate branch involves a rewrite of its history in the event that a candidate is backed out and redone.
