### PR TITLE
remove ocw-to-hugo output s3 upload

### DIFF
--- a/salt/apps/ocw/templates/webhook-publish.sh.jinja
+++ b/salt/apps/ocw/templates/webhook-publish.sh.jinja
@@ -240,15 +240,6 @@ if [ $? -ne 0 ]; then
     log_message "WARNING: Failed to clear Fastly cache!"
 fi
 
-# Sync ocw-to-hugo output to S3
-
-log_message "Syncing ocw-to-hugo output to S3"
-aws s3 sync $COURSE_CONTENT_PATH/ s3://$OCW_TO_HUGO_BUCKET/ \
-    --delete --only-show-errors >> $LOG_DIR/ocw-to-hugo-output-sync.log 2>&1
-if [ $? -ne 0 ]; then
-    error_and_exit "Failed to sync to S3 bucket. See $LOG_DIR/ocw-to-hugo-output-sync.log"
-fi
-
 
 log_message "Done"
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/1482

#### What's this PR do?
This PR removes the step from OCW's `webhook-publish.sh.jinja` that uploads the `ocw-to-hugo` output to S3.  This task is being moved into its own Concourse pipeline so it can be run on a regular basis and be configured specfically for import into `ocw-studio`, rather than having to make its output compatible with both the EC2 server's deployment strategy and that.

#### How should this be manually tested?
N/A
