### PR TITLE
Change OCW_STUDIO_LIVE_URL for production to ocw.mit.edu

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -84,7 +84,7 @@
       'OCW_IMPORT_STARTER_SLUG': 'ocw-course',
       'OCW_STUDIO_BASE_URL': 'https://ocw-studio.odl.mit.edu/',
       'OCW_STUDIO_DRAFT_URL': 'https://ocw-preview.odl.mit.edu/',
-      'OCW_STUDIO_LIVE_URL': 'https://ocw-published.odl.mit.edu/',
+      'OCW_STUDIO_LIVE_URL': 'https://ocw.mit.edu/',
       'OCW_STUDIO_LOG_LEVEL': 'INFO',
       'OCW_STUDIO_SUPPORT_EMAIL': 'ocw-studio-support@mit.edu',
       'OPEN_DISCUSSIONS_URL': 'https://open.mit.edu',


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1212

#### What's this PR do?
Changes the OCW_STUDIO_LIVE_URL value for production to "https://ocw.mit.edu/"

#### How should this be manually tested?
N/A
