### PR TITLE
Add settings for OL Django User Retirement app

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -81,6 +81,8 @@ heroku:
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: MITx Online ({{ env_data.env_name }})
     MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-client-id
     MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-client-secret
+    MITOL_OPENEDX_USER_RETIREMENT_CLIENT_ID: __vault__::secret-mitxonline/openedx-user-retirement>data>worker-client-id
+    MITOL_OPENEDX_USER_RETIREMENT_CLIENT_SECRET: __vault__::secret-mitxonline/openedx-user-retirement>data>worker-client-secret
     MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>drive-api-project-id
     MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID: __vault__::secret-mitxonline/google-sheets-refunds>data>enrollment-change-sheet-id
     MITOL_GOOGLE_SHEETS_REFUNDS_COMPLETED_DATE_COL: 12


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxonline/issues/697
Relevant PRs: https://github.com/mitodl/ol-django/pull/101 & https://github.com/mitodl/ol-infrastructure/pull/1302

#### What's this PR do?
Adds settings for MITxOnline that are required by the newly added Open edX User Retirement app.

#### How should this be manually tested?
Once the related PRs are merged and retirement is configured. `retire_one_learner` management command should work in MITxOnline.
