### PR TITLE
PROLEARN_CATALOG_API_URL for open discussions

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -246,6 +246,7 @@ heroku:
     PGBOUNCER_DEFAULT_POOL_SIZE: {{ env_data.PGBOUNCER_DEFAULT_POOL_SIZE}}
     PGBOUNCER_MAX_CLIENT_CONN: {{ env_data.PGBOUNCER_MAX_CLIENT_CONN }}
     PGBOUNCER_MIN_POOL_SIZE: {{ env_data.PGBOUNCER_MIN_POOL_SIZE }}
+    PROLEARN_CATALOG_API_URL: https://prolearn.mit.edu/graphql
     RECAPTCHA_SECRET_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/recaptcha-keys>data>secret_key
     RECAPTCHA_SITE_KEY: __vault__::secret-operations/{{ env_data.vault_env_path }}/{{ business_unit }}/recaptcha-keys>data>site_key
     SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ env_data.env_name }}/django-secret-key>data>value


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/open-discussions/issues/3787

#### What's this PR do?
Adds a url value for PROLEARN_CATALOG_API_URL to import courses/programs from the prolearn.mit.edu search API

#### How should this be manually tested?
N/A
