### PR TITLE
fix: temporarily run the course run sync taks on just fridays(MITxPRO)

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -125,6 +125,7 @@ heroku:
     AWS_STORAGE_BUCKET_NAME: 'xpro-app-{{ env_data.env_name }}'
     COUPON_REQUEST_SHEET_ID: __vault__::secret-{{ business_unit }}/{{ environment }}/google-sheets-coupon-integration>data>sheet_id
     CRON_COURSERUN_SYNC_HOURS: '*'
+    CRON_COURSERUN_SYNC_DAYS: 'fri'
     CYBERSOURCE_ACCESS_KEY: {{ cybersource_creds.data.access_key }}
     CYBERSOURCE_MERCHANT_ID: 'mit_odl_xpro'
     CYBERSOURCE_PROFILE_ID: {{ cybersource_creds.data.profile_id }}


### PR DESCRIPTION
#### What are the relevant tickets?
Temporary fix for https://github.com/mitodl/hq/issues/1406

- edx course details API is returning incorrect/cached start-end dates for the courses and that's effecting the behavior on xPRO, The dates in xPRO sync every hour, and even when we set the right dates manually the hourly task overrides them with the wrong ones in edX.

#### What's this PR do?
- Sets the task frequency to be run on Friday only, So that meanwhile we can figure out what's going on on edX side. This will stop the task for some days, meanwhile, we can see what's going on in edX.

#### How should this be manually tested?
- Check that the value set is the readable and right config value for celery tasks.
- The task only runs on Fridays

