### PR TITLE
Remove ocw-to-hugo-hash.txt

### DIFF
--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -190,8 +190,6 @@ log_message "Writing commit hash files"
 
 cd /opt/ocw/ocw-www \
 && git rev-parse HEAD > $SITE_OUTPUT_DIR/static/ocw-www-hash.txt \
-&& cd /opt/ocw/ocw-to-hugo \
-&& git rev-parse HEAD > $SITE_OUTPUT_DIR/static/ocw-to-hugo-hash.txt \
 && cd /opt/ocw/ocw-hugo-themes \
 && git rev-parse HEAD > $SITE_OUTPUT_DIR/static/ocw-hugo-themes-hash.txt
 


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
We are writing out three hash files, including `ocw-to-hugo-hash.txt`, which communicate the git hash of the deployed code. We used to use the latest `ocw-to-hugo` from the main branch of that repository. However we switched to `ocw-to-hugo` which is referenced and installed as a package in `ocw-hugo-themes`. The `ocw-to-hugo-hash.txt` file now serves no purpose.

