### PR TITLE
Added EMAIL_SUPPORT env value for mitxonline production

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -54,6 +54,7 @@ heroku:
     {% set rds_endpoint = salt.boto_rds.get_endpoint('mitxonline-production-app-db') %}
     {% set pg_creds = salt.vault.cached_read('postgres-mitxonline/creds/app', cache_prefix='heroku-mitxonline') %}
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/mitxonline
+    EMAIL_SUPPORT: 'mitxonline-support@mit.edu'
     HIREFIRE_TOKEN: __vault__::secret-{{ business_unit }}/production-apps/hirefire_token>data>value
     {% endif %}
     FEATURE_SYNC_ON_DASHBOARD_LOAD: True


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/241

#### What's this PR do?
Adds the correct env value for the `EMAIL_SUPPORT` setting in mitxonline production 

#### Any background context you want to provide?
There isn't a CI/RC email address that I know of, hence the production-only setting