### PR TITLE
Enabled volume encryption on edx instances

### DIFF
--- a/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx-worker.conf
@@ -9,6 +9,7 @@ edx-worker:
     - DeviceName: /dev/sda1
       Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
+      Ebs.Encrypted: true
   iam_profile: edx-instance-role
   tag:
     role: edx-worker

--- a/salt/orchestrate/aws/cloud_profiles/edx.conf
+++ b/salt/orchestrate/aws/cloud_profiles/edx.conf
@@ -9,6 +9,7 @@ edx:
     - DeviceName: /dev/sda1
       Ebs.VolumeSize: 25
       Ebs.VolumeType: gp2
+      Ebs.Encrypted: true
   iam_profile: edx-instance-role
   tag:
     role: edx


### PR DESCRIPTION
#### What's this PR do?
Change enables EC2 EBS volume encryption using the default AWS managed KMS key on Open edX instances.