### PR TITLE
Updated xqueue-watcher configs to map to live/staging split

### DIFF
--- a/pillar/edx/xqwatcher_600.sls
+++ b/pillar/edx/xqwatcher_600.sls
@@ -3,6 +3,13 @@
 {% set env_data = env_settings.environments[environment] %}
 {% set xqwatcher_venv_base = '/edx/app/xqwatcher/venvs' %}
 {% set python3_version = 'python3.8' %}
+{% set env_map = {
+  "mitx": "production",
+  "mitx-staging": "master"
+} %}
+
+{% set watcher_git_ref = env_map[environment.rsplit("-", 1)[0]] %}
+{% set env_prefix = environment.rsplit("-", 1)[-1] %}
 
 edx:
   xqwatcher:
@@ -10,12 +17,10 @@ edx:
       - numpy
   ansible_vars:
    XQWATCHER_COURSES:
-    {% for purpose, purpose_data in env_data.purposes.items() %}
-    {% if 'residential' in purpose %}
     {% for queue_name in ['Watcher-MITx-6.0001r', 'Watcher-MITx-6.00x'] %}
-    - COURSE: "mit-600x-{{ purpose }}-{{ queue_name }}"
+    - COURSE: "mit-600x-{{ queue_name }}"
       GIT_REPO: git@github.com:mitodl/graders-mit-600x
-      GIT_REF: {{ purpose_data.versions.xqwatcher_courses }}
+      GIT_REF: {{ watcher_git_ref }}
       PYTHON_REQUIREMENTS:
         - name: numpy
           version: 1.19.4
@@ -27,8 +32,8 @@ edx:
       QUEUE_NAME: {{ queue_name }}
       QUEUE_CONFIG:
         AUTH:
-          - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>username
-          - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>password
+          - xqwatcher
+          - __vault__::secret-{{ env_prefix }}/edx-xqueue>data>xqwatcher_password
         SERVER: http://xqueue.service.consul:18040
         CONNECTIONS: 5
         HANDLERS:
@@ -39,23 +44,17 @@ edx:
               lang: python3
               bin_path: "{{ xqwatcher_venv_base }}/mit-600x/bin/python"
             KWARGS:
-              grader_root: ../data/mit-600x-{{ purpose }}-{{ queue_name }}/graders/python3graders/
-    {% endfor %}
-    {% endif %}
+              grader_root: ../data/mit-600x-{{ queue_name }}/graders/python3graders/
     {% endfor %}
 
 
 schedule:
-  {% for purpose, purpose_data in env_data.purposes.items() %}
-  {% if purpose_data.business_unit == 'residential' %}
   {% for queue_name in ['Watcher-MITx-6.0001r', 'Watcher-MITx-6.00x'] %}
-  update_live_grader_for_{{ purpose }}_with_{{ queue_name }}_queue:
+  update_live_grader_for_{{ queue_name }}_queue:
     function: git.pull
     minutes: 5
     args:
-      - /edx/app/xqwatcher/data/mit-600x-{{ purpose }}-{{ queue_name }}/
+      - /edx/app/xqwatcher/data/mit-600x-{{ queue_name }}/
     kwargs:
       identity: /edx/app/xqwatcher/.ssh/xqwatcher-courses
-  {% endfor %}
-  {% endif %}
   {% endfor %}

--- a/pillar/edx/xqwatcher_6S082.sls
+++ b/pillar/edx/xqwatcher_6S082.sls
@@ -4,6 +4,13 @@
 {% set xqwatcher_venv_base = '/edx/app/xqwatcher/venvs' %}
 {% set python3_version = 'python3.8' %}
 {% set queue_name = 'mitx-6S082grader' %}
+{% set env_map = {
+  "mitx": "production",
+  "mitx-staging": "master"
+} %}
+
+{% set watcher_git_ref = env_map[environment.rsplit("-", 1)[-1]] %}
+{% set env_prefix = environment.rsplit("-", 1)[-1] %}
 
 edx:
   xqwatcher:
@@ -11,11 +18,9 @@ edx:
       - numpy
   ansible_vars:
    XQWATCHER_COURSES:
-    {% for purpose, purpose_data in env_data.purposes.items() %}
-    {% if 'residential' in purpose %}
-    - COURSE: "mit-6S082-{{ purpose }}-{{ queue_name }}"
+    - COURSE: "mit-6S082"
       GIT_REPO: git@github.mit.edu:mitx/graders-mit-6S082r
-      GIT_REF: {{ purpose_data.versions.xqwatcher_courses }}
+      GIT_REF: {{ watcher_git_ref }}
       PYTHON_REQUIREMENTS:
         - name: numpy
           version: 1.19.4
@@ -27,8 +32,8 @@ edx:
       QUEUE_NAME: {{ queue_name }}
       QUEUE_CONFIG:
         AUTH:
-          - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>username
-          - __vault__::secret-residential/{{ environment }}/xqwatcher-xqueue-django-auth-{{ purpose }}>data>password
+          - xqwatcher
+          - __vault__::secret-{{ env_prefix }}/edx-xqueue>data>xqwatcher_password
         SERVER: http://xqueue.service.consul:18040
         CONNECTIONS: 5
         HANDLERS:
@@ -39,20 +44,14 @@ edx:
               lang: python3
               bin_path: "{{ xqwatcher_venv_base }}/mit-6S082/bin/python"
             KWARGS:
-              grader_root: ../data/mit-6S082-{{ purpose }}-{{ queue_name }}/
-    {% endif %}
-    {% endfor %}
+              grader_root: ../data/mit-6S082/
 
 
 schedule:
-  {% for purpose, purpose_data in env_data.purposes.items() %}
-  {% if purpose_data.business_unit == 'residential' %}
-  update_live_grader_for_{{ purpose }}_with_{{ queue_name }}_queue:
+  update_live_grader_for:
     function: git.pull
     minutes: 5
     args:
-      - /edx/app/xqwatcher/data/mit-6S082-{{ purpose }}-{{ queue_name }}/
+      - /edx/app/xqwatcher/data/mit-6S082/
     kwargs:
       identity: /edx/app/xqwatcher/.ssh/xqwatcher-courses
-  {% endif %}
-  {% endfor %}

--- a/salt/environment_settings.yml
+++ b/salt/environment_settings.yml
@@ -53,38 +53,6 @@ current_residential_versions_rp: &current_residential_versions_rp
   codename: lilac
   ami_id: ami-0885b1f6bd170450c
 
-next_residential_versions: &next_residential_versions
-  edx_config_repo: https://github.com/mitodl/configuration
-  edx_config_version: open-release/lilac.master
-  edx_platform_repo: 'https://github.com/mitodl/edx-platform'
-  edxapp: mitx/lilac
-  forum_source_repo: 'https://github.com/mitodl/cs_comments_service'
-  forum: open-release/lilac.master
-  xqueue_source_repo: 'https://github.com/mitodl/xqueue'
-  xqueue: open-release/lilac.master
-  xqwatcher_courses: master
-  theme_source_repo: 'https://github.com/mitodl/mitx-theme'
-  theme_name: 'mitx-theme'
-  theme: lilac
-  codename: lilac
-  ami_id: ami-0885b1f6bd170450c
-
-edxapp_continuous_delivery_versions: &continuous_delivery_versions
-  edx_config_repo: https://github.com/mitodl/configuration
-  edx_config_version: master
-  edx_platform_repo: 'https://github.com/edx/edx-platform'
-  edxapp: master
-  forum_source_repo: 'https://github.com/edx/cs_comments_service'
-  forum: master
-  xqueue_source_repo: 'https://github.com/edx/xqueue'
-  xqueue: master
-  xqwatcher_courses: master
-  theme_source_repo: 'https://github.com/mitodl/mitx-theme'
-  theme_name: 'mitx-theme'
-  theme: master
-  codename: tumbleweed
-  ami_id: ami-80861296
-
 xpro_qa_versions: &xpro_qa_versions
   edx_config_repo: https://github.com/mitodl/configuration
   edx_config_version: open-release/koa.master
@@ -115,32 +83,6 @@ xpro_production_versions: &xpro_production_versions
   theme_name: 'mitxpro-theme'
   theme: koa
   codename: koa
-  ami_id: ami-0885b1f6bd170450c
-
-mitxonline_qa_versions: &mitxonline_qa_versions
-  edx_config_repo: https://github.com/edx/configuration
-  edx_config_version: master
-  edx_platform_repo: 'https://github.com/edx/edx-platform'
-  edxapp: master
-  forum_source_repo: 'https://github.com/edx/cs_comments_service'
-  forum: master
-  xqueue_source_repo: 'https://github.com/edx/xqueue'
-  xqueue: master
-  xqwatcher_courses: master
-  codename: lilac
-  ami_id: ami-0885b1f6bd170450c
-
-mitxonline_production_versions: &mitxonline_production_versions
-  edx_config_repo: https://github.com/edx/configuration
-  edx_config_version: master
-  edx_platform_repo: 'https://github.com/edx/edx-platform'
-  edxapp: master
-  forum_source_repo: 'https://github.com/edx/cs_comments_service'
-  forum: master
-  xqueue_source_repo: 'https://github.com/edx/xqueue'
-  xqueue: master
-  xqwatcher_courses: master
-  codename: lilac
   ami_id: ami-0885b1f6bd170450c
 
 sandbox_residential_versions: &sandbox_residential_versions
@@ -411,10 +353,6 @@ environments:
         - elasticsearch
         - mongodb
         - rabbitmq
-    purposes:
-      mitxonline-qa:
-        app: edx-platform
-        business_unit: mitxonline
   mitxonline-production:
     business_unit: mitxonline
     network_prefix: '10.21'
@@ -427,27 +365,23 @@ environments:
         - elasticsearch
         - mongodb
         - rabbitmq
+  mitx-staging-qa:
+    business_unit: residential-staging
+    network_prefix: '10.30'
+    vpc_name: MITx QA Staging
+    vpc_peers:
+      - operations-qa
     purposes:
-      mitxonline-production:
-        app: edx-platform
-        business_unit: mitxonline
-        domains:
-          cms: studio.mitxonline.mit.edu
-          lms: courses.mitxonline.mit.edu
-          preview: preview.mitxonline.mit.edu
+      xqwatcher:
+        app: xqueue-watcher
+        business_unit: residential-staging
         versions:
-          <<: *mitxonline_production_versions
-        instances:
-          edxapp:
-            min_number: 6
-            max_number: 10
-            type: r5a.large
-          edx-worker:
-            min_number: 3
-            max_number: 7
-            type: t3a.large
-        security_groups:
-          - edx
+          xqwatcher: 41ef7dff8e73f2ef5a5ffee20c4a5b822eb95341
+          edx_config_repo: https://github.com/edx/configuration
+          edx_config_version: open-release/maple.master
+        courses:
+          - name: 600x
+            num_instances: 1
   mitx-qa:
     business_unit: residential
     network_prefix: '10.5'
@@ -491,14 +425,14 @@ environments:
         app: xqueue-watcher
         business_unit: residential
         versions:
-          xqwatcher: fe9d465
-          edx_config_repo: https://github.com/mitodl/configuration
-          edx_config_version: open-release/koa.master
+          xqwatcher: 41ef7dff8e73f2ef5a5ffee20c4a5b822eb95341
+          edx_config_repo: https://github.com/edx/configuration
+          edx_config_version: open-release/maple.master
         courses:
           - name: 600x
             num_instances: 2
           - name: 686
-            num_instances: 1
+            num_instances: 
           - name: 6S082
             num_instances: 1
           - name: 940
@@ -557,6 +491,23 @@ environments:
         domains:
           - auth.mitx.mit.edu
         num_instances: 1
+  mitx-staging-production:
+    business_unit: residential-staging
+    network_prefix: '10.31'
+    vpc_name: MITx Production Staging
+    vpc_peers:
+      - operations-production
+    purposes:
+      xqwatcher:
+        app: xqueue-watcher
+        business_unit: residential-staging
+        versions:
+          xqwatcher: 41ef7dff8e73f2ef5a5ffee20c4a5b822eb95341
+          edx_config_repo: https://github.com/edx/configuration
+          edx_config_version: open-release/maple.master
+        courses:
+          - name: 600x
+            num_instances: 2
   mitx-production:
     business_unit: residential
     network_prefix: '10.7'
@@ -600,9 +551,9 @@ environments:
         app: xqueue-watcher
         business_unit: residential
         versions:
-          xqwatcher: a95cc96
-          edx_config_repo: https://github.com/mitodl/configuration
-          edx_config_version: open-release/koa.master
+          xqwatcher: 41ef7dff8e73f2ef5a5ffee20c4a5b822eb95341
+          edx_config_repo: https://github.com/edx/configuration
+          edx_config_version: open-release/maple.master
         courses:
           - name: 600x
             num_instances: 3

--- a/salt/orchestrate/edx/xqwatcher.sls
+++ b/salt/orchestrate/edx/xqwatcher.sls
@@ -23,7 +23,7 @@ ensure_instance_profile_exists_for_xqwatcher:
 {% for course in env_data.purposes[app_name].courses %}
 {% set INSTANCE_COUNT = course.num_instances %}
 {% set security_groups = course.get('security_groups', []) %}
-{% do security_groups.extend(['master-ssh', 'consul-agent']) %}
+{% do security_groups.extend(['salt-minion', 'consul-agent']) %}
 generate_xqwatcher_{{ course.name }}_cloud_map_file:
   file.managed:
     - name: /etc/salt/cloud.maps.d/{{ ENVIRONMENT }}_xqwatcher_map.yml
@@ -47,7 +47,7 @@ generate_xqwatcher_{{ course.name }}_cloud_map_file:
         securitygroupid:
           {% for group_name in security_groups %}
           - {{ salt.boto_secgroup.get_group_id(
-            '{}-{}'.format(group_name, ENVIRONMENT), vpc_name=VPC_NAME) }}
+            '{}-{}'.format(ENVIRONMENT, group_name), vpc_name=VPC_NAME) }}
           {% endfor %}
         subnetids: {{ subnet_ids|tojson }}
     - require:


### PR DESCRIPTION
For our deployment of the Maple release we are splitting the live and staging
environments into separate VPCs. This means that for residential use of xqueue-watcher
we need to deploy a separate group of watchers for those courses that use the staging
environment. This updates the configuration to reduce the amount of extraneous logic so
that we can deploy dedicated watchers per environment.

- Gets rid of iteration over purposes that is difficult to understand
- Adds new environment definitions to include the staging environments of QA and
- Production
- Updates xqueue-watcher versions to match the latest code