### PR TITLE
Vector: send MITx tracking logs to S3, not Elasticsearch

### DIFF
--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -536,9 +536,9 @@ vector:
         inputs:
           - tracking_log_timestamp_renamer
         type: aws_s3
-        bucket: {{ salt.grains.get('environment') }}-tracking-logs
+        bucket: odl-residential-tracking-data
         region: us-east-1
-        key_prefix: "%F/tracking-{{ salt.grains.get('environment') }}_%F.%T_"
+        key_prefix: "%F-%H_"
         encoding:
           codec: ndjson
         batch:

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -524,6 +524,6 @@ vector:
         encoding:
           codec: ndjson
         batch:
-          timeout_secs: {{ 60 * 60 * 24 }}
+          timeout_secs: {{ 60 * 60 }}
           max_bytes: {{ 1024 * 1024 * 1024 * 2 }}
         healthcheck: false

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -432,6 +432,16 @@ vector:
         fields:
           time: "@timestamp"
 
+      tracking_log_field_adder:
+        inputs:
+          - tracking_log_timestamp_renamer
+        type: add_fields
+        fields:
+          labels:
+            - edx_tracking
+          environment: {{ salt.grains.get('environment') }}
+
+
       auth_log_parser:
         inputs:
           - auth_log
@@ -505,6 +515,14 @@ vector:
         type: elasticsearch
         endpoint: 'http://operations-elasticsearch.query.consul:9200'
         index: logs-mitx-stderr-%Y.%W
+        healthcheck: false
+
+      elasticsearch_tracking:
+        inputs:
+          - tracking_log_field_adder
+        type: elasticsearch
+        endpoint: 'http://operations-elasticsearch.query.consul:9200'
+        index: logs-mitx-tracking-%Y.%W
         healthcheck: false
 
       elasticsearch_authlog:

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -1,3 +1,8 @@
+{% if environment == 'mitx-qa' %}
+{% set tracking_bucket = 'odl-residential-tracking-data-qa' %}
+{% elif environment == 'mitx-production' %}
+{% set tracking_bucket = 'odl-residential-tracking-data' %}
+
 vector:
   configuration:
 
@@ -536,7 +541,7 @@ vector:
         inputs:
           - tracking_log_timestamp_renamer
         type: aws_s3
-        bucket: odl-residential-tracking-data
+        bucket: {{ tracking_bucket }}
         region: us-east-1
         key_prefix: "%F-%H_"
         encoding:

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -543,7 +543,7 @@ vector:
         type: aws_s3
         bucket: {{ tracking_bucket }}
         region: us-east-1
-        key_prefix: "%F-%H_"
+        key_prefix: "logs/%F-%H_"
         encoding:
           codec: ndjson
         batch:

--- a/pillar/vector/mitx.sls
+++ b/pillar/vector/mitx.sls
@@ -446,7 +446,6 @@ vector:
             - edx_tracking
           environment: {{ salt.grains.get('environment') }}
 
-
       auth_log_parser:
         inputs:
           - auth_log
@@ -539,7 +538,7 @@ vector:
 
       s3_tracking:
         inputs:
-          - tracking_log_timestamp_renamer
+          - tracking_log_timestamp_coercer
         type: aws_s3
         bucket: {{ tracking_bucket }}
         region: us-east-1


### PR DESCRIPTION
This changes the MITx Vector configuration to send the tracking logs to an S3 bucket, instead of Elasticsearch.

The logs are batched by day (or in 2 GB increments, whichever comes first).

The formatting results in folders and files named in this fashion:

```
2021-03-09/tracking-mitx-qa_2021-03-09.16:23:58_1615307099-663dd84c-1c8a-4aac-bc40-c7e8a788d543.log.gz
```

The unique identifiers are added by default by Vector's `aws_s3` sink to prevent collisions when multiple hosts are involved.

