### PR TITLE
Set MITX_ONLINE_SUPPORT_EMAIL for RC

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -59,8 +59,8 @@ heroku:
     {% set pg_creds = salt.vault.cached_read('postgres-mitxonline/creds/app', cache_prefix='heroku-mitxonline') %}
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/mitxonline
     HIREFIRE_TOKEN: __vault__::secret-{{ business_unit }}/production-apps/hirefire_token>data>value
-    MITX_ONLINE_SUPPORT_EMAIL: 'mitxonline-support@mit.edu'
     {% endif %}
+    MITX_ONLINE_SUPPORT_EMAIL: 'mitxonline-support@mit.edu'
     FEATURE_SYNC_ON_DASHBOARD_LOAD: True
     GA_TRACKING_ID: {{ env_data.GOOGLE_TRACKING_ID }}
     GTM_TRACKING_ID: {{ env_data.GOOGLE_TAG_MANAGER_ID }}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/729

#### What's this PR do?
Sets MITX_ONLINE_SUPPORT_EMAIL for RC.

#### How should this be manually tested?
Can check Value from the server.

#### Any background context you want to provide?
MITX_ONLINE_SUPPORT_EMAIL environment variable was not set for RC. It turned out that this variable was only being used for the `production` environment due to a conditional block in the configs. In this PR, MITX_ONLINE_SUPPORT_EMAIL is being set outside the `production` environment conditional block.
