### PR TITLE
ocw next webhook keys

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -199,6 +199,7 @@ heroku:
     OCW_LEARNING_COURSE_BUCKET_NAME: open-learning-course-data-{{ env_data.env_name }}
     OCW_NEXT_AWS_STORAGE_BUCKET_NAME: {{ env_data.OCW_NEXT_AWS_STORAGE_BUCKET_NAME }}
     OCW_NEXT_LIVE_BUCKET: {{ env_data.OCW_NEXT_LIVE_BUCKET }}
+    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-{{ business_unit }}/global/update-search-data-webhook-key>data>value
     OCW_UPLOAD_IMAGE_ONLY: {{ env_data.OCW_UPLOAD_IMAGE_ONLY }}
     OLL_ALT_URL: https://openlearninglibrary.mit.edu/courses/
     OLL_API_ACCESS_TOKEN_URL: https://openlearninglibrary.mit.edu/oauth2/access_token/

--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -25,6 +25,7 @@
       'OCW_STUDIO_LIVE_URL': '',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-ci-support@mit.edu',
+      'OPEN_DISCUSSIONS_URL': 'https://discussions-ci.odl.mit.edu',
       'SEARCH_API_URL': 'https://discussions-ci.odl.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio CI',
@@ -54,6 +55,7 @@
       'OCW_STUDIO_LIVE_URL': 'https://ocw-live-qa.global.ssl.fastly.net/',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-rc-support@mit.edu',
+      'OPEN_DISCUSSIONS_URL': 'https://discussions-rc.odl.mit.edu',
       'SEARCH_API_URL': 'https://discussions-rc.odl.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio RC',
@@ -83,6 +85,7 @@
       'OCW_STUDIO_LIVE_URL': 'https://ocw-published.odl.mit.edu/',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-support@mit.edu',
+      'OPEN_DISCUSSIONS_URL': 'https://open.mit.edu',
       'SEARCH_API_URL': 'https://open.mit.edu/api/v0/search/',
       'sentry_log_level': 'WARN',
       'SITE_NAME': 'MIT OCW Studio',
@@ -156,6 +159,8 @@ heroku:
     OCW_STUDIO_LOG_LEVEL: {{ env_data.OCW_STUDIO_LOG_LEVEL }}
     OCW_STUDIO_SUPPORT_EMAIL: {{ env_data.OCW_STUDIO_SUPPORT_EMAIL }}
     OCW_STUDIO_USE_S3: True
+    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-{{ business_unit }}/global/update-search-data-webhook-key>data>value
+    OPEN_DISCUSSIONS_URL: {{ env_data.OPEN_DISCUSSIONS_URL }}
     PREPUBLISH_ACTIONS: videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata
     SEARCH_API_URL: {{ env_data.SEARCH_API_URL }}
     SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ app }}/{{ environment }}/django-secret-key>data>value


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/1005

#### What's this PR do?
This PR adds OCW_NEXT_WEBHOOK_KEY to open-discussions and OPEN_DISCUSSIONS_WEBHOOK_KEY to ocw-studio. They can be any string but should be the same for each environment. I'm a little confused about how vault is organized - it seems like the paths in discussions.sls follow a different pattern than the paths in ocw-studio.sls. Please double check that I got them right 
