### PR TITLE
Use ocw-to-hugo version referenced by ocw-course-hugo-theme

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -4,7 +4,6 @@ ocw-next:
   ocw_to_hugo_bucket: ocw-to-hugo-output-production
   source_data_bucket: open-learning-course-data-production
   search_api_url: //open.mit.edu/api/v0/search/
-  ocw_to_hugo_git_ref: release
   ocw_www_git_ref: release
   ocw_course_hugo_starter_git_ref: release
   fastly_api_token: __vault__::secret-open-courseware/production-apps/fastly-api>data>token

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -4,7 +4,6 @@ ocw-next:
   ocw_to_hugo_bucket: ocw-to-hugo-output-qa
   source_data_bucket: open-learning-course-data-rc
   search_api_url: //discussions-rc.odl.mit.edu/api/v0/search/
-  ocw_to_hugo_git_ref: release-candidate
   ocw_www_git_ref: release-candidate
   ocw_course_hugo_starter_git_ref: release-candidate
   fastly_api_token: __vault__::secret-open-courseware/rc-apps/fastly-api>data>token

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -22,7 +22,6 @@ WEBSITE_BUCKET={{ website_bucket }}
 OCW_TO_HUGO_BUCKET={{ ocw_to_hugo_bucket }}
 FASTLY_API_TOKEN={{ fastly_api_token }}
 FASTLY_SERVICE_ID={{ fastly_service_id }}
-OCW_TO_HUGO_GIT_REF={{ ocw_to_hugo_git_ref }}
 OCW_WWW_GIT_REF={{ ocw_www_git_ref }}
 OCW_COURSE_HUGO_STARTER_GIT_REF={{ ocw_course_hugo_starter_git_ref }}
 COURSE_BASE_URL={{ course_base_url }}
@@ -114,20 +113,12 @@ cd /opt/ocw/ocw-www || error_and_exit "Can not cd to ocw-www"
 git_fetch_and_reset ocw-www $OCW_WWW_GIT_REF
 ocw_www_changed=$?
 
-
-# Pull ocw-to-hugo
-
-cd /opt/ocw/ocw-to-hugo || error_and_exit "Can not cd to ocw-to-hugo"
-git_fetch_and_reset ocw-to-hugo $OCW_TO_HUGO_GIT_REF
-ocw_to_hugo_changed=$?
-
 # Pull ocw-course-hugo-starter
 
 cd /opt/ocw/ocw-course-hugo-starter \
     || error_and_exit "Can not cd to ocw-course-hugo-starter"
 git_fetch_and_reset ocw-course-hugo-starter $OCW_COURSE_HUGO_STARTER_GIT_REF
 ocw_course_hugo_starter_changed=$?
-
 
 # Continue if there were changes, or if we want a 'full' run regardless of
 # changes.
@@ -146,11 +137,24 @@ if [ "$script_option" != "full" ]; then
 fi
 
 
+# Install ocw-course-hugo-theme and ocw-to-hugo which is a dependency of that
+cd /opt/ocw/ocw-course-hugo-starter
+
+# Install dependencies in the _vendor folder
+rm -rf _vendor
+hugo mod get -u || error_and_exit "Unable to install go dependencies of ocw-course-hugo-starter"
+hugo mod vendor || error_and_exit "Unable to run hugo mod vendor for ocw-course-hugo-starter"
+
+# Install packages for ocw-course-hugo-theme (this should include ocw-to-hugo)
+cd ./_vendor/github.com/mitodl/ocw-course-hugo-theme
+log_message "Doing yarn install of dependencies for ocw-course-hugo-theme"
+yarn install --pure-lockfile >> $LOG_DIR/ocw-course-hugo-theme-install.log 2>&1 \
+    || error_and_exit "Can't install dependencies for ocw-course-hugo-theme"
+
 # Run ocw-to-hugo
+cd ./node_modules/@mitodl/ocw-to-hugo
 
-cd /opt/ocw/ocw-to-hugo
-
-clear_directory /opt/ocw/ocw-to-hugo/node_modules
+clear_directory ./node_modules
 
 log_message "Doing yarn install of ocw-to-hugo"
 yarn install --pure-lockfile >> $LOG_DIR/ocw-to-hugo-install.log 2>&1 \


### PR DESCRIPTION
**Note**: do not merge until we add ocw-to-hugo as a dependency to ocw-course-hugo-theme first (https://github.com/mitodl/ocw-course-hugo-theme/pull/79)

#### What are the relevant tickets?
None

#### What's this PR do?
Previously the ocwnext deployment script used the latest version of `ocw-to-hugo` from the `release-candidate` branch. To make the build process more explicit, we want to reference the version of `ocw-to-hugo` in `ocw-course-hugo-theme` specifically. This PR updates the build script to use that version of `ocw-to-hugo`, and remove some unused settings related to `ocw-to-hugo`.

#### How should this be manually tested?
TBD -- is this a necessary step for reviews in salt-ops?

#### Other context
I'm not sure what this line means for ocw-to-hugo or how this file is used in general. Should we just delete this block or is it still useful? https://github.com/mitodl/salt-ops/blob/main/salt/apps/ocw/nextgen_build_install.sls#L51
