### PR TITLE
fix: setting name is COURSE_INVITE_ONLY

### DIFF
--- a/pillar/edx/ansible_vars/cloud_deployment.sls
+++ b/pillar/edx/ansible_vars/cloud_deployment.sls
@@ -61,7 +61,7 @@
   {% set edxapp_git_repo_dir = '/mnt/data/prod_repos' %}
   {% set edxapp_course_about_visibility_permission = 'see_exists' %}
   {% set edxapp_course_catalog_visibility_permission = 'see_exists' %}
-  {% set edxapp_course_default_invite_only = False %}
+  {% set edxapp_course_invite_only = False %}
   {% set edxapp_aws_grades_root_path = 'rp-prod/grades' %}
   {% set edxapp_upload_storage_prefix = 'submissions_attachments_prod' %}
   {% set edxapp_log_env_suffix = 'prod' %}
@@ -69,7 +69,7 @@
   {% set edxapp_git_repo_dir = '/mnt/data/repos' %}
   {% set edxapp_course_about_visibility_permission = 'staff' %}
   {% set edxapp_course_catalog_visibility_permission = 'staff' %}
-  {% set edxapp_course_default_invite_only = True %}
+  {% set edxapp_course_invite_only = True %}
   {% set edxapp_aws_grades_root_path =  'rp-dev/grades' %}
   {% set edxapp_upload_storage_prefix = 'submissions_attachments_dev' %}
   {% set edxapp_log_env_suffix = 'dev' %}
@@ -77,7 +77,7 @@
   {% set edxapp_git_repo_dir = '/mnt/data/repos' %}
   {% set edxapp_course_about_visibility_permission = 'see_exists' %}
   {% set edxapp_course_catalog_visibility_permission = 'see_exists' %}
-  {% set edxapp_course_default_invite_only = False %}
+  {% set edxapp_course_invite_only = False %}
   {% set edxapp_aws_grades_root_path =  'grades' %}
   {% set edxapp_upload_storage_prefix = 'submissions_attachments' %}
   {% set edxapp_log_env_suffix = 'prod' %}

--- a/pillar/edx/ansible_vars/residential.sls
+++ b/pillar/edx/ansible_vars/residential.sls
@@ -9,7 +9,7 @@
   {% set edxapp_git_repo_dir = '/mnt/data/prod_repos' %}
   {% set edxapp_course_about_visibility_permission = 'see_exists' %}
   {% set edxapp_course_catalog_visibility_permission = 'see_exists' %}
-  {% set edxapp_course_default_invite_only = False %}
+  {% set edxapp_course_invite_only = False %}
   {% set edxapp_aws_grades_root_path = 'rp-prod/grades' %}
   {% set edxapp_upload_storage_prefix = 'submissions_attachments_prod' %}
   {% set edxapp_log_env_suffix = 'prod' %}
@@ -17,7 +17,7 @@
   {% set edxapp_git_repo_dir = '/mnt/data/repos' %}
   {% set edxapp_course_about_visibility_permission = 'staff' %}
   {% set edxapp_course_catalog_visibility_permission = 'staff' %}
-  {% set edxapp_course_default_invite_only = True %}
+  {% set edxapp_course_invite_only = True %}
   {% set edxapp_aws_grades_root_path =  'rp-dev/grades' %}
   {% set edxapp_upload_storage_prefix = 'submissions_attachments_dev' %}
   {% set edxapp_log_env_suffix = 'dev' %}


### PR DESCRIPTION
not COURSE_DEFAULT_INVITE_ONLY

#### What are the relevant tickets?

fixes https://github.mit.edu/mitx/Summer-2021/issues/22

#### What's this PR do?

Any course that hasn't been set will default to being invite-only

#### How should this be manually tested?

1. Set the flag
2. Create a course
3. Login as a different user and navigate to /courses/[course-key]/course and click the enroll button

