### PR TITLE
Change ocw next webhook logging

### DIFF
--- a/pillar/logrotate/ocw_build.sls
+++ b/pillar/logrotate/ocw_build.sls
@@ -1,0 +1,51 @@
+logrotate:
+  webhook_publish_log:
+    name: /opt/ocw/logs/webhook-publish.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  hugo_www_log:
+    name: /opt/ocw/logs/hugo-www.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  ocw_www_yarn_install_log:
+    name: /opt/ocw/logs/ocw-www-yarn-install.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  ocw_to_hugo_log:
+    name: /opt/ocw/logs/ocw-to-hugo.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  ocw_to_hugo_install_log:
+    name: /opt/ocw/logs/ocw-to-hugo-install.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  ocw_to_hugo_output_sync_log:
+    name: /opt/ocw/logs/ocw-to-hugo-output-sync.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  website_sync_log:
+    name: /opt/ocw/logs/website-sync.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+  course_builds_log:
+    name: /opt/ocw/logs/course-builds.log
+    options:
+      - rotate 4
+      - daily
+      - notifempty
+      - compress
+      - delaycompress

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -375,3 +375,6 @@ base:
     - apps.ocw-next-qa
     - caddy
     - caddy.ocw_build
+  'roles:ocw-build'
+    - match: grain
+    - logrotate.ocw_build

--- a/salt/apps/ocw/nextgen_build_install.sls
+++ b/salt/apps/ocw/nextgen_build_install.sls
@@ -41,6 +41,13 @@ ensure_state_of_opt_ocw:
     - group: caddy
     - dir_mode: '0755'
 
+ensure_state_of_log_directory:
+  file.directory:
+    - name: /opt/ocw/logs
+    - user: caddy
+    - group: caddy
+    - dir_mode: '0755'
+
 git_pull_ocw_to_hugo:
   git.latest:
     - name: https://github.com/mitodl/ocw-to-hugo.git

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -90,10 +90,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -e $retry_file ]; then
-    cat /dev/null > $LOG_FILE || error_and_exit "Can not initialize logfile"
-else
-    # Do not initialize the logfile if this is a re-run
+if [ -e $retry_file ]; then
     log_message "This is a re-run."
     rm $retry_file
 fi

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -12,8 +12,8 @@
 # cd /opt/ocw
 # ./webhook-publish.sh full
 
-
-LOG_FILE=/opt/ocw/webhook-publish.log
+LOG_DIR=/opt/ocw/logs
+LOG_FILE=$LOG_DIR/webhook-publish.log
 SOURCE_DATA_BUCKET={{ source_data_bucket }}
 SOURCE_DATA_DIR=/opt/ocw/open-learning-course-data
 SITE_OUTPUT_DIR=/opt/ocw/ocw-www/dist/  # Should end in '/'
@@ -151,14 +151,14 @@ cd /opt/ocw/ocw-to-hugo
 clear_directory /opt/ocw/ocw-to-hugo/node_modules
 
 log_message "Doing yarn install of ocw-to-hugo"
-yarn install --pure-lockfile > /opt/ocw/ocw-to-hugo-install.log 2>&1 \
+yarn install --pure-lockfile >> $LOG_DIR/ocw-to-hugo-install.log 2>&1 \
     || error_and_exit "Can not install ocw-to-hugo"
 
 log_message "Running ocw-to-hugo"
 node . -i $SOURCE_DATA_DIR -o $COURSES_MARKDOWN_DIR \
-    --strips3 --staticPrefix /coursemedia > /opt/ocw/ocw-to-hugo.log 2>&1
+    --strips3 --staticPrefix /coursemedia >> $LOG_DIR/ocw-to-hugo.log 2>&1
 if [ $? -ne 0 ]; then
-    error_and_exit "Failed to run ocw-to-hugo. See /opt/ocw/ocw-to-hugo.log"
+    error_and_exit "Failed to run ocw-to-hugo. See $LOG_DIR/ocw-to-hugo.log"
 fi
 
 
@@ -169,13 +169,13 @@ cd /opt/ocw/ocw-www
 clear_directory /opt/ocw/ocw-www/node_modules
 
 log_message "Doing yarn install of ocw-www"
-yarn install --pure-lockfile > /opt/ocw/ocw-www-yarn-install.log 2>&1 \
+yarn install --pure-lockfile >> $LOG_DIR/ocw-www-yarn-install.log 2>&1 \
     || error_and_exit "Can not install ocw-www"
 
 log_message "Running ocw-www build"
-npm run build > /opt/ocw/hugo-www.log 2>&1
+npm run build >> $LOG_DIR/hugo-www.log 2>&1
 if [ $? -ne 0 ]; then
-    error_and_exit "Failed to run ocw-www. See /opt/ocw/ocw-www.log"
+    error_and_exit "Failed to run ocw-www. See $LOG_DIR/ocw-www.log"
 fi
 
 
@@ -187,9 +187,9 @@ cd /opt/ocw/ocw-course-hugo-starter
     --output $SITE_OUTPUT_DIR \
     --courses $COURSES_MARKDOWN_DIR \
     --baseUrl $COURSE_BASE_URL \
-    > /opt/ocw/course-builds.log 2>&1
+    >> $LOG_DIR/course-builds.log 2>&1
 if [ $? -ne 0 ]; then
-    error_and_exit "Failed to run course builds. See /opt/ocw/course-builds.log"
+    error_and_exit "Failed to run course builds. See $LOG_DIR/course-builds.log"
 fi
 
 
@@ -220,9 +220,9 @@ if [ $? -ne 0 ]; then
     SITE_OUTPUT_DIR=$SITE_OUTPUT_DIR/
 fi
 aws s3 sync $SITE_OUTPUT_DIR s3://$WEBSITE_BUCKET/ \
-    --delete --only-show-errors > /opt/ocw/website-sync.log 2>&1
+    --delete --only-show-errors >> $LOG_DIR/website-sync.log 2>&1
 if [ $? -ne 0 ]; then
-    error_and_exit "Failed to sync to S3 bucket. See /opt/ocw/website-sync.log"
+    error_and_exit "Failed to sync to S3 bucket. See $LOG_DIR/website-sync.log"
 fi
 
 
@@ -239,9 +239,9 @@ fi
 
 log_message "Syncing ocw-to-hugo output to S3"
 aws s3 sync $COURSES_MARKDOWN_DIR/ s3://$OCW_TO_HUGO_BUCKET/ \
-    --delete --only-show-errors > /opt/ocw/ocw-to-hugo-output-sync.log 2>&1
+    --delete --only-show-errors >> $LOG_DIR/ocw-to-hugo-output-sync.log 2>&1
 if [ $? -ne 0 ]; then
-    error_and_exit "Failed to sync to S3 bucket. See /opt/ocw/ocw-to-hugo-output-sync.log"
+    error_and_exit "Failed to sync to S3 bucket. See $LOG_DIR/ocw-to-hugo-output-sync.log"
 fi
 
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -292,3 +292,4 @@ base:
     - node
     - caddy
     - apps.ocw.nextgen_build_install
+    - utils.logrotate


### PR DESCRIPTION
Improve the OCW Next webhook build script's logging, following reports of issues where the logs had been truncated and we lacked diagnostic information.

The logs are now put in their own `logs` directory, and are rotated with logrotate. Not truncating them also allows us to consume them more reliably with a logging agent like Vector or FluentD.

