### PR TITLE
Fix admin API access, apps Elasticsearch cluster

### DIFF
--- a/pillar/elastic_stack/elasticsearch/apps.sls
+++ b/pillar/elastic_stack/elasticsearch/apps.sls
@@ -29,17 +29,21 @@ elastic_stack:
           enable: 'true'
           response_if_req_forbidden: Acess Denied
           access_control_rules:
+            - name: All APIs from localhost
+              type: allow
+              actions:
+                - 'cluster:*'
+                - 'indices:*'
+                - 'internal:*'
+              hosts_local:
+                - '127.0.0.1'
             - name: Cluster access within VPC
               type: allow
               actions:
                 - 'cluster:*'
               hosts:
-                - localhost
-                - 127.0.0.1
                 - {{ env_data.network_prefix }}.0.0/16
               x_forwarded_for:
-                - localhost
-                - 127.0.0.1
                 - {{ env_data.network_prefix }}.0.0/16
             - name: Access for micromasters production index with HTTP Auth
               type: allow


### PR DESCRIPTION
Fix "localhost" access to all of the Elasticsearch APIs on the Apps Elasticsearch clusters. We've installed a new version of ReadonlyRest, which seems to work better with this new `hosts_local` property that we haven't used before.