### PR TITLE
Adding mapping of Consul datacenter names to Pulumi

### DIFF
--- a/pillar/consul/apps.sls
+++ b/pillar/consul/apps.sls
@@ -2,6 +2,13 @@
 {% set ENVIRONMENT = salt.grains.get('environment') %}
 {% set env_settings = salt.cp.get_url("https://raw.githubusercontent.com/mitodl/salt-ops/main/salt/environment_settings.yml", dest=None)|load_yaml %}
 {% set env_data = env_settings.environments[ENVIRONMENT] %}
+{% set datacenter = "apps-ci" %}
+{% if ENVIRONMENT == "rc-apps" %}
+{% set datacenter = "apps-qa" %}
+{% endif %}
+{% if ENVIRONMENT = "production-apps"}
+{% set datacenter = "apps-production" %}
+{% endif %}
 
 consul:
   extra_configs:
@@ -9,3 +16,4 @@ consul:
       recursors:
         - {{ env_settings.environments[ENVIRONMENT].network_prefix }}.0.2
         - 8.8.8.8
+      datacenter: {{ datacenter }}

--- a/pillar/consul/xpro.sls
+++ b/pillar/consul/xpro.sls
@@ -1,0 +1,7 @@
+{% set ENVIRONMENT = salt.grains.get('environment') %}
+{% set datacenter = ENVIRONMENT.replace("mitxpro", "xpro") %}
+
+consul:
+  extra_configs:
+    defaults:
+      datacenter: {{ datacenter }}

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -166,6 +166,12 @@ base:
     - match: compound
     - datadog
     - consul
+  'P@environment:.*apps.*':
+    - match: compound
+    - consul.apps
+  'P@environment:.*mitxpro.*':
+    - match: compound
+    - consul.xpro
   'P@environment:mitx(pro|-online)?-(qa|production)':
     - match: compound
     - consul.mitx


### PR DESCRIPTION
As we are migrating things to Pulumi one of the points of mismatch is the datacenter name that we want to use between Salt and Pulumi. Specifically we run into this for xpro and apps environments. This adds specific overrides to allow existing infrastructure to continue working properly as we progress through the migration.