### PR TITLE
Add Keycloak specific environment variables

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -43,6 +43,9 @@
       'TIKA_SERVER_ENDPOINT': 'https://tika-ci.odl.mit.edu',
       'vault_env_path': 'rc-apps',
       'env_stage': 'ci',
+      'FEATURE_KEYCLOAK_ENABLED': True,
+      'KEYCLOAK_BASE_URL': 'https://sso-ci.odl.mit.edu',
+      'KEYCLOAK_REALM_NAME': 'olapps',
       },
     'rc': {
       'app_log_level': 'INFO',
@@ -86,6 +89,9 @@
       'TIKA_SERVER_ENDPOINT': 'https://tika-qa.odl.mit.edu',
       'vault_env_path': 'rc-apps',
       'env_stage': 'qa',
+      'FEATURE_KEYCLOAK_ENABLED': True,
+      'KEYCLOAK_BASE_URL': 'https://sso-qa.odl.mit.edu',
+      'KEYCLOAK_REALM_NAME': 'olapps',
       },
     'production': {
       'app_log_level': 'INFO',
@@ -129,6 +135,9 @@
       'TIKA_SERVER_ENDPOINT': 'https://tika-production.odl.mit.edu',
       'vault_env_path': 'production-apps',
       'env_stage': 'production',
+      'FEATURE_KEYCLOAK_ENABLED': False,
+      'KEYCLOAK_BASE_URL': '',
+      'KEYCLOAK_REALM_NAME': '',
       }
 } %}
 {% set env_data = env_dict[environment] %}


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/open-discussions/pull/4234

# Description (What does it do?)
This adds 3 new environment variables to Open Discussions which are required by https://github.com/mitodl/open-discussions/pull/4234.

The environment variables are: 
`FEATURE_KEYCLOAK_ENABLED`
`KEYCLOAK_BASE_URL`
`KEYCLOAK_REALM_NAME`
