### PR TITLE
Switched digtial credentials auth mode to 'code'

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -166,7 +166,7 @@ heroku:
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
     MAILGUN_FROM_EMAIL: {{ env_data.MAILGUN_FROM_EMAIL }}
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
-    MITOL_DIGITAL_CREDENTIALS_AUTH_TYPE: xpro
+    MITOL_DIGITAL_CREDENTIALS_AUTH_TYPE: code
     MITOL_DIGITAL_CREDENTIALS_DEEP_LINK_URL: dccrequest://request
     MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET: __vault__::secret-{{ business_unit }}/{{ environment }}/digital-credentials-integration>data>hmac_secret
     MITOL_DIGITAL_CREDENTIALS_VERIFY_SERVICE_BASE_URL: __vault__::secret-{{ business_unit }}/{{ environment }}/digital-credentials-integration>data>sign_and_verify_url


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Changes the configured `auth_mode` for digital credentials to `"code"`.

#### How should this be manually tested?
I've already manually set this on RC and it's been verified by the DC team, so other than valid yaml it should be ok.