### PR TITLE
add mailchimp settings for newsletter on home page

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -12,6 +12,8 @@ ocw-next:
   course_base_url: https://ocwnext.odl.mit.edu/courses
   ocw_studio_base_url: https://ocw-studio.odl.mit.edu/
   gtm_account_id: GTM-NMQZ25T
+  mailchimp_audience_id: e07062bda1v
+  mailchmip_user_id: ad81d725159c1f322a0c54837
 
 node:
   version: 12.19.0


### PR DESCRIPTION
#### What are the relevant tickets?

fixes https://github.com/mitodl/ocw-www/issues/52

#### What's this PR do?

Adds Mailchimp settings, which I hope will be available to the ocw-www build. 

#### How should this be manually tested?

Visit the ocwnext home page and enter your email address in the newsletter form:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/430126/109070112-1733c800-76c0-11eb-9dd0-697b2c173415.png">

