### PR TITLE
add env variables for theme assets pipeline

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -24,6 +24,7 @@
       'OCW_STUDIO_LIVE_URL': '',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-ci-support@mit.edu',
+      'SEARCH_API_URL': 'https://discussions-ci.odl.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio CI',
       'SOCIAL_AUTH_SAML_SP_ENTITY_ID': 'https://ocw-studio-ci.odl.mit.edu/saml/metadata',
@@ -51,6 +52,7 @@
       'OCW_STUDIO_LIVE_URL': 'https://ocw-live-qa.global.ssl.fastly.net/',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-rc-support@mit.edu',
+      'SEARCH_API_URL': 'https://discussions-rc.odl.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio RC',
       'SOCIAL_AUTH_SAML_SP_ENTITY_ID': 'https://ocw-studio-rc.odl.mit.edu/saml/metadata',
@@ -78,6 +80,7 @@
       'OCW_STUDIO_LIVE_URL': 'https://ocw-published.odl.mit.edu/',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-support@mit.edu',
+      'SEARCH_API_URL': 'https://open.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio',
       'SOCIAL_AUTH_SAML_SP_ENTITY_ID': 'https://ocw-studio.odl.mit.edu/saml/metadata',
@@ -108,6 +111,7 @@ heroku:
     AWS_STORAGE_BUCKET_NAME: 'ol-ocw-studio-app-{{ env_data.env }}'
     CONTENT_SYNC_BACKEND: content_sync.backends.github.GithubBackend
     CONTENT_SYNC_PIPELINE: content_sync.pipelines.concourse.ConcourseGithubPipeline
+    CONTENT_SYNC_THEME_PIPELINE: content_sync.pipelines.concourse.ThemeAssetsPipeline
     CONCOURSE_URL: {{ env_data.CONCOURSE_URL }}
     CONCOURSE_USERNAME: oldevops
     CONCOURSE_PASSWORD: __vault__::secret-concourse/data/web>data>data>admin_password
@@ -147,6 +151,7 @@ heroku:
     OCW_STUDIO_SUPPORT_EMAIL: {{ env_data.OCW_STUDIO_SUPPORT_EMAIL }}
     OCW_STUDIO_USE_S3: True
     PREPUBLISH_ACTIONS: videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata
+    SEARCH_API_URL: {{ env_data.SEARCH_API_URL }}
     SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ app }}/{{ environment }}/django-secret-key>data>value
     SENTRY_DSN: __vault__::secret-operations/global/{{ business_unit }}/ocw-studio/sentry-dsn>data>value
     SENTRY_LOG_LEVEL: {{ env_data.sentry_log_level }}


### PR DESCRIPTION
This PR adds the relevant env variables `CONTENT_SYNC_THEME_PIPELINE` and `SEARCH_API_URL` that will be used once https://github.com/mitodl/ocw-studio/pull/945 is merged and sets the per-environment values for `SEARCH_API_URL`.