### PR TITLE
Add index cleanup cronjobs, apps Elasticsearch clusters

### DIFF
--- a/salt/elastic_stack/elasticsearch/apps/cronjobs.sls
+++ b/salt/elastic_stack/elasticsearch/apps/cronjobs.sls
@@ -10,8 +10,8 @@ manage_search_index_pruning_job:
     - hour: random
     - minute: random
     - name: >-
-       for index in `curl -s 'localhost:9200/_aliases' | jq 'to_entries | \
-       map(select(.value.aliases == {}) | .key) | .[]' | sed s'/"//g'`; \
+       for index in `curl -s 'localhost:9200/_aliases' | jq 'to_entries |
+       map(select(.value.aliases == {}) | .key) | .[]' | sed s'/"//g'`;
        do curl -X DELETE localhost:9200/$index; done > /var/tmp/prune-search-idx.log 2>&1
 
 {% if salt.grains.get('environment') == 'rc-apps' %}
@@ -23,6 +23,6 @@ manage_ci_index_pruning_job:
     - minute: random
     - day: 6
     - name: >-
-      for index in `curl -s localhost:9200/_cat/indices/*-ci* | awk '{print $3}'`; \
+      for index in `curl -s localhost:9200/_cat/indices/*-ci* | awk '{print $3}'`;
       do curl -X DELETE localhost:9200/$index; done > /var/tmp/prune-ci-idx.log 2>&1
 {% endif %}

--- a/salt/elastic_stack/elasticsearch/apps/cronjobs.sls
+++ b/salt/elastic_stack/elasticsearch/apps/cronjobs.sls
@@ -1,0 +1,28 @@
+
+ensure_installation_of_jq:
+  pkg.installed:
+    - name: jq
+
+manage_search_index_pruning_job:
+  cron.present:
+    - identifier: PRUNE_SEARCH_INDICES
+    - user: root
+    - hour: random
+    - minute: random
+    - name: >-
+       for index in `curl -s 'localhost:9200/_aliases' | jq 'to_entries | \
+       map(select(.value.aliases == {}) | .key) | .[]' | sed s'/"//g'`; \
+       do curl -X DELETE localhost:9200/$index; done > /var/tmp/prune-search-idx.log 2>&1
+
+{% if salt.grains.get('environment') == 'rc-apps' %}
+manage_ci_index_pruning_job:
+  cron.present:
+    - identifier: PRUNE_CI_INDICES
+    - user: root
+    - hour: 6
+    - minute: random
+    - day: 6
+    - name: >-
+      for index in `curl -s localhost:9200/_cat/indices/*-ci* | awk '{print $3}'`; \
+      do curl -X DELETE localhost:9200/$index; done > /var/tmp/prune-ci-idx.log 2>&1
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -167,6 +167,7 @@ base:
     - match: compound
     - elastic-stack.elasticsearch
     - elastic-stack.elasticsearch.plugins
+    - elastic-stack.elasticsearch.apps.cronjobs
     - nginx
   'G@roles:elasticsearch and P@environment:mitx(pro)?-(qa|production)':
     - match: compound


### PR DESCRIPTION
Add index cleanup jobs to the Elasticsearch apps clusters, to keep shard counts from creeping up. The jobs remove stale indices that have no aliases, and remove temporary indices that are created by CI jobs. When search data are reindexed, new indices are created and aliases are repointed at the new indices, so any indices without aliases are due for removal.

The `jq` command in the `PRUNE_SEARCH_INDICES` job works on data from the `/_aliases/` Elasticsearch API endpiont, which produces JSON looking like this:
```
{
  "discussions-rc_bootcamp_ded060bcf4b74bc8916d58b0e95734d4": {
    "aliases": {
      "discussions-rc_all_default": {},
      "discussions-rc_bootcamp_default": {}
    }
  },
[ ... etc ...]
```
When the index has no aliases, `aliases` is an empty object.

The job for CI indices relies on the fact that no live search indices in RC or production ever contain the string "-ci".

The random execution times are a hack to make this easy to set up on the elasticsearch nodes themselves,  without having to spin up or appropriate any other server for this purpose.

See: https://trello.com/c/ebh8qF0R/177-automate-pruning-of-production-apps-indices