### PR TITLE
Add sink for MITx auth log data

### DIFF
--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -453,6 +453,15 @@ vector:
           type: check_fields
           "message.not_contains": "CRON"
 
+      auth_log_labeler:
+        inputs:
+          - auth_log_sampler
+        type: add_fields
+        fields:
+          labels:
+            - authlog
+            - edx_authlog
+
     sinks:
 
       {% if 'edx' in salt.grains.get('roles') %}
@@ -505,3 +514,10 @@ vector:
         endpoint: 'http://operations-elasticsearch.query.consul:9200'
         index: logs-mitx-tracking-%Y.%W
         healthcheck: false
+
+      elasticsearch_auth:
+        inputs:
+          - auth_log_labeler
+        type: elasticsearch
+        endpoint: 'http://operations-elasticsearch.query.consul:9200'
+        index: logs-authlog-%Y.%W

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -515,7 +515,7 @@ vector:
         index: logs-mitx-tracking-%Y.%W
         healthcheck: false
 
-      elasticsearch_auth:
+      elasticsearch_authlog:
         inputs:
           - auth_log_labeler
         type: elasticsearch


### PR DESCRIPTION
I'd neglected to add a sink for the auth.log data in my last Vector PR.

This adds that sink and sets a new paradigm of adding all auth.log events to a single index for all of our servers. I figured this would make it easier to manage permissions on security data in the future.