### PR TITLE
Adds the two Posthog settings to the list for MITx Online.

### DIFF
--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -138,6 +138,8 @@ heroku:
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
     USE_X_FORWARDED_HOST: True
     ZENDESK_HELP_WIDGET_ENABLED: True
+    POSTHOG_API_TOKEN: __vault__::secret-{{ business_unit }}/{{ env_data.env_name }}/posthog-credentials>data>api-token
+    POSTHOG_API_HOST: "https://app.posthog.com"
 
 schedule:
   refresh_{{ env_data.app_name }}_configs:

--- a/pillar/heroku/mitxonline.sls
+++ b/pillar/heroku/mitxonline.sls
@@ -138,7 +138,7 @@ heroku:
     STATUS_TOKEN: __vault__:gen_if_missing:secret-{{ business_unit }}/{{ environment }}/django-status-token>data>value
     USE_X_FORWARDED_HOST: True
     ZENDESK_HELP_WIDGET_ENABLED: True
-    POSTHOG_API_TOKEN: __vault__::secret-{{ business_unit }}/{{ env_data.env_name }}/posthog-credentials>data>api-token
+    POSTHOG_API_TOKEN: __vault__::secret-{{ business_unit }}/posthog-credentials>data>api-token
     POSTHOG_API_HOST: "https://app.posthog.com"
 
 schedule:


### PR DESCRIPTION
# What are the relevant tickets?

mitodl/mitxonline#1809

# Description (What does it do?)

Adds the two Posthog configuration settings to the salt file for MITx Online.

# Additional Context

`POSTHOG_API_TOKEN` is set up to use the vault (in the same manner that other tokens are, like the ones for CyberSource).
