### PR TITLE
Add Vector agent to OCW Next build server

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -378,3 +378,4 @@ base:
   'roles:ocw-build':
     - match: grain
     - logrotate.ocw_build
+    - vector.ocw_build

--- a/pillar/vector/init.sls
+++ b/pillar/vector/init.sls
@@ -1,0 +1,2 @@
+vector:
+  configuration:

--- a/pillar/vector/init.sls
+++ b/pillar/vector/init.sls
@@ -1,2 +1,0 @@
-vector:
-  configuration:

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -1,5 +1,7 @@
 vector:
   configuration:
+    api:
+      enabled: true
     sources:
       webhook_publish_log:
         type: file

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -4,7 +4,7 @@ vector:
       webhook_publish_log:
         type: file
         include:
-          - /opt/ocw/logs/webhook_publish.log
+          - /opt/ocw/logs/webhook-publish.log
     transforms:
       webhook_publish_log_parser:
         inputs:

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -14,9 +14,9 @@ vector:
         type: regex_parser
         field: message
         patterns:
-          - '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<message>.*)$'
+          - '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{9}) (?P<message>.*)$'
         types:
-          timestamp: timestamp|%F %T
+          timestamp: timestamp|%Y-%m-%d %H:%M:%S.%f
         overwrite_target: true
       enriched_webhook_publish_log:
         inputs:

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -32,3 +32,4 @@ vector:
         type: elasticsearch
         endpoint: 'http://operations-elasticsearch.query.consul:9200'
         index: logstash-ocw-build-%Y.%W
+        healthcheck: false

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -1,0 +1,31 @@
+vector:
+  configuration:
+    sources:
+      webhook_publish_log:
+        type: file
+        include:
+          - /opt/ocw/logs/webhook_publish.log
+    transforms:
+      webhook_publish_log_parser:
+        inputs:
+          - webhook_publish_log
+        type: regex_parser
+        field: message
+        patterns:
+          - '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<message>.*)$'
+        types:
+          timestamp: timestamp|%F %T
+        overwrite_target: true
+      enriched_webhook_publish_log:
+        inputs:
+          - webhook_publish_log_parser
+        type: add_fields
+        fields:
+          category: ocw_build
+    sinks:
+      es_cluster:
+        inputs:
+          - enriched_webhook_publish_log
+        type: elasticsearch
+        host: 'http://operations-elasticsearch.query.consul:9200'
+        index: logstash-ocw-build-%Y.%W

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -30,5 +30,5 @@ vector:
         inputs:
           - enriched_webhook_publish_log
         type: elasticsearch
-        host: 'http://operations-elasticsearch.query.consul:9200'
+        endpoint: 'http://operations-elasticsearch.query.consul:9200'
         index: logstash-ocw-build-%Y.%W

--- a/pillar/vector/ocw_build.sls
+++ b/pillar/vector/ocw_build.sls
@@ -23,7 +23,8 @@ vector:
           - webhook_publish_log_parser
         type: add_fields
         fields:
-          category: ocw_build
+          labels:
+            - ocw_build
     sinks:
       es_cluster:
         inputs:

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -41,7 +41,7 @@ export OCW_STUDIO_BASE_URL
 script_option=$1
 
 log_message() {
-    echo `date +'%Y-%m-%d %H:%M:%S'` $1 | tee -a ${LOG_FILE}
+    echo `date +'%Y-%m-%d %H:%M:%S.%N'` $1 | tee -a ${LOG_FILE}
 }
 
 error_and_exit() {

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -288,7 +288,7 @@ base:
     - edx.django_user
   'roles:ocw-build':
     - match: grain
-    - fluentd
+    - vector
     - node
     - caddy
     - apps.ocw.nextgen_build_install

--- a/salt/vector/configure.sls
+++ b/salt/vector/configure.sls
@@ -1,0 +1,15 @@
+include:
+  - .service
+
+ensure_absence_of_default_toml_configuration:
+{# We will use YAML, instead. #}
+  file.absent:
+    - name: /etc/vector/vector.toml
+
+manage_vector_configuration_file:
+  file.managed:
+    - name: /etc/vector/vector.yaml
+    - contents: |
+        {{ salt.pillar.get('vector:configuration')|yaml(False)|indent(4) }}
+    - onchanges_in:
+      - service: vector_service_running

--- a/salt/vector/files/vector.service
+++ b/salt/vector/files/vector.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Vector
+Documentation=https://vector.dev
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+User=vector
+Group=vector
+# The YAML configuration file is not the default and must be specified
+# explicitly.
+ExecStart=/usr/bin/vector --config /etc/vector/vector.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=no
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+EnvironmentFile=-/etc/default/vector
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/vector/init.sls
+++ b/salt/vector/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .install
+  - .configure

--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -28,9 +28,7 @@ ensure_state_of_systemd_service_file:
   file.managed:
     - name: /etc/systemd/system/vector.service
     - source: salt://vector/files/vector.service
-  {% if salt.grains.get('init') == 'systemd' %}
   cmd.wait:
     - name: systemctl daemon-reload
     - watch:
         - file: ensure_state_of_systemd_service_file
-  {% endif %}

--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -1,6 +1,21 @@
-install_vector_repo:
+ensure_package_prerequisite_installations:
+  pkg.installed:
+    pkgs:
+      - debian-keyring
+      - debian-archive-keyring
+      - apt-transport-https
+      - ca-certificates
+      - gnupg
+
+install_vector_repo_key:
   cmd.run:
-    - name: curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | bash
+    - name: curl -1sLf "https://repositories.timber.io/public/vector/cfg/gpg/gpg.3543DB2D0A2BC4B8.key" | apt-key add -
+
+update_apt_sources_list:
+  pkgrepo.managed:
+    - humanname: Vector
+    - name: deb https://repositories.timber.io/public/vector/deb/debian {{ salt.grains.get('oscodename', 'stable') }} main
+    - refresh_db: True
 
 ensure_vector_package_state:
   pkg.installed:

--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -13,3 +13,9 @@ ensure_state_of_systemd_service_file:
   file.managed:
     - name: /etc/systemd/system/vector.service
     - source: salt://vector/files/vector.service
+  {% if salt.grains.get('init') == 'systemd' %}
+  cmd.wait:
+    - name: systemctl daemon-reload
+    - watch:
+        - file: ensure_state_of_systemd_service_file
+  {% endif %}

--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -30,5 +30,5 @@ ensure_state_of_systemd_service_file:
     - source: salt://vector/files/vector.service
   cmd.wait:
     - name: systemctl daemon-reload
-    - watch:
+    - onchanges:
         - file: ensure_state_of_systemd_service_file

--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -1,0 +1,15 @@
+install_vector_repo:
+  cmd.run:
+    - name: curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | bash
+
+ensure_vector_package_state:
+  pkg.installed:
+    - name: vector
+    - refresh: True
+    - require:
+      - cmd: install_vector_repo
+
+ensure_state_of_systemd_service_file:
+  file.managed:
+    - name: /etc/systemd/system/vector.service
+    - source: salt://vector/files/vector.service

--- a/salt/vector/service.sls
+++ b/salt/vector/service.sls
@@ -1,0 +1,5 @@
+vector_service_running:
+  service.running:
+    - name: vector
+    - enable: True
+    - reload: True


### PR DESCRIPTION
Add the Vector log agent to the OCW Next build server and have it ship directly to Elasticsearch.

This is a trial and if it goes well we will add aggregators and more agents.

Though I haven't been able to test the Salt states, I've been able to test the configuration file itself with a couple of VirtualBox VMs that simulate an agent and the Elasticsearch service. I've also tested the systemd service configuration.
