### PR TITLE
Pdpinch patch 1

### DIFF
--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -36,7 +36,7 @@
       'CYBERSOURCE_REFERENCE_PREFIX': 'rc',
       'CYBERSOURCE_WSDL_URL': 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl',
       'EDXORG_BASE_URL': 'https://courses.stage.edx.org',
-      'FEATURE_ENABLE_CERTIFICATE_USER_VIEW': T'GA_TRACKING_ID': 'UA-5145472-19',
+      'GA_TRACKING_ID': 'UA-5145472-19',
       'GTM_TRACKING_ID': 'GTM-NZT8SRC',
       'HUBSPOT_PORTAL_ID': '6431386',
       'HUBSPOT_CREATE_USER_FORM_ID': '995ee734-a0ff-47cc-b747-6ea1d2dd6303',

--- a/pillar/heroku/bootcamps.sls
+++ b/pillar/heroku/bootcamps.sls
@@ -36,7 +36,7 @@
       'CYBERSOURCE_REFERENCE_PREFIX': 'rc',
       'CYBERSOURCE_WSDL_URL': 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl',
       'EDXORG_BASE_URL': 'https://courses.stage.edx.org',
-      'GA_TRACKING_ID': 'UA-5145472-19',
+      'FEATURE_ENABLE_CERTIFICATE_USER_VIEW': T'GA_TRACKING_ID': 'UA-5145472-19',
       'GTM_TRACKING_ID': 'GTM-NZT8SRC',
       'HUBSPOT_PORTAL_ID': '6431386',
       'HUBSPOT_CREATE_USER_FORM_ID': '995ee734-a0ff-47cc-b747-6ea1d2dd6303',
@@ -122,6 +122,7 @@ heroku:
     EDXORG_BASE_URL: {{ env_data.EDXORG_BASE_URL }}
     EDXORG_CLIENT_ID: __vault__::secret-{{ business_unit }}/{{ env_data.env_name }}/edx>data>client_id
     EDXORG_CLIENT_SECRET: __vault__::secret-{{ business_unit }}/{{ env_data.env_name }}/edx>data>client_secret
+    FEATURE_ENABLE_CERTIFICATE_USER_VIEW: True
     FEATURE_SOCIAL_AUTH_API: True
     FEATURE_CMS_HOME_PAGE: True
     FEATURE_NOVOED_INTEGRATION: False


### PR DESCRIPTION
#### What are the relevant tickets?

part of https://github.com/mitodl/bootcamp-ecommerce/issues/1095

#### What's this PR do?

Add FEATURE_ENABLE_CERTIFICATE_USER_VIEW key to Bootcamps Pillar data and sets it to true. 

This a part of the rollout of Bootcamp certificates. 

#### How should this be manually tested?

After it's deployed, try to view a test certificate URL. Also the user that the certificate belongs to should be able to see a link on their application dashboard. 
