### PR TITLE
Upgrade Elasticsearch and Kibana to Open Distro

### DIFF
--- a/salt/elastic_stack/files/upgrade_es.sh
+++ b/salt/elastic_stack/files/upgrade_es.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+systemctl stop elasticsearch
+cp -p /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.backup-pre-upgrade
+dpkg -P elasticsearch
+grep -v 'artifacts.elastic.co' /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
+dpkg -P ca-certificates-java openjdk-8-jre-headless
+grep -v 'ftp.us.debian.org/debian/ stretch main contrib non-free' /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
+apt-get update
+apt-get clean
+apt-get install -y software-properties-common dirmngr apt-transport-https unzip
+echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
+apt-get update
+apt-get install -y openjdk-11-jdk
+wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | apt-key add -
+echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+apt-get update
+cd /var/tmp
+wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.2-amd64.deb
+dpkg -i elasticsearch-oss-7.10.2-amd64.deb
+rm elasticsearch-oss-7.10.2-amd64.deb
+apt-get install -y opendistro-index-management opendistro-alerting opendistro-job-scheduler
+cp -p /etc/elasticsearch/elasticsearch.yml.backup-pre-upgrade /etc/elasticsearch/elasticsearch.yml
+systemctl start elasticsearch

--- a/salt/elastic_stack/files/upgrade_kibana.sh
+++ b/salt/elastic_stack/files/upgrade_kibana.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# There's no Salt state to run this script. We only have one Kibana instance
+# per environment, so it's easier to just copy and run this script or these
+# commands on the instance.
+
+set -e
+
+systemctl stop kibana
+cp -p /etc/kibana/kibana.yml /etc/kibana/kibana.yml.backup-pre-upgrade
+dpkg -P kibana
+grep -v 'artifacts.elastic.co' /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
+apt-get update
+apt-get clean
+wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | apt-key add -
+echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
+apt-get update
+apt-get install -y opendistroforelasticsearch-kibana
+cp -p /etc/kibana/kibana.yml.backup-pre-upgrade /etc/kibana/kibana.yml
+/usr/share/kibana/bin/kibana-plugin --allow-root remove opendistroSecurityKibana
+systemctl daemon-reload
+systemctl enable kibana.service
+systemctl start kibana

--- a/salt/elastic_stack/upgrade_es_to_open_distro.sls
+++ b/salt/elastic_stack/upgrade_es_to_open_distro.sls
@@ -1,0 +1,4 @@
+
+run_upgrade_script:
+  cmd.script:
+    - name: salt://elastic_stack/files/upgrade_es.sh

--- a/salt/orchestrate/elastic_stack/upgrade_es_to_open_distro.sls
+++ b/salt/orchestrate/elastic_stack/upgrade_es_to_open_distro.sls
@@ -1,0 +1,59 @@
+{# USAGE:
+    Set ES_BASE_URL to your Elasticsearch URL.
+    Set ES_NODE_TARGET to the Salt target for your Elasticsearch node minions.
+    Set WAIT to the time to wait after restarting nodes and doing the next one.
+
+    Example:
+      sudo -E \
+        ES_BASE_URL=http://mycluster:9200 \
+        ES_NODE_TARGET="elasticsearch-*" \
+        WAIT=30 \
+        salt-run state.orchestrate elastic_stack.upgrade_es_to_open_distro
+#}
+
+{% set ES_NODE_TARGET = salt.environ.get('ES_NODE_TARGET') %}
+{% set ES_BASE_URL = salt.environ.get('ES_BASE_URL') %}
+{% set WAIT = salt.environ.get('WAIT', '30') %}
+
+disable_shard_allocation:
+  http.query:
+    - name: {{ ES_BASE_URL }}/_cluster/settings
+    - method: PUT
+    - status: 200
+    - data: >-
+        {
+          "persistent": {
+            "cluster.routing.allocation.enable": "none"
+          }
+        }
+    - header_dict:
+        'Content-Type': 'application/json'
+        'Accept': 'application/json'
+
+upgrade_elasticsearch:
+  salt.state:
+    - tgt: "{{ ES_NODE_TARGET }}"
+    - batch: 1
+    - batch_wait: {{ WAIT | int }}
+    - sls:
+      - elastic_stack.upgrade_es_to_open_distro.sls
+    - require:
+      - http: disable_shard_allocation
+
+enable_shard_allocation:
+  http.query:
+    - name: {{ ES_BASE_URL }}/_cluster/settings
+    - method: PUT
+    - status: 200
+    - data: >-
+        {
+          "persistent": {
+            "cluster.routing.allocation.enable": "all"
+          }
+        }
+    - header_dict:
+        'Content-Type': 'application/json'
+        'Accept': 'application/json'
+
+    - require:
+      - salt: upgrade_elasticsearch


### PR DESCRIPTION
This upgrades Elasticsearch and Kibana from Elastic.co's licence-restricted distribution to Open Distro.

We are working to reduce the time and energy we're investing in Saltstack, so this is done as simply as possible, with most of the work performed by a shell script.
