### PR TITLE
Adding ENV_NAME variable to ocw-studio

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -139,6 +139,7 @@ heroku:
     {% set pg_creds = salt.vault.cached_read('postgres-ocw-studio-applications-{}/creds/app'.format(env_data.env), cache_prefix='heroku-ocw-studio-' ~ env_data.env) %}
     {% set rds_endpoint = salt.boto_rds.get_endpoint('ocw-studio-db-applications-{}'.format(env_data.env)) %}
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/ocw_studio
+    ENV_NAME: {{ env_data.env_name }}
     GIT_API_URL: "https://github.mit.edu/api/v3"
     {% endif %}
     DRIVE_S3_UPLOAD_PREFIX: gdrive_uploads


### PR DESCRIPTION
#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/1125.

#### What's this PR do?
Adds the environment variable `ENV_NAME` to `ocw-studio`, which is necessary for differentiating between QA and production in defining the `noindex` meta tags to avoid indexing QA by search engines.

#### How should this be manually tested?
Verify that `ENV_NAME` is being defined correctly in Heroku, in particular to `rc` and `production`, as appropriate.