### PR TITLE
Adds "True" value for IGNORE_EDX_FAILURES, so enrollments in mitxonline will persist if the edx enrollment fails

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -70,6 +70,7 @@ heroku:
     {% set pg_creds = salt.vault.cached_read('postgres-mitxonline/creds/app', cache_prefix='heroku-mitxonline') %}
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/mitxonline
     FEATURE_SYNC_ON_DASHBOARD_LOAD: True
+    FEATURE_IGNORE_EDX_FAILURES: True
     GA_TRACKING_ID: {{ env_data.GOOGLE_TRACKING_ID }}
     GTM_TRACKING_ID: {{ env_data.GOOGLE_TAG_MANAGER_ID }}
     HUBSPOT_PIPELINE_ID: '19817792'


### PR DESCRIPTION

#### What are the relevant tickets?

n/a but the absence of the flag was noticed while working through Sentry issue https://sentry.io/organizations/mit-office-of-digital-learning/issues/3826849409/?project=5864687&query=is%3Aunresolved&referrer=issue-stream

#### What's this PR do?

Adds `FEATURE_IGNORE_EDX_FAILURES` and sets it to True (default for FEATURES is False). This should have the effect of making MITx Online store enrollments that haven't been successfully applied in edX so they can be reconciled later. 
