### PR TITLE
Moved XPRO_BASE_URL from hacks.sls

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -108,6 +108,7 @@ edx:
         SKIP_EMAIL_VALIDATION: True
       EOX_CORE_SENTRY_INTEGRATION_DSN: __vault__::secret-{{ business_unit }}/{{ environment }}{{ purpose }}/sentry>data>dsn
       EOX_CORE_SENTRY_IGNORED_ERRORS: []
+      XPRO_BASE_URL: '{{ heroku_env }}'
 
     EDXAPP_CMS_ENV_EXTRA:
       ADDL_INSTALLED_APPS:


### PR DESCRIPTION
#### What's this PR do?
This is related to the work in this [PR](https://github.com/mitodl/salt-ops/pull/1352) to remove the `xpro_base_url` from the `hacks.sls` file

