### PR TITLE
Apply forum host to only edx-workers

### DIFF
--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -23,7 +23,11 @@ edx:
     EDXAPP_EDX_API_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/edx-api-key>data>value
     EDXAPP_SESSION_COOKIE_DOMAIN: .xpro.mit.edu
     EDXAPP_SESSION_COOKIE_NAME: {{ environment }}-{{ purpose }}-session
+    {% if 'worker' in grains.get(roles) %}
     EDXAPP_COMMENTS_SERVICE_URL: "http://forum-{{ purpose }}.service.consul:4567"
+    {% else %}
+    EDXAPP_COMMENTS_SERVICE_URL: "http://localhost:4567"
+    {% endif %}
     EDXAPP_COMMENTS_SERVICE_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/global/forum-api-key>data>value
     EDXAPP_IDA_LOGOUT_URI_LIST: ['{{ heroku_env }}/logout']
     # Enable Secure flag on cookies for browser SameSite restrictions


### PR DESCRIPTION
#### What's this PR do?
Users and [sentry](https://sentry.io/organizations/mit-office-of-digital-learning/issues/2380952651/?project=1730882&referrer=slack) have reported issues reaching discussions. We believe the recent change of adding a forum consul check to make the edx-username-change work is causing this issue. This PR make the edx-worker instances use the forum consul hostname and the edxapp instance continue to use localhost.

