### PR TITLE
ES7 for mitx-qa

### DIFF
--- a/pillar/elastic_stack/elasticsearch/mitx.sls
+++ b/pillar/elastic_stack/elasticsearch/mitx.sls
@@ -1,0 +1,19 @@
+elastic_stack:
+  version: 7.12.0
+  elasticsearch:
+    configuration_settings:
+      discovery:
+        zen.hosts_provider: ec2
+      discovery.zen.minimum_master_nodes: 2
+      gateway.recover_after_nodes: 2
+      gateway.expected_nodes: 3
+      gateway.recover_after_time: 5m
+      rest.action.multi.allow_explicit_index: false
+      xpack.security.enabled: false
+      xpack.monitoring.collection.enabled: false
+      xpack.ml.enabled: false
+    plugins:
+      - name: discovery-ec2
+        config:
+          aws:
+            region: us-east-1

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -206,9 +206,16 @@ base:
     - nginx
     - nginx.apps_es
     - datadog.nginx-integration
-  'G@roles:elasticsearch and P@environment:mitx(pro)?-(qa|production)':
+  'G@roles:elasticsearch and P@environment:mitx(pro)?-production':
     - match: compound
     - elasticsearch.mitx
+  'G@roles:elasticsearch and P@environment:mitxpro-qa':
+    - match: compound
+    - elasticsearch.mitx
+  'G@roles:elasticsearch and P@environment:mitx-qa':
+    - match: compound
+    - elastic_stack.elasticsearch
+    - elastic_stack.elasticsearch.mitx
   'G@roles:elasticsearch and G@environment:operations':
     - match: compound
     - elastic_stack.elasticsearch.logging_production

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -169,7 +169,15 @@ base:
     - elastic-stack.elasticsearch.plugins
     - elastic_stack.elasticsearch.apps.cronjobs
     - nginx
-  'G@roles:elasticsearch and P@environment:mitx(pro)?-(qa|production)':
+  'G@roles:elasticsearch and P@environment:mitx-qa':
+    - match: compound
+    - elastic-stack.elasticsearch
+    - elastic-stack.elasticsearch.plugins
+  'G@roles:elasticsearch and P@environment:mitxpro-qa':
+    - match: compound
+    - elasticsearch
+    - elasticsearch.plugins
+  'G@roles:elasticsearch and P@environment:mitx(pro)?-production':
     - match: compound
     - elasticsearch
     - elasticsearch.plugins


### PR DESCRIPTION
#### What's this PR do?
Changes related to getting an ES7 cluster deployed for use with mitx-qa