### PR TITLE
Workaround for ES 7 clustering

### DIFF
--- a/pillar/elastic_stack/elasticsearch/mitx.sls
+++ b/pillar/elastic_stack/elasticsearch/mitx.sls
@@ -1,11 +1,19 @@
+{% set minion_id = salt.grains.get('id', '') %}
+
 elastic_stack:
   version: 7.12.0
   elasticsearch:
     configuration_settings:
       cloud.node.auto_attributes: true
+      # This is necessary based on this discussion
+      # https://discuss.elastic.co/t/discovery-with-ecs-dynamic-initial-master-nodes/183149/9
+      {% if '0' in minion_id %}
+      cluster.initial_master_nodes:
+        - {{ minion_id }}
+      node.name: {{ minion_id }}
+      {% endif %}
       cluster.routing.allocation.awareness.attributes: aws_availability_zone
       discovery.seed_providers: ec2
-      discovery.zen.minimum_master_nodes: 2
       gateway.expected_nodes: 3
       gateway.recover_after_nodes: 2
       gateway.recover_after_time: 5m


### PR DESCRIPTION
#### What's this PR do?
This is a very basic/simple workaround needed to get ES 7 clustering bootstrapped based on [this discussion](https://discuss.elastic.co/t/discovery-with-ecs-dynamic-initial-master-nodes/183149/9)

Tested this manually on ES QA cluster and resolved clustering issue