### PR TITLE
Revert "fix: temporarily run the course run sync taks on just fridays(MITxPRO)"

### DIFF
--- a/pillar/heroku/xpro.sls
+++ b/pillar/heroku/xpro.sls
@@ -125,7 +125,6 @@ heroku:
     AWS_STORAGE_BUCKET_NAME: 'xpro-app-{{ env_data.env_name }}'
     COUPON_REQUEST_SHEET_ID: __vault__::secret-{{ business_unit }}/{{ environment }}/google-sheets-coupon-integration>data>sheet_id
     CRON_COURSERUN_SYNC_HOURS: '*'
-    CRON_COURSERUN_SYNC_DAYS: 'fri'
     CYBERSOURCE_ACCESS_KEY: {{ cybersource_creds.data.access_key }}
     CYBERSOURCE_MERCHANT_ID: 'mit_odl_xpro'
     CYBERSOURCE_PROFILE_ID: {{ cybersource_creds.data.profile_id }}


### PR DESCRIPTION
Reverts mitodl/salt-ops#1563

In the original PR, we changed the course run sync frequency from every hour daily to just every hour on `Friday`. The reason for doing that was that we were facing issues with edX dates. The course details API of our edX instance was returning wrong/cached dates and for that reason, they were getting overridden in xPRO making the course dates to be out of sync.

Now, The course details API from our edX instance seems to work fine and we are in a position to revert this change.