### PR TITLE
Set youtube_project_id for prod ocw-studio

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -85,7 +85,7 @@
       'SITE_NAME': 'MIT OCW Studio',
       'SOCIAL_AUTH_SAML_SP_ENTITY_ID': 'https://ocw-studio.odl.mit.edu/saml/metadata',
       'vault_env_path': 'production-apps',
-      'youtube_project_id': ''
+      'youtube_project_id': 'ocw-studio-qa'
       }
 } %}
 {% set env_data = env_dict[environment] %}


### PR DESCRIPTION
#### What are the relevant tickets?
Part of [https://github.com/mitodl/ocw-studio/issues/486](https://github.com/mitodl/ocw-studio/issues/486#issuecomment-994929752)

#### What's this PR do?
Sets `youtube_project_id` for production

#### How should this be manually tested?
N/A

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
Still to do:
- Set `YT_PROJECT_ID`, `YT_CLIENT_ID`, and `YT_CLIENT_SECRET` values in vault to the same as rc
- Use the ocw-studio `youtube_tokens` management command to generate the `YT_ACCESS_TOKEN`, `YT_REFRESH_TOKEN` values for the production channel, then add those to vault as well.

