### PR TITLE
config: add config for course run sync to be every hour (MITxPRO)

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -124,6 +124,7 @@ heroku:
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/read-write-delete-xpro-app-{{ env_data.env_name }}>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'xpro-app-{{ env_data.env_name }}'
     COUPON_REQUEST_SHEET_ID: __vault__::secret-{{ business_unit }}/{{ environment }}/google-sheets-coupon-integration>data>sheet_id
+    CRON_COURSERUN_SYNC_HOURS: '*'
     CYBERSOURCE_ACCESS_KEY: {{ cybersource_creds.data.access_key }}
     CYBERSOURCE_MERCHANT_ID: 'mit_odl_xpro'
     CYBERSOURCE_PROFILE_ID: {{ cybersource_creds.data.profile_id }}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/mitxpro/issues/2616

#### What's this PR do?
- Adds values for cron job hours to run the job every hour. Previously it was using a value of `0` by default right from settings. Now it needs to be overridden in Heroku as `*`. We need to run the task every hour.

#### How should this be manually tested?
The `sync_courseruns` should run every hour moving onward, but that's actually testable in xPRO.
