### PR TITLE
add root website update task to ocw-studio prepublish actions

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -177,7 +177,7 @@ heroku:
     OCW_STUDIO_USE_S3: True
     OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-{{ business_unit }}/global/update-search-data-webhook-key>data>value
     OPEN_DISCUSSIONS_URL: {{ env_data.OPEN_DISCUSSIONS_URL }}
-    PREPUBLISH_ACTIONS: videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata
+    PREPUBLISH_ACTIONS: videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata,content_sync.tasks.update_website_in_root_website
     SEARCH_API_URL: {{ env_data.SEARCH_API_URL }}
     SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ app }}/{{ environment }}/django-secret-key>data>value
     SENTRY_DSN: __vault__::secret-operations/global/{{ business_unit }}/ocw-studio/sentry-dsn>data>value


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/1698

#### What's this PR do?
This PR adds `content_sync.tasks.update_website_in_root_website` to the `PREPUBLISH_ACTIONS` env var in `ocw-studio`. This task updates `WebsiteContent` objects of type "website" in the site denoted by `ROOT_WEBSITE_NAME`, providing a list of metadata for all other sites `ocw-studio` knows about in the form of markdown content.

#### How should this be manually tested?
Needs to be tested by being deployed in `ocw-studio` RC
