### PR TITLE
Improve Open Distro upgrade script and orchestration

### DIFF
--- a/salt/elastic_stack/files/upgrade_es.sh
+++ b/salt/elastic_stack/files/upgrade_es.sh
@@ -2,9 +2,12 @@
 
 set -e
 
-systemctl stop elasticsearch
+systemctl stop elasticsearch || true
 cp -p /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.backup-pre-upgrade
+umount /var/lib/elasticsearch
 dpkg -P elasticsearch
+mkdir /var/lib/elasticsearch
+mount /var/lib/elasticsearch
 grep -v 'artifacts.elastic.co' /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
 dpkg -P ca-certificates-java openjdk-8-jre-headless
 grep -v 'ftp.us.debian.org/debian/ stretch main contrib non-free' /etc/apt/sources.list > /tmp/sources.list && mv /tmp/sources.list /etc/apt/sources.list
@@ -13,6 +16,7 @@ apt-get clean
 apt-get install -y software-properties-common dirmngr apt-transport-https unzip
 echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
 apt-get update
+apt-get install -y ca-certificates-java  # must happen on its own line, before openjdk-11-jdk
 apt-get install -y openjdk-11-jdk
 wget -qO - https://d3g5vo6xdbdb9a.cloudfront.net/GPG-KEY-opendistroforelasticsearch | apt-key add -
 echo "deb https://d3g5vo6xdbdb9a.cloudfront.net/apt stable main" | tee -a /etc/apt/sources.list.d/opendistroforelasticsearch.list
@@ -23,4 +27,14 @@ dpkg -i elasticsearch-oss-7.10.2-amd64.deb
 rm elasticsearch-oss-7.10.2-amd64.deb
 apt-get install -y opendistro-index-management opendistro-alerting opendistro-job-scheduler
 cp -p /etc/elasticsearch/elasticsearch.yml.backup-pre-upgrade /etc/elasticsearch/elasticsearch.yml
-systemctl start elasticsearch
+find /etc/elasticsearch -nogroup -exec chgrp elasticsearch {} \;
+find /etc/elasticsearch -nouser -exec chown elasticsearch {} \;
+find /var/lib/elasticsearch -nogroup -exec chgrp elasticsearch {} \;
+find /var/lib/elasticsearch -nouser -exec chown elasticsearch {} \;
+find /usr/share/elasticsearch -nogroup -exec chgrp elasticsearch {} \;
+find /usr/share/elasticsearch -nouser -exec chown elasticsearch {} \;
+chown -Rh root:root /var/lib/elasticsearch/lost+found
+/usr/share/elasticsearch/bin/elasticsearch-plugin install -b discovery-ec2
+/usr/share/elasticsearch/bin/elasticsearch-plugin install -b repository-s3
+systemctl daemon-reload
+systemctl enable elasticsearch.service

--- a/salt/orchestrate/elastic_stack/upgrade_es_to_open_distro.sls
+++ b/salt/orchestrate/elastic_stack/upgrade_es_to_open_distro.sls
@@ -1,4 +1,19 @@
 {# USAGE:
+
+    Before upgrading:
+      1. Uninstall Elastalert from the Kibana minion
+      2. Remove Index Lifecycle policies in Kibana
+      3. Remove "index.lifecycle" objects from all indices' settings
+         For example:
+          curl -XPUT "http://es-host:9200/logs*/_settings" \
+            -H 'Content-Type: application/json' \
+            -d'{"index": { "lifecycle.*": null} }'
+      4. Remove ILM-related index templates from Elasticsearch
+      5. Shut down the Kibana service
+      6. Delete the .kibana* indices from Elasticsearch
+
+    Then ...
+
     Set ES_BASE_URL to your Elasticsearch URL.
     Set ES_NODE_TARGET to the Salt target for your Elasticsearch node minions.
     Set WAIT to the time to wait after restarting nodes and doing the next one.
@@ -30,15 +45,31 @@ disable_shard_allocation:
         'Content-Type': 'application/json'
         'Accept': 'application/json'
 
+stop_elasticsearch:
+  salt.function:
+    - tgt: "{{ ES_NODE_TARGET }}"
+    - name: service.stop
+    - arg:
+      - elasticsearch
+    - require:
+      - http: disable_shard_allocation
+
 upgrade_elasticsearch:
   salt.state:
     - tgt: "{{ ES_NODE_TARGET }}"
-    - batch: 1
-    - batch_wait: {{ WAIT | int }}
     - sls:
       - elastic_stack.upgrade_es_to_open_distro.sls
     - require:
-      - http: disable_shard_allocation
+      - salt: stop_elasticsearch
+
+start_elasticsearch:
+  salt.function:
+    - tgt: "{{ ES_NODE_TARGET }}"
+    - name: service.start
+    - arg:
+      - elasticsearch
+    - require:
+      - salt: upgrade_elasticsearch
 
 enable_shard_allocation:
   http.query:


### PR DESCRIPTION
- Fix the shell script so that it jumps through more hoops
- Update the orchestration so that it does a full cluster shutdown

I can update you with some of the crazy things I had to go through to make the upgrade work in QA, if you like.

Highlights:

* We can use the discovery-ec2 plugin for discovery... for now... until they break it or ES.co decides to make it not work with Open Distro. It's being pulled from the Es.co repository, I think.
* The uninstallation and re-installation of Java does not work the way a reasonable person would expect it to
* Index Lifecycle Management has been superceded by Open Distro's index management plugin, which is incompatible with ILM even though it does the same things. It has a different JSON syntax for configuration. We have to just delete ILM policies and recreate their equivalents ourselves in Kibana after the upgrade.
* If you don't delete the ILM settings from your index `_settings`, the "lifecycle" object gets moved to a new "archived" object in the settings ... which causes `400 Bad Request` errors when you try to update any settings on that index... and you can't delete it unless you use a little trick that is out-of-scope for this PR description. So we just delete the ILM settings before doing the upgrade.
* You have to delete the `.kibana` indices to avoid running into this awesome error when you start the cluster back up: `org.elasticsearch.bootstrap.StartupException: java.lang.IllegalStateException: unable to upgrade the mappings for the index [[.kibana_3/0
56zS2BBQtS-9vBzf2qTsQ]]` (Which renders the cluster unstartable.)
