### PR TITLE
Commenting out policy definitions to avoid overwrites

### DIFF
--- a/salt/orchestrate/edx/backup.sls
+++ b/salt/orchestrate/edx/backup.sls
@@ -25,16 +25,16 @@ ensure_backup_bucket_exists:
 ensure_instance_profile_exists_for_backups:
   boto_iam_role.present:
     - name: backups-instance-role
-    - delete_policies: False
-    - policies:
-        operations-backups-policy:
-          Statement:
-            - Action:
-                - s3:*
-              Effect: Allow
-              Resource:
-                - arn:aws:s3:::odl-operations-backups
-                - arn:aws:s3:::odl-operations-backups/*
+    # - delete_policies: False
+    # - policies:
+    #     operations-backups-policy:
+    #       Statement:
+    #         - Action:
+    #             - s3:*
+    #           Effect: Allow
+    #           Resource:
+    #             - arn:aws:s3:::odl-operations-backups
+    #             - arn:aws:s3:::odl-operations-backups/*
     - require:
         - boto_s3_bucket: ensure_backup_bucket_exists
 

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -81,25 +81,25 @@ ensure_tracking_bucket_exists:
     - Bucket: {{ edx_tracking_bucket }}
     - region: us-east-1
 
-ensure_instance_profile_exists_for_tracking:
-  boto_iam_role.present:
-    - name: edx-{{ ENVIRONMENT }}-instance-role
-    - delete_policies: False
-    - policies:
-        edx-old-tracking-logs-policy:
-          Statement:
-            - Action:
-                - s3:GetObject
-                - s3:ListAllMyBuckets
-                - s3:ListBucket
-                - s3:ListObjects
-                - s3:PutObject
-              Effect: Allow
-              Resource:
-                - arn:aws:s3:::{{ edx_tracking_bucket }}
-                - arn:aws:s3:::{{ edx_tracking_bucket }}/*
-    - require:
-        - boto_s3_bucket: ensure_tracking_bucket_exists
+# ensure_instance_profile_exists_for_tracking:
+#   boto_iam_role.present:
+#     - name: edx-{{ ENVIRONMENT }}-instance-role
+#     - delete_policies: False
+#     - policies:
+#         edx-old-tracking-logs-policy:
+#           Statement:
+#             - Action:
+#                 - s3:GetObject
+#                 - s3:ListAllMyBuckets
+#                 - s3:ListBucket
+#                 - s3:ListObjects
+#                 - s3:PutObject
+#               Effect: Allow
+#               Resource:
+#                 - arn:aws:s3:::{{ edx_tracking_bucket }}
+#                 - arn:aws:s3:::{{ edx_tracking_bucket }}/*
+#     - require:
+#         - boto_s3_bucket: ensure_tracking_bucket_exists
 
 deploy_edx_cloud_map:
   salt.function:

--- a/salt/orchestrate/edx/restore.sls
+++ b/salt/orchestrate/edx/restore.sls
@@ -27,16 +27,16 @@ ensure_backup_bucket_exists:
 ensure_instance_profile_exists_for_backups:
   boto_iam_role.present:
     - name: backups-instance-role
-    - delete_policies: False
-    - policies:
-        operations-backups-policy:
-          Statement:
-            - Action:
-                - s3:*
-              Effect: Allow
-              Resource:
-                - arn:aws:s3:::odl-operations-backups
-                - arn:aws:s3:::odl-operations-backups/*
+    # - delete_policies: False
+    # - policies:
+    #     operations-backups-policy:
+    #       Statement:
+    #         - Action:
+    #             - s3:*
+    #           Effect: Allow
+    #           Resource:
+    #             - arn:aws:s3:::odl-operations-backups
+    #             - arn:aws:s3:::odl-operations-backups/*
     - require:
         - boto_s3_bucket: ensure_backup_bucket_exists
 

--- a/salt/orchestrate/operations/backups.sls
+++ b/salt/orchestrate/operations/backups.sls
@@ -24,16 +24,16 @@ ensure_backup_bucket_exists:
 ensure_instance_profile_exists_for_backups:
   boto_iam_role.present:
     - name: backups-instance-role
-    - delete_policies: False
-    - policies:
-        operations-backups-policy:
-          Statement:
-            - Action:
-                - s3:*
-              Effect: Allow
-              Resource:
-                - arn:aws:s3:::odl-operations-backups
-                - arn:aws:s3:::odl-operations-backups/*
+    # - delete_policies: False
+    # - policies:
+    #     operations-backups-policy:
+    #       Statement:
+    #         - Action:
+    #             - s3:*
+    #           Effect: Allow
+    #           Resource:
+    #             - arn:aws:s3:::odl-operations-backups
+    #             - arn:aws:s3:::odl-operations-backups/*
     - require:
         - boto_s3_bucket: ensure_backup_bucket_exists
 


### PR DESCRIPTION
As we are transitioning to Pulumi we want to avoid having Salt overwrite any policy definitions that we are managing elsewhere. This comments out policy definitions from orchestrate scripts to avoid those collisions. The reason for commenting rather than deleting is to make it easier to identify and translate policies that need to be migrated.