### PR TITLE
Updated values for honor_code to hidden for xPRO and residential

### DIFF
--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -112,7 +112,7 @@ edx:
       year_of_birth: "optional"
       mailing_address: "hidden"
       goals: "optional"
-      honor_code: "required"
+      honor_code: "hidden"
       terms_of_service: "hidden"
       city: "hidden"
       country: "hidden"

--- a/pillar/edx/ansible_vars/xpro.sls
+++ b/pillar/edx/ansible_vars/xpro.sls
@@ -65,7 +65,7 @@ edx:
       year_of_birth: "optional"
       mailing_address: "hidden"
       goals: "optional"
-      honor_code: "required"
+      honor_code: "hidden"
       terms_of_service: "hidden"
       city: "hidden"
       country: "hidden"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/1421

#### What's this PR do?
Sets `honor_code` var to `hidden` for xPRO and residential. Related to https://github.com/mitodl/edx-sysadmin/issues/40

#### How should this be manually tested?
Confirm that Honor Code value is no longer required when creating a new user in the sysadmin dashboard
