### PR TITLE
Disabling management of fluentd resources on all elasticsearch nodes.

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -18,7 +18,6 @@ base:
     - vector.cas
   'G@roles:elasticsearch and not P@environment:operations*':
     - match: compound
-    - fluentd.elasticsearch
     - consul
     - consul.elasticsearch
   'roles:kibana':
@@ -172,13 +171,11 @@ base:
     - match: compound
     - elastic_stack.elasticsearch.logging_production
     - netdata.elasticsearch_logging
-    - fluentd.elasticsearch
     - consul.elasticsearch
   'G@roles:elasticsearch and G@environment:operations-qa':
     - match: compound
     - elastic_stack.elasticsearch.logging_qa
     - netdata.elasticsearch_logging
-    - fluentd.elasticsearch
     - consul.elasticsearch
   'roles:xqwatcher':
     - match: grain


### PR DESCRIPTION
#### What are the relevant tickets?
Partially addresses #1512 

#### What's this PR do?
Turns off salt management of fluentd processes and configurations on all elasticsearch nodes. 

#### How should this be manually tested?
```
sudo salt 'elasticsearch-apps-qa-*' cmd.run "systemctl stop fluentd"
sudo salt 'elasticsearch-apps-qa-*' cmd.run "systemctl disable fluentd"
sudo salt 'elasticsearch-apps-qa-*' cmd.run "ps -elf | grep fluentd"
```
Run state/highstate for these nodes. 

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
Elasticsearch nodes in QA were reported flapping by dev on 20220303

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
![Sadness](https://media.giphy.com/media/Jq7y34Hgfy01y/giphy.gif)
