### PR TITLE
Removed digital credential run from production

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -86,7 +86,7 @@
       'CSRF_TRUSTED_ORIGINS': 'xpro.mit.edu,xpro-web.odl.mit.edu',
       'CYBERSOURCE_SECURE_ACCEPTANCE_URL': 'https://secureacceptance.cybersource.com/pay',
       'CYBERSOURCE_WSDL_URL': 'https://ics2wsa.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl',
-      'DIGITAL_CREDENTIALS_SUPPORTED_RUNS': 'course-v1:xPRO+BioEngx+R6',
+      'DIGITAL_CREDENTIALS_SUPPORTED_RUNS': '',
       'HUBSPOT_CREATE_USER_FORM_ID': '9ada5d38-33ee-415c-8cb2-9d72e735b1d5',
       'HUBSPOT_FOOTER_FORM_GUID': '6f7e46ec-f757-43a4-b109-597210df0f75',
       'HUBSPOT_ID_PREFIX': 'xpro',


### PR DESCRIPTION
#### What's this PR do?
Given that we the timeline for digital credentials has been delayed, removed the run that was set to support digital credentials. We will add a run back once things are ready.

#### What GIF best describes this PR or how it makes you feel?
![thumb_when-you-are-on-time-rvc-j-www-rvcj-com-but-14452433](https://user-images.githubusercontent.com/21342568/124019571-36689c00-d9b7-11eb-96cb-871d3f19e418.png)

