### PR TITLE
add offline draft / live buckets to ocw-studio env

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -125,6 +125,8 @@ heroku:
     AWS_REGION: us-east-1
     AWS_PREVIEW_BUCKET_NAME: 'ocw-content-draft-{{ env_data.env }}'
     AWS_PUBLISH_BUCKET_NAME: 'ocw-content-live-{{ env_data.env }}'
+    AWS_OFFLINE_PREVIEW_BUCKET_NAME: 'ocw-content-offline-draft-{{ env_data.env }}'
+    AWS_OFFLINE_PUBLISH_BUCKET_NAME: 'ocw-content-offline-live-{{ env_data.env }}'
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/ocw-studio-app-{{ env_data.env }}>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'ol-ocw-studio-app-{{ env_data.env }}'
     CONTENT_SYNC_BACKEND: content_sync.backends.github.GithubBackend


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/1555

#### What's this PR do?
This PR adds the `AWS_OFFLINE_PREVIEW_BUCKET_NAME` and `AWS_OFFLINE_PUBLISH_BUCKET_NAME` env variables to the `ocw-studio` configuration. This is being done to provide the buckets in which to store offline copies of OCW course builds in, so we can close https://github.com/mitodl/ocw-studio/issues/1689.

#### How should this be manually tested?
No testing required, just adding an env variable
