### PR TITLE
Swap Vector for FluentD on MongoDB minions

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -92,7 +92,7 @@ base:
   'roles:mongodb':
     - match: grain
     - mongodb
-    - fluentd.mongodb
+    - vector.mongodb
     - consul.mongodb
   mongodb*production*:
     - datadog.mongodb-integration

--- a/pillar/vector/mongodb.sls
+++ b/pillar/vector/mongodb.sls
@@ -1,0 +1,57 @@
+vector:
+  configuration:
+
+    api:
+      enabled: true
+
+    log_schema:
+      timestamp_key: "@timestamp"
+      host_key: log_host
+
+    sources:
+
+      mongodb_log:
+        type: file
+        file_key: log_file
+        include:
+          - /var/log/mongodb/mongodb.log
+
+    transforms:
+
+      log_parser:
+        inputs:
+          - mongodb_log
+        type: regex_parser
+        drop_failed: true
+        field: message
+        overwrite_target: true
+        patterns:
+          - '^(?P<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4}) (?P<log_level>\w) (?P<component>\w+)\s+\[(?P<context>.+?)\] (?P<message>.*)'
+        types:
+          time: timestamp|%Y-%m-%dT%H:%M:%S%.3f%z
+
+     field_adder:
+        inputs:
+          - log_parser
+        type: add_fields
+        fields:
+          labels:
+            - mongodb
+          environment: {{ salt.grains.get('environment') }}
+
+      timestamp_renamer:
+        inputs:
+          - field_adder
+        type: rename_fields
+        fields:
+          time: "@timestamp"
+
+    sinks:
+
+      elasticsearch:
+        inputs:
+          - timestamp_renamer
+        type: elasticsearch
+        endpoint: 'http://operations-elasticsearch.query.consul:9200'
+        index: logs-mongodb-%Y.%W
+        healthcheck: false

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,7 +1,7 @@
 base:
   '*':
     - utils.install_libs
-  'not G@roles:devstack':
+  'not G@roles:devstack and not G@roles:edx and not G@roles:mongodb':
     - match: compound
     - utils.inotify_watches
     - fluentd
@@ -175,6 +175,7 @@ base:
     - match: grain
     - mongodb
     - mongodb.consul_check
+    - vector
   'G@roles:mongodb and P@environment:mitx(pro)?-production':
     - match: compound
     - datadog.plugins


### PR DESCRIPTION
This adds the Vector agent to MongoDB minions, and changes/fixes the topfile selectors for both the `mongodb` and `edx` roles.

The main thing I could use input on is the index naming pattern: `logs-mongodb-%Y.%W`. As envisioned, this would hold MongoDB logs for all `mongodb` hosts, including XPro and MITx. Is this going to be OK, or do we want the ability to preserve MITx Residential's MongoDB logs for a different duration than XPro's? In that case, I'd want to name the indexes based on the environment name in addition to "mongodb."

