### PR TITLE
OCW STATIC_API_BASE_URL

### DIFF
--- a/pillar/apps/ocw-next-production.sls
+++ b/pillar/apps/ocw-next-production.sls
@@ -11,6 +11,7 @@ ocw-next:
   course_base_url: https://ocwnext.odl.mit.edu/courses
   ocw_studio_base_url: https://ocw-studio.odl.mit.edu/
   ocw_import_starter_slug: ocw-course
+  static_api_base_url: https://ocw-live-production.global.ssl.fastly.net/
   gtm_account_id: GTM-NMQZ25T
   mailchimp_audience_id: e07062bda1v
   mailchmip_user_id: ad81d725159c1f322a0c54837

--- a/pillar/apps/ocw-next-qa.sls
+++ b/pillar/apps/ocw-next-qa.sls
@@ -11,6 +11,7 @@ ocw-next:
   course_base_url: https://ocwnext-rc.odl.mit.edu/courses
   ocw_studio_base_url: https://ocw-studio-rc.odl.mit.edu/
   ocw_import_starter_slug: ocw-course
+  static_api_base_url: https://ocw-live-qa.global.ssl.fastly.net/
   gtm_account_id: GTM-PJMJGF6
 
 node:

--- a/salt/apps/ocw/nextgen_build_install.sls
+++ b/salt/apps/ocw/nextgen_build_install.sls
@@ -118,3 +118,4 @@ install_caddy_webhook_script:
         ocw_studio_base_url: {{ ocw_next.ocw_studio_base_url }}
         gtm_account_id: {{ ocw_next.gtm_account_id }}
         ocw_import_starter_slug: {{ ocw_next.ocw_import_starter_slug }}
+        static_api_base_url: {{ ocw_next.static_api_base_url }}

--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -27,6 +27,7 @@ OCW_HUGO_THEMES_GIT_REF={{ ocw_hugo_themes_git_ref }}
 COURSE_BASE_URL={{ course_base_url }}
 OCW_STUDIO_BASE_URL={{ ocw_studio_base_url }}
 OCW_IMPORT_STARTER_SLUG={{ ocw_import_starter_slug }}
+STATIC_API_BASE_URL={{ static_api_base_url }}
 GTM_ACCOUNT_ID={{ gtm_account_id }}
 # lock_dir ensures that only one run of this script happens at once.
 lock_dir=/tmp/webhook-publish-lock
@@ -42,6 +43,7 @@ export OCW_TO_HUGO_OUTPUT_DIR=$COURSES_MARKDOWN_DIR
 export COURSE_OUTPUT_DIR=$SITE_OUTPUT_DIR/courses
 export COURSE_BASE_URL=$COURSE_BASE_URL
 export OCW_IMPORT_STARTER_SLUG=$OCW_IMPORT_STARTER_SLUG
+export STATIC_API_BASE_URL=$STATIC_API_BASE_URL
 
 # Optional script argument
 script_option=$1


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/1465

#### What's this PR do?
This PR adds the `OCW_STATIC_API_BASE_URL` env variable to the OCW Next build servers, pointing at the QA and production instances of the `ocw-www` site deployed by Concourse.

#### How should this be manually tested?
N/A

