### PR TITLE
Initial cleanup of hacks.sls

### DIFF
--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -1,10 +1,4 @@
 {% set purpose = salt.grains.get('purpose', 'xpro-qa') %}
-{% set heroku_xpro_env_url_mapping = {
-    'sandbox': 'https://xpro-ci.odl.mit.edu',
-    'xpro-qa': 'https://xpro-rc.odl.mit.edu',
-    'xpro-production': 'https://xpro.mit.edu'
-  } %}
-{% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
 
 {% if salt.file.directory_exists('/edx/var/edxapp/staticfiles/studio/templates') %}
 ensure_license_selector_template_is_in_expected_location:
@@ -44,13 +38,5 @@ add_social_auth_https_redirect_to_lms_production_file:
   file.append:
     - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
     - text: SOCIAL_AUTH_REDIRECT_IS_HTTPS = ENV_TOKENS.get('SOCIAL_AUTH_REDIRECT_IS_HTTPS', True)
-
-{% for app in ['lms', 'cms'] %}
-add_xpro_base_url_to_{{ app }}_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
-    - text: XPRO_BASE_URL = '{{ heroku_env }}'
-{% endfor %}
-
 {% endif %}
 {% endif %}

--- a/salt/edx/hacks.sls
+++ b/salt/edx/hacks.sls
@@ -5,12 +5,6 @@
     'xpro-production': 'https://xpro.mit.edu'
   } %}
 {% set heroku_env = heroku_xpro_env_url_mapping['{}'.format(purpose)] %}
-{% set JWT_SECRET_KEY = salt.pillar.get('edx:JWT_SECRET_KEY') %}
-{% set JWT_ISSUER = salt.pillar.get('edx:JWT_ISSUER') %}
-{% set JWT_AUDIENCE = salt.pillar.get('edx:JWT_AUDIENCE') %}
-{% set JWT_SECRET_KEY = salt.pillar.get('edx:JWT_SECRET_KEY') %}
-{% set JWT_PUBLIC_SIGNING_JWK_SET = salt.pillar.get('edx:JWT_PUBLIC_SIGNING_JWK_SET') %}
-{% set JWT_PRIVATE_SIGNING_JWK_SET = salt.pillar.get('edx:JWT_PRIVATE_SIGNING_JWK_SET') %}
 
 {% if salt.file.directory_exists('/edx/var/edxapp/staticfiles/studio/templates') %}
 ensure_license_selector_template_is_in_expected_location:
@@ -45,19 +39,6 @@ copy_select_static_assets_to_static_subfolder:
     - preserve: True
 {% endif %}
 
-{% if 'tumbleweed' != salt.grains.get('edx_codename') %}
-set_from_bulk_email_address_in_lms_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
-    - text: EMAIL_USE_DEFAULT_FROM_FOR_BULK = ENV_TOKENS.get('EMAIL_USE_DEFAULT_FROM_FOR_BULK', False)
-
-{% for app in ['lms', 'cms'] %}
-add_sentry_integration_to_{{ app }}_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
-    - text: RAVEN_CONFIG = ENV_TOKENS.get('RAVEN_CONFIG', {})
-{% endfor %}
-
 {% if 'mitxpro' in salt.grains.get('environment') %}
 add_social_auth_https_redirect_to_lms_production_file:
   file.append:
@@ -70,22 +51,6 @@ add_xpro_base_url_to_{{ app }}_production_file:
     - name: /edx/app/edxapp/edx-platform/{{ app }}/envs/production.py
     - text: XPRO_BASE_URL = '{{ heroku_env }}'
 {% endfor %}
-
-{% if 'ironwood' in grains.get('edx_codename') %}
-add_jwt_auth_to_production_file:
-  file.append:
-    - name: /edx/app/edxapp/edx-platform/lms/envs/production.py
-    - text: |
-        JWT_AUTH.update({'JWT_SECRET_KEY': '{{ JWT_SECRET_KEY }}',
-        'JWT_ISSUER': '{{ JWT_ISSUER }}',
-        'JWT_AUDIENCE': '{{ JWT_AUDIENCE }}',
-        'JWT_PUBLIC_SIGNING_JWK_SET': (
-            {{ JWT_PUBLIC_SIGNING_JWK_SET }}
-        ),
-        'JWT_PRIVATE_SIGNING_JWK': (
-            {{ JWT_PRIVATE_SIGNING_JWK_SET }}
-        ), })
-{% endif %}
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
#### What's this PR do?
Removed the following hacks since they are no longer needed or have been added to `ansible_vars`:
- EMAIL_USE_DEFAULT_FROM_FOR_BULK -> added to `ansible_vars`
- RAVEN_CONFIG -> replaced through the use of `eox-core[sentry]`
- JWT config for xpro -> handled through `ansible_vars`
- Removed XPRO_BASE_URL -> added config to edx-platform and configure it through ansible_vars