### PR TITLE
Adding config to prevent abusive scans for PHP vulnerabilities

### DIFF
--- a/salt/edx/templates/extra_locations_lms.j2
+++ b/salt/edx/templates/extra_locations_lms.j2
@@ -25,3 +25,11 @@
         try_files $uri @proxy_to_lms_app;
     }
 {% endif %}
+
+location ~ .*\.php {
+    return 404;
+}
+
+location ~ ^/wp-(admin|content) {
+    return 404;
+}


### PR DESCRIPTION
We have been getting Sentry errors due to people scanning for wordpress and PHP endpoints on our edX servers. This adds nginx rules to return a 404 for any wp-content or wp-admin routes and anything ending in .php