### PR TITLE
Update xPro redirects for learner certificates

### DIFF
--- a/pillar/nginx/mitxpro_redirect.sls
+++ b/pillar/nginx/mitxpro_redirect.sls
@@ -26,7 +26,12 @@ nginx:
               - resolver: 1.1.1.1
               - location /.well-known/:
                 - alias: /usr/share/nginx/html/.well-known/
-              - location /certificates/:
-                - return: 301 https://courses.edx.org$request_uri
+              - location ~*  ^/certificates/(.*)$:
+                - return: 301 https://certificates.mitxpro.mit.edu/course/$1.pdf
+              # The following redirect is for requests for /credentials/[id] that
+              # are being proxied from the certificates.mitxpro.mit.edu
+              # Cloudfront distribution.
+              - location ~*  ^/credentials/(.*?)/.*$:
+                - return: 301 https://certificates.mitxpro.mit.edu/program/$1.pdf
               - location /:
                 - return: 301 https://xpro.mit.edu/


### PR DESCRIPTION
This fixes a redirect that we used to return for xPro learners' course certificates, which sent them to edx.org. We're now sending them to our certificates.mitxpro.mit.edu site. Additionally, it adds a redirect for xPro program certificates; again, sending them to the new certificates domain. The Cloudfront distribution for certificates.mitxpro.mit.edu has been updated with a Behavior to send requests for `/credentials` to our redirect server so that it can issue the redirect, because redirects are a pain to configure in S3, if not impossible for this particular pattern-matching use-case.

This is already set on the server. The changes here document what's already been modified.