### PR TITLE
Set USE_X_FORWARDED_HOST to True for all xPRO environments

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -35,7 +35,6 @@
       'SHEETS_REFUND_ERROR_COL': 13,
       'SHEETS_REFUND_SKIP_ROW_COL': 14,
       'vault_env_path': 'rc-apps',
-      'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 1
       },
     'rc': {
@@ -71,7 +70,6 @@
       'SHEETS_REFUND_COMPLETED_DATE_COL': 13,
       'SHEETS_REFUND_ERROR_COL': 14,
       'SHEETS_REFUND_SKIP_ROW_COL': 15,
-      'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 1
       },
     'production': {
@@ -107,7 +105,6 @@
       'SHEETS_REFUND_ERROR_COL': 14,
       'SHEETS_REFUND_SKIP_ROW_COL': 15,
       'vault_env_path': 'production-apps',
-      'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 4
       }
 } %}
@@ -225,7 +222,7 @@ heroku:
     SHOW_UNREDEEMED_COUPON_ON_DASHBOARD: True
     SITE_NAME: "MIT xPRO"
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
-    USE_X_FORWARDED_HOST: {{ env_data.USE_X_FORWARDED_HOST }}
+    USE_X_FORWARDED_HOST: True
     VOUCHER_COMPANY_ID: {{ env_data.VOUCHER_COMPANY_ID }}
     VOUCHER_DOMESTIC_AMOUNT_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/voucher-domestic>data>amount_key
     VOUCHER_DOMESTIC_COURSE_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/voucher-domestic>data>course_key

--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -35,7 +35,7 @@
       'SHEETS_REFUND_ERROR_COL': 13,
       'SHEETS_REFUND_SKIP_ROW_COL': 14,
       'vault_env_path': 'rc-apps',
-      'USE_X_FORWARDED_HOST': False,
+      'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 1
       },
     'rc': {
@@ -71,7 +71,7 @@
       'SHEETS_REFUND_COMPLETED_DATE_COL': 13,
       'SHEETS_REFUND_ERROR_COL': 14,
       'SHEETS_REFUND_SKIP_ROW_COL': 15,
-      'USE_X_FORWARDED_HOST': False,
+      'USE_X_FORWARDED_HOST': True,
       'VOUCHER_COMPANY_ID': 1
       },
     'production': {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Sets `USE_X_FORWARDED_HOST` to True for CI and RC environments for xPRO. The code for creating the Cybersource redirect URL uses the `Host` header which meant the redirect URL had a different domain, causing the user to need to login again on purchase (on RC). We need to set `USE_X_FORWARDED_HOST` so that the `X_FORWARDED_HOST` header is used instead, which contains the correct host value.

#### How should this be manually tested?
- Login to rc.xpro.mit.edu
- Go to https://rc.xpro.mit.edu/checkout/?product=90 and make a purchase. Use the fake Cybersource credit card information
- You should be redirected to a URL starting with `rc.xpro.mit.edu`. 
