### PR TITLE
Removed datadog.http-check-integration as it's no longer used

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -193,7 +193,6 @@ base:
   'G@roles:consul_server and P@environment:mitx(pro|-online)?-production':
     - match: compound
     - datadog.mysql-integration
-    - datadog.http-check-integration
   'P@roles:(vault_server|master)':
     - match: compound
     - vault


### PR DESCRIPTION
#### What's this PR do?
Removes the `datadog.http-check-integration` as it's no longer and we have already deleted the file however we didn't remove it from the top pillar file.