### PR TITLE
Vault path reconciliation for mitopen

### DIFF
--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -107,7 +107,7 @@ heroku:
     ENABLE_INFINITE_CORRIDOR: {{ env_data.ENABLE_INFINITE_CORRIDOR }}
     GA_G_TRACKING_ID: {{ env_data.GA_G_TRACKING_ID }}
     GA_TRACKING_ID: {{ env_data.GA_TRACKING_ID }}
-    GITHUB_ACCESS_TOKEN: __vault__::secret-mitopen/secrets>data>data>global>odlbot-github-access-token
+    GITHUB_ACCESS_TOKEN: __vault__::secret-operations/global/odlbot-github-access-token>data>value
     INDEXING_API_USERNAME: {{ env_data.INDEXING_API_USERNAME }}
     MAILGUN_FROM_EMAIL: 'MIT Open <no-reply@{{ env_data.MAILGUN_SENDER_DOMAIN }}'
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
@@ -127,7 +127,7 @@ heroku:
     OCW_NEXT_AWS_STORAGE_BUCKET_NAME: {{ env_data.OCW_NEXT_AWS_STORAGE_BUCKET_NAME }}
     OCW_NEXT_BASE_URL: {{ env_data.OCW_NEXT_BASE_URL }}
     OCW_NEXT_LIVE_BUCKET: {{ env_data.OCW_NEXT_LIVE_BUCKET }}
-    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-mitopen/secrets>data>data>global>update-search-data-webhook-key
+    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-operations/global/update-search-data-webhook-key>data>value
     OCW_UPLOAD_IMAGE_ONLY: {{ env_data.OCW_UPLOAD_IMAGE_ONLY }}
     OLL_ALT_URL: https://openlearninglibrary.mit.edu/courses/
     OLL_API_ACCESS_TOKEN_URL: https://openlearninglibrary.mit.edu/oauth2/access_token/

--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -153,7 +153,7 @@ heroku:
     MITOPEN_ENVIRONMENT: {{ env_data.env_name }}
     MITOPEN_FROM_EMAIL: MITOpen <mitopen-support@mit.edu>
     MITOPEN_FRONTPAGE_DIGEST_MAX_POSTS: 10
-    MITOPEN_JWT_SECRET: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>jwt_secret
+    MITOPEN_JWT_SECRET: __vault__::secret-mitopen/secrets>data>data>jwt_secret
     MITOPEN_LOG_LEVEL: {{ env_data.app_log_level }}
     MITOPEN_SUPPORT_EMAIL: {{ env_data.MITOPEN_SUPPORT_EMAIL }}
     MITOPEN_USE_S3: True
@@ -167,10 +167,10 @@ heroku:
     PGBOUNCER_MAX_CLIENT_CONN: {{ env_data.PGBOUNCER_MAX_CLIENT_CONN }}
     PGBOUNCER_MIN_POOL_SIZE: {{ env_data.PGBOUNCER_MIN_POOL_SIZE }}
     PROLEARN_CATALOG_API_URL: https://prolearn.mit.edu/graphql
-    SECRET_KEY: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>django-secret-key
+    SECRET_KEY: __vault__::secret-mitopen/secrets>data>data>django-secret-key
     SEE_BASE_URL: https://executive.mit.edu/
     SENTRY_DSN: __vault__::secret-operations/global/mitopen/sentry-dsn>data>value
-    STATUS_TOKEN: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>django-status-token
+    STATUS_TOKEN: __vault__::secret-mitopen/secrets>data>data>django-status-token
     TIKA_ACCESS_TOKEN: __vault__::secret-operations/tika/access-token>data>value
     TIKA_SERVER_ENDPOINT: {{ env_data.TIKA_SERVER_ENDPOINT }}
     USE_X_FORWARDED_HOST: True

--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -158,7 +158,7 @@ heroku:
     MITOPEN_SUPPORT_EMAIL: {{ env_data.MITOPEN_SUPPORT_EMAIL }}
     MITOPEN_USE_S3: True
     OPENSEARCH_DEFAULT_TIMEOUT: 30
-    OPENSEARCH_HTTP_AUTH: __vault__::secret-mitopen/secrets>data>data>elasticsearch>http_auth
+    OPENSEARCH_HTTP_AUTH: __vault__::secret-mitopen/secrets>data>data>opensearch>http_auth
     OPENSEARCH_INDEX: {{ env_data.OPENSEARCH_INDEX}}
     OPENSEARCH_INDEXING_CHUNK_SIZE: 75
     OPENSEARCH_SHARD_COUNT: {{ env_data.OPENSEARCH_SHARD_COUNT }}

--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -74,7 +74,6 @@
       }
 } %}
 {% set env_data = env_dict[environment] %}
-{% set business_unit = 'mitopen' %}
 {% set pg_creds = salt.vault.cached_read('postgres-mitopen/creds/app', cache_prefix='heroku-mitopen') %}
 {% set rds_endpoint = salt.boto_rds.get_endpoint('rds-postgresql-mitopen') %}
 
@@ -93,22 +92,22 @@ heroku:
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws/creds/mitopen>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'ol-mitopen-app-storage-{{ env_data.env_name }}'
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: {{ env_data.CELERY_WORKER_MAX_MEMORY_PER_CHILD }}
-    CKEDITOR_ENVIRONMENT_ID:  __vault__::secret-{{ business_unit }}/ckeditor>data>environment_id
-    CKEDITOR_SECRET_KEY:  __vault__::secret-{{ business_unit }}/ckeditor>data>secret_key
-    CKEDITOR_UPLOAD_URL:  __vault__::secret-{{ business_unit }}/ckeditor>data>upload_url
+    CKEDITOR_ENVIRONMENT_ID:  __vault__::secret-mitopen/secrets>data>data>ckeditor>environment_id
+    CKEDITOR_SECRET_KEY:  __vault__::secret-mitopen/secrets>data>data>ckeditor>secret_key
+    CKEDITOR_UPLOAD_URL:  __vault__::secret-mitopen/secrets>data>data>ckeditor>upload_url
     CSAIL_BASE_URL: https://cap.csail.mit.edu/
     DATABASE_URL: postgres://{{ pg_creds.data.username }}:{{ pg_creds.data.password }}@{{ rds_endpoint }}/mitopen
     DEBUG: {{ env_data.DEBUG }}
     DUPLICATE_COURSES_URL: https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/duplicate_courses.yml
     EDX_API_ACCESS_TOKEN_URL: https://api.edx.org/oauth2/v1/access_token
-    EDX_API_CLIENT_ID: __vault__::secret-{{ business_unit }}/edx-api-client>data>id
-    EDX_API_CLIENT_SECRET: __vault__::secret-{{ business_unit }}/edx-api-client>data>secret
+    EDX_API_CLIENT_ID: __vault__::secret-mitopen/secrets>data>data>edx-api-client>id
+    EDX_API_CLIENT_SECRET: __vault__::secret-mitopen/secrets>data>data>edx-api-client>secret
     EDX_API_URL: https://api.edx.org/catalog/v1/catalogs/10/courses
-    EMBEDLY_KEY: __vault__::secret-operations/{{ business_unit }}/embedly_key>data>value
+    EMBEDLY_KEY: __vault__::secret-operations/mitopen/embedly_key>data>value
     ENABLE_INFINITE_CORRIDOR: {{ env_data.ENABLE_INFINITE_CORRIDOR }}
     GA_G_TRACKING_ID: {{ env_data.GA_G_TRACKING_ID }}
     GA_TRACKING_ID: {{ env_data.GA_TRACKING_ID }}
-    GITHUB_ACCESS_TOKEN: __vault__::secret-{{ business_unit }}/global/odlbot-github-access-token>data>value
+    GITHUB_ACCESS_TOKEN: __vault__::secret-mitopen/secrets>data>data>global>odlbot-github-access-token
     INDEXING_API_USERNAME: {{ env_data.INDEXING_API_USERNAME }}
     MAILGUN_FROM_EMAIL: 'MIT Open <no-reply@{{ env_data.MAILGUN_SENDER_DOMAIN }}'
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
@@ -128,12 +127,12 @@ heroku:
     OCW_NEXT_AWS_STORAGE_BUCKET_NAME: {{ env_data.OCW_NEXT_AWS_STORAGE_BUCKET_NAME }}
     OCW_NEXT_BASE_URL: {{ env_data.OCW_NEXT_BASE_URL }}
     OCW_NEXT_LIVE_BUCKET: {{ env_data.OCW_NEXT_LIVE_BUCKET }}
-    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-{{ business_unit }}/global/update-search-data-webhook-key>data>value
+    OCW_NEXT_SEARCH_WEBHOOK_KEY: __vault__::secret-mitopen/secrets>data>data>global>update-search-data-webhook-key
     OCW_UPLOAD_IMAGE_ONLY: {{ env_data.OCW_UPLOAD_IMAGE_ONLY }}
     OLL_ALT_URL: https://openlearninglibrary.mit.edu/courses/
     OLL_API_ACCESS_TOKEN_URL: https://openlearninglibrary.mit.edu/oauth2/access_token/
-    OLL_API_CLIENT_ID: __vault__::secret-{{ business_unit }}/open-learning-library-client>data>client-id
-    OLL_API_CLIENT_SECRET: __vault__::secret-{{ business_unit }}/open-learning-library-client>data>client-secret
+    OLL_API_CLIENT_ID: __vault__::secret-mitopen/secrets>data>data>open-learning-library-client>client-id
+    OLL_API_CLIENT_SECRET: __vault__::secret-mitopen/secrets>data>data>open-learning-library-client>client-secret
     OLL_API_URL: https://discovery.openlearninglibrary.mit.edu/api/v1/catalogs/1/courses/
     OLL_BASE_URL: https://openlearninglibrary.mit.edu/course/
     MITOPEN_ADMIN_EMAIL: cuddle-bunnies@mit.edu
@@ -154,12 +153,12 @@ heroku:
     MITOPEN_ENVIRONMENT: {{ env_data.env_name }}
     MITOPEN_FROM_EMAIL: MITOpen <mitopen-support@mit.edu>
     MITOPEN_FRONTPAGE_DIGEST_MAX_POSTS: 10
-    MITOPEN_JWT_SECRET: __vault__:gen_if_missing:secret-{{ business_unit }}/jwt_secret>data>value
+    MITOPEN_JWT_SECRET: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>jwt_secret
     MITOPEN_LOG_LEVEL: {{ env_data.app_log_level }}
     MITOPEN_SUPPORT_EMAIL: {{ env_data.MITOPEN_SUPPORT_EMAIL }}
     MITOPEN_USE_S3: True
     OPENSEARCH_DEFAULT_TIMEOUT: 30
-    OPENSEARCH_HTTP_AUTH: __vault__::secret-{{ business_unit }}/elasticsearch>data>http_auth
+    OPENSEARCH_HTTP_AUTH: __vault__::secret-mitopen/secrets>data>data>elasticsearch>http_auth
     OPENSEARCH_INDEX: {{ env_data.OPENSEARCH_INDEX}}
     OPENSEARCH_INDEXING_CHUNK_SIZE: 75
     OPENSEARCH_SHARD_COUNT: {{ env_data.OPENSEARCH_SHARD_COUNT }}
@@ -168,17 +167,17 @@ heroku:
     PGBOUNCER_MAX_CLIENT_CONN: {{ env_data.PGBOUNCER_MAX_CLIENT_CONN }}
     PGBOUNCER_MIN_POOL_SIZE: {{ env_data.PGBOUNCER_MIN_POOL_SIZE }}
     PROLEARN_CATALOG_API_URL: https://prolearn.mit.edu/graphql
-    SECRET_KEY: __vault__:gen_if_missing:secret-{{ business_unit }}/django-secret-key>data>value
+    SECRET_KEY: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>django-secret-key
     SEE_BASE_URL: https://executive.mit.edu/
-    SENTRY_DSN: __vault__::secret-operations/global/{{ business_unit }}/sentry-dsn>data>value
-    STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/django-status-token>data>value
+    SENTRY_DSN: __vault__::secret-operations/global/mitopen/sentry-dsn>data>value
+    STATUS_TOKEN: __vault__:gen_if_missing:secret-mitopen/secrets>data>data>django-status-token
     TIKA_ACCESS_TOKEN: __vault__::secret-operations/tika/access-token>data>value
     TIKA_SERVER_ENDPOINT: {{ env_data.TIKA_SERVER_ENDPOINT }}
     USE_X_FORWARDED_HOST: True
     USE_X_FORWARDED_PORT: True
     XPRO_CATALOG_API_URL: https://{{ etl_xpro_host }}/api/programs/
     XPRO_COURSES_API_URL: https://{{ etl_xpro_host }}/api/courses/
-    YOUTUBE_DEVELOPER_KEY: __vault__::secret-{{ business_unit }}/youtube-developer-key>data>value
+    YOUTUBE_DEVELOPER_KEY: __vault__::secret-mitopen/secrets>data>data>youtube-developer-key
     YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS: 21600
     YOUTUBE_FETCH_TRANSCRIPT_SLEEP_SECONDS: 20
 


### PR DESCRIPTION

# What are the relevant tickets?
Cousin : https://github.com/mitodl/salt-ops/pull/1577

# Description (What does it do?)
Refactoring for new value paths for mitopen and hard-coding 'mitopen' as the business unit in all paths rather than using a variable that never varies.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots
