### PR TITLE
Removed iam role creation

### DIFF
--- a/salt/orchestrate/apps/deploy.sls
+++ b/salt/orchestrate/apps/deploy.sls
@@ -50,10 +50,6 @@ generate_{{ app_name }}_cloud_map_file:
     - require:
         - file: load_{{ app_name }}_cloud_profile
 
-ensure_instance_profile_exists_for_{{ app_name }}:
-  boto_iam_role.present:
-    - name: {{ app_name }}-instance-role
-
 deploy_{{ app_name }}_cloud_map:
   salt.runner:
     - name: cloud.map_run

--- a/salt/orchestrate/edx/build_ami.sls
+++ b/salt/orchestrate/edx/build_ami.sls
@@ -114,10 +114,6 @@ create_edx_worker_baseline_instance_in_{{ ENVIRONMENT }}:
     - require:
         - file: load_edx_base_cloud_profile
 
-ensure_instance_profile_exists_for_edx:
-  boto_iam_role.present:
-    - name: edx-instance-role
-
 load_pillar_data_on_edx_base_nodes:
   salt.function:
     - name: saltutil.refresh_pillar

--- a/salt/orchestrate/edx/deploy.sls
+++ b/salt/orchestrate/edx/deploy.sls
@@ -81,26 +81,6 @@ ensure_tracking_bucket_exists:
     - Bucket: {{ edx_tracking_bucket }}
     - region: us-east-1
 
-# ensure_instance_profile_exists_for_tracking:
-#   boto_iam_role.present:
-#     - name: edx-{{ ENVIRONMENT }}-instance-role
-#     - delete_policies: False
-#     - policies:
-#         edx-old-tracking-logs-policy:
-#           Statement:
-#             - Action:
-#                 - s3:GetObject
-#                 - s3:ListAllMyBuckets
-#                 - s3:ListBucket
-#                 - s3:ListObjects
-#                 - s3:PutObject
-#               Effect: Allow
-#               Resource:
-#                 - arn:aws:s3:::{{ edx_tracking_bucket }}
-#                 - arn:aws:s3:::{{ edx_tracking_bucket }}/*
-#     - require:
-#         - boto_s3_bucket: ensure_tracking_bucket_exists
-
 deploy_edx_cloud_map:
   salt.function:
     - tgt: 'roles:master'


### PR DESCRIPTION
#### What's this PR do?
When running orchestrate states, salt is messing with the existing roles managed by Pulumi now. This should address that issue.