### PR TITLE
Added some additional settings for google sheets

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -73,11 +73,13 @@ heroku:
     MAILGUN_FROM_EMAIL: {{ env_data.MAILGUN_FROM_EMAIL }}
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
     MITOL_GOOGLE_SHEET_PROCESSOR_APP_NAME: MITx Online ({{ env_data.env_name }})
+    MITOL_GOOGLE_SHEETS_ADMIN_EMAILS: __vault__::secret-mitxonline/google-service-worker>data>admin_emails
     MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-client-id
     MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-client-secret
     MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-api-project-id
     MITOL_GOOGLE_SHEETS_DRIVE_SERVICE_ACCOUNT_CREDS: __vault__::secret-mitxonline/google-service-worker>data>json_key
     MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>enrollment-change-sheet-id
+    MITOL_GOOGLE_SHEETS_REFUNDS_COMPLETED_DATE_COL: 12
     MITOL_GOOGLE_SHEETS_REFUNDS_ERROR_COL: 13
     MITOL_GOOGLE_SHEETS_REFUNDS_SKIP_ROW_COL: 14
     MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID: {{ env_data.MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID }}


### PR DESCRIPTION
#### What are the relevant tickets?
Related to changes for https://github.com/mitodl/mitxonline/issues/968

#### What's this PR do?
Adds some additional configuration settings to avoid some errors.

#### How should this be manually tested?

- Changes can be applied to RC, a value for `MITOL_GOOGLE_SHEETS_ADMIN_EMAILS` is not needed in RC
- In production, `MITOL_GOOGLE_SHEETS_ADMIN_EMAILS` does require a value, it should be a python list literal of email addresses. I _think_ that is supposed to be at least the service account's email address, but the documentation I have around this is a bit vague so we might need to trial-and-error this a bit. 