### PR TITLE
Make OCW Next build script upload ocw-to-hugo's output

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -1,6 +1,7 @@
 
 ocw-next:
   website_bucket: ocw-website-applications-production
+  ocw_to_hugo_bucket: ocw-to-hugo-output-production
   source_data_bucket: open-learning-course-data-production
   search_api_url: //open.mit.edu/api/v0/search/
   ocw_to_hugo_git_ref: release

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -1,7 +1,7 @@
 
 ocw-next:
   website_bucket: ocw-website-applications-qa
-  ocw_to_hugo_bucketh: ocw-to-hugo-output-qa
+  ocw_to_hugo_bucket: ocw-to-hugo-output-qa
   source_data_bucket: open-learning-course-data-rc
   search_api_url: //discussions-rc.odl.mit.edu/api/v0/search/
   ocw_to_hugo_git_ref: release-candidate

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -1,6 +1,7 @@
 
 ocw-next:
   website_bucket: ocw-website-applications-qa
+  ocw_to_hugo_bucketh: ocw-to-hugo-output-qa
   source_data_bucket: open-learning-course-data-rc
   search_api_url: //discussions-rc.odl.mit.edu/api/v0/search/
   ocw_to_hugo_git_ref: release-candidate

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -19,6 +19,7 @@ SOURCE_DATA_DIR=/opt/ocw/open-learning-course-data
 SITE_OUTPUT_DIR=/opt/ocw/ocw-www/dist/  # Should end in '/'
 COURSES_MARKDOWN_DIR=/opt/ocw/ocw-to-hugo/private/output
 WEBSITE_BUCKET={{ website_bucket }}
+OCW_TO_HUGO_BUCKET={{ ocw_to_hugo_bucket }}
 FASTLY_API_TOKEN={{ fastly_api_token }}
 FASTLY_SERVICE_ID={{ fastly_service_id }}
 OCW_TO_HUGO_GIT_REF={{ ocw_to_hugo_git_ref }}
@@ -216,8 +217,17 @@ if [ $? -ne 0 ]; then
     log_message "WARNING: Failed to clear Fastly cache!"
 fi
 
-log_message "Done"
+# Sync ocw-to-hugo output to S3
 
+log_message "Syncing ocw-to-hugo output to S3"
+aws s3 sync $COURSES_MARKDOWN_DIR/ s3://$OCW_TO_HUGO_BUCKET/ \
+    --delete --only-show-errors 2>&1 > /opt/ocw/ocw-to-hugo-output-sync.log
+if [ $? -ne 0 ]; then
+    error_and_exit "Failed to sync to S3 bucket. See /opt/ocw/ocw-to-hugo-output-sync.log"
+fi
+
+
+log_message "Done"
 
 # Clean up
 


### PR DESCRIPTION
This adds an `aws S3 sync` of the Markdown and JSON files that come out of `ocw-to-hugo`. They are pushed up to an S3 bucket that is to be consumed by `ocw-studio`.
