### PR TITLE
Removed sentry dsn from salt-master

### DIFF
--- a/pillar/master/config.sls
+++ b/pillar/master/config.sls
@@ -68,12 +68,6 @@ salt_master:
         host: fluentd.service.consul
         port: 9999
         version: 1
-      sentry_handler:
-        dsn: __vault__::secret-operations/global/saltstack-sentry-dsn>data>value
-        context:
-          - id
-          - environment
-          - saltversion
     reactors:
       reactor:
         - salt/beacon/*/inotify/*:


### PR DESCRIPTION
#### What's this PR do?
Removed sentry config from salt-master as at times salt errors are causing a spike in sentry events thus depleting our subscription plan. 
