### PR TITLE
update MITXONLINE_BASE_URL to use rc.mitxonline domain

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -16,7 +16,7 @@
       'openedx_environment': 'mitxonline-qa',
       'MAILGUN_FROM_EMAIL': 'MITx Online <no-reply@mitxonline-rc-mail.mitxonline.mit.edu>',
       'MAILGUN_SENDER_DOMAIN': 'mitxonline-rc-mail.mitxonline.mit.edu',
-      'MITXONLINE_BASE_URL': 'https://mitxonline-rc.mitxonline.mit.edu',
+      'MITXONLINE_BASE_URL': 'https://rc.mitxonline.mit.edu',
       'MITXONLINE_SECURE_SSL_HOST': 'mitxonline-rc.mitxonline.mit.edu',
       },
     'production': {


### PR DESCRIPTION
#### What are the relevant tickets?
(Partially related) https://github.com/mitodl/mitxonline/issues/102

#### What's this PR do?
Updates `MITXONLINE_BASE_URL` to use https://rc.mitxonline.mit.edu instead of https://mitxonline-rc.mitxonline.mit.edu since the app on https://rc.mitxonline.mit.edu was sending the wrong `MITXONLINE_BASE_URL` to a redirect_url param in LMS logout call.


#### Any background context you want to provide?
You can have a look at the details on why we needed to do this (https://github.com/mitodl/mitxonline/issues/102#issuecomment-904705295)[here].
