### PR TITLE
export COURSE_BASE_URL and put exports with the others

### DIFF
--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -37,6 +37,9 @@ retry_file=/tmp/webhook-publish-retry
 # processes we execute
 export OCW_STUDIO_BASE_URL
 export GTM_ACCOUNT_ID
+export OCW_TO_HUGO_OUTPUT_DIR=$COURSES_MARKDOWN_DIR
+export COURSE_OUTPUT_DIR=$SITE_OUTPUT_DIR/courses
+export COURSE_BASE_URL=$COURSE_BASE_URL
 
 # Optional script argument
 script_option=$1
@@ -171,8 +174,6 @@ fi
 
 # Run course builds with ocw-hugo-themes
 echo "Running hugo on courses in $COURSES_MARKDOWN_DIR..."
-export OCW_TO_HUGO_OUTPUT_DIR=$COURSES_MARKDOWN_DIR
-export COURSE_OUTPUT_DIR=$SITE_OUTPUT_DIR/courses
 cd /opt/ocw/ocw-hugo-themes
 ./build_scripts/build_all_courses.sh >> $LOG_DIR/course-builds.log 2>&1
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This PR adds an extra `export` line to export `COURSE_BASE_URL` so that `build_all_courses.sh` in the OCW webook publish script can read this variable.  It also organizes all the exports together.

#### How should this be manually tested?
I'm not sure it can be, needs to be released and tested on RC.
