### PR TITLE
Pointed mitx-production to new mongodb and ES

### DIFF
--- a/pillar/mongodb/init.sls
+++ b/pillar/mongodb/init.sls
@@ -12,13 +12,16 @@
 
 mongodb:
   overrides:
-    version: '3.6'
+    version: '4.4'
     config:
       net:
         bindIp: '0.0.0.0,::'
         unixDomainSocket:
           enabled: False
         ipv6: True
+    systemd_overrides:
+      Service:
+        PIDFile: '/run/mongodb/mongod.pid'
   admin_username: admin
   admin_password: __vault__::secret-{{ business_unit }}/{{ environment }}/mongodb-admin-password>data>value
   replset_name: rs0

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -211,13 +211,13 @@ base:
     - nginx
     - nginx.apps_es
     - datadog.nginx-integration
-  'G@roles:elasticsearch and P@environment:mitx(pro)?-production':
+  'G@roles:elasticsearch and P@environment:mitxpro-production':
     - match: compound
     - elasticsearch.mitx
   'G@roles:elasticsearch and P@environment:mitxpro-qa':
     - match: compound
     - elasticsearch.mitx
-  'G@roles:elasticsearch and P@environment:(mitx-qa|mitxonline-qa|mitxonline-production)':
+  'G@roles:elasticsearch and P@environment:(mitx-qa|mitxonline-qa|mitxonline-production|mitx-production)':
     - match: compound
     - elastic_stack.elasticsearch
     - elastic_stack.elasticsearch.mitx

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -168,7 +168,7 @@ base:
     - elastic-stack.elasticsearch.plugins
     - elastic_stack.elasticsearch.apps.cronjobs
     - nginx
-  'G@roles:elasticsearch and P@environment:(mitx-qa|mitxonline-qa|mitxonline-production)':
+  'G@roles:elasticsearch and P@environment:(mitx-qa|mitxonline-qa|mitxonline-production|mitx-production)':
     - match: compound
     - elastic-stack.elasticsearch
     - elastic-stack.elasticsearch.plugins
@@ -176,7 +176,7 @@ base:
     - match: compound
     - elasticsearch
     - elasticsearch.plugins
-  'G@roles:elasticsearch and P@environment:mitx(pro)?-production':
+  'G@roles:elasticsearch and P@environment:mitxpro-production':
     - match: compound
     - elasticsearch
     - elasticsearch.plugins


### PR DESCRIPTION
#### What's this PR do?
Work related to residential production upgrade. This mainly allows us to deploy new versions of the mongodb and ES7 clusters.