### PR TITLE
Fix Vector installation for Ubuntu

### DIFF
--- a/salt/vector/install.sls
+++ b/salt/vector/install.sls
@@ -1,11 +1,10 @@
+{% from "vector/map.jinja" import vector with context %}
+
+
 ensure_package_prerequisite_installations:
   pkg.installed:
-    - pkgs:
-        - debian-keyring
-        - debian-archive-keyring
-        - apt-transport-https
-        - ca-certificates
-        - gnupg
+    - pkgs: {{ vector.pkg_dependencies }}
+    - update: true
 
 install_vector_repo_key:
   cmd.run:
@@ -14,7 +13,7 @@ install_vector_repo_key:
 update_apt_sources_list:
   pkgrepo.managed:
     - humanname: Vector
-    - name: deb https://repositories.timber.io/public/vector/deb/debian {{ salt.grains.get('oscodename', 'stable') }} main
+    - name: deb https://repositories.timber.io/public/vector/deb/{{ salt.grains.get('os', 'Debian')|lower }} {{ salt.grains.get('oscodename', 'stable') }} main
     - refresh_db: True
 
 ensure_vector_package_state:

--- a/salt/vector/map.jinja
+++ b/salt/vector/map.jinja
@@ -1,0 +1,18 @@
+{% set vector = salt['grains.filter_by']({
+    'Debian': {
+        'pkg_dependencies': [
+            'debian-keyring',
+            'debian-archive-keyring',
+            'apt-transport-https',
+            'ca-certificates',
+            'gnupg'
+        ]
+    },
+    'Ubuntu': {
+        'pkg_dependencies': [
+            'apt-transport-https',
+            'ca-certificates',
+            'gnupg'
+        ]
+    }
+}, grain='os', merge=salt.pillar.get('vector:overrides'), base='default') %}


### PR DESCRIPTION
Here is a quick PR to fix the Vector `install` state for an Ubuntu minion.

The package repository that I had hardcoded does not work for Ubuntu, with "debian" as the o/s and "focal" as the (nonexistent for Debian) release codename.

The `/etc/apt/sources.list.d/timber-vector.list` value in my Ubuntu VM is:
```
deb https://repositories.timber.io/public/vector/deb/ubuntu focal main
```
