### PR TITLE
Add quotes to nginx app_metric referer field

### DIFF
--- a/pillar/nginx/init.sls
+++ b/pillar/nginx/init.sls
@@ -15,7 +15,7 @@ nginx:
             status=$status
             bytes_sent=$bytes_sent
             body_bytes_sent=$body_bytes_sent
-            referer=$http_referer
+            referer="$http_referer"
             user_agent="$http_user_agent"
             upstream_addr=$upstream_addr
             upstream_status=$upstream_status


### PR DESCRIPTION
Add quotes to the 'referer' field in the logs, or else it gets parsed incorrectly by Vector's built-in 'logfmt_parser' Transform when a URL has certain special characters.
