### PR TITLE
config: add config for course run sync to be every hour (MITxOnline)

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -62,6 +62,7 @@ heroku:
     AWS_ACCESS_KEY_ID:  __vault__:cache:aws-mitx/creds/mitxonline>data>access_key
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/mitxonline>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'ol-mitxonline-app-{{ env_data.env_stage}}'
+    CRON_COURSERUN_SYNC_HOURS: '*'
     {% if env_data.env_name == 'production' %}
     HIREFIRE_TOKEN: __vault__::secret-{{ business_unit }}/production-apps/hirefire_token>data>value
     {% endif %}


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1211

#### What's this PR do?
- Adds values for cron job hours to run the job every hour. Previously it was using a value of `0` by default right from settings. Now it needs to be overridden in Heroku as *. We need to run the task every hour.

#### How should this be manually tested?
- To test it locally, you can run this task w.r.t minutes and check that the sync task runs every (Mins) that you've set. For this you can set the value for `CRON_COURSERUN_SYNC_HOURS` to be in decimal.
- The sync_courseruns should run every hour moving onward, but that's actually testable in xPRO.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
We made a similar change in https://github.com/mitodl/salt-ops/pull/1560 for xPRO.

