### PR TITLE
add OCW_IMPORT_STARTER_SLUG to the webhook-publish build script

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -10,6 +10,7 @@ ocw-next:
   fastly_service_id: __vault__::secret-open-courseware/production-apps/fastly-api>data>service_id
   course_base_url: https://ocwnext.odl.mit.edu/courses
   ocw_studio_base_url: https://ocw-studio.odl.mit.edu/
+  ocw_import_starter_slug: ocw-course
   gtm_account_id: GTM-NMQZ25T
   mailchimp_audience_id: e07062bda1v
   mailchmip_user_id: ad81d725159c1f322a0c54837

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -10,6 +10,7 @@ ocw-next:
   fastly_service_id: __vault__::secret-open-courseware/rc-apps/fastly-api>data>service_id
   course_base_url: https://ocwnext-rc.odl.mit.edu/courses
   ocw_studio_base_url: https://ocw-studio-rc.odl.mit.edu/
+  ocw_import_starter_slug: ocw-course
   gtm_account_id: GTM-PJMJGF6
 
 node:

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -26,6 +26,7 @@ OCW_WWW_GIT_REF={{ ocw_www_git_ref }}
 OCW_HUGO_THEMES_GIT_REF={{ ocw_hugo_themes_git_ref }}
 COURSE_BASE_URL={{ course_base_url }}
 OCW_STUDIO_BASE_URL={{ ocw_studio_base_url }}
+OCW_IMPORT_STARTER_SLUG ={{ ocw_import_starter_slug }}
 GTM_ACCOUNT_ID={{ gtm_account_id }}
 # lock_dir ensures that only one run of this script happens at once.
 lock_dir=/tmp/webhook-publish-lock
@@ -40,6 +41,7 @@ export GTM_ACCOUNT_ID
 export OCW_TO_HUGO_OUTPUT_DIR=$COURSES_MARKDOWN_DIR
 export COURSE_OUTPUT_DIR=$SITE_OUTPUT_DIR/courses
 export COURSE_BASE_URL=$COURSE_BASE_URL
+export OCW_IMPORT_STARTER_SLUG=$OCW_IMPORT_STARTER_SLUG
 
 # Optional script argument
 script_option=$1

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -26,7 +26,7 @@ OCW_WWW_GIT_REF={{ ocw_www_git_ref }}
 OCW_HUGO_THEMES_GIT_REF={{ ocw_hugo_themes_git_ref }}
 COURSE_BASE_URL={{ course_base_url }}
 OCW_STUDIO_BASE_URL={{ ocw_studio_base_url }}
-OCW_IMPORT_STARTER_SLUG ={{ ocw_import_starter_slug }}
+OCW_IMPORT_STARTER_SLUG={{ ocw_import_starter_slug }}
 GTM_ACCOUNT_ID={{ gtm_account_id }}
 # lock_dir ensures that only one run of this script happens at once.
 lock_dir=/tmp/webhook-publish-lock


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/1455

#### What's this PR do?
This PR sets the `OCW_IMPORT_STARTER_SLUG` env variable in the `webhook-publish.sh.jinja` build script in order for Hugo to be able to generate API request links to `ocw-studio` to fetch new courses by the starter name they are imported with.

#### How should this be manually tested?
N/A