### PR TITLE
set AWS_MAX_CONCURRENT_CONNECTIONS to 100

### DIFF
--- a/pillar/heroku/ocw-studio.sls
+++ b/pillar/heroku/ocw-studio.sls
@@ -148,6 +148,7 @@ heroku:
     AWS_OFFLINE_PUBLISH_BUCKET_NAME: 'ocw-content-offline-live-{{ env_data.env }}'
     AWS_SECRET_ACCESS_KEY: __vault__:cache:aws-mitx/creds/ocw-studio-app-{{ env_data.env }}>data>secret_key
     AWS_STORAGE_BUCKET_NAME: 'ol-ocw-studio-app-{{ env_data.env }}'
+    AWS_MAX_CONCURRENT_CONNECTIONS: 100
     CONTENT_SYNC_BACKEND: content_sync.backends.github.GithubBackend
     CONTENT_SYNC_PIPELINE: content_sync.pipelines.concourse.ConcourseGithubPipeline
     CONTENT_SYNC_THEME_PIPELINE: content_sync.pipelines.concourse.ThemeAssetsPipeline


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/1998

# Description (What does it do?)
This sets the `AWS_MAX_CONCURRENT_CONNECTIONS` env variable to 100 in `ocw-studio`. This setting was added in https://github.com/mitodl/ocw-studio/pull/1999 and controls the `max_concurrent_connections` setting in the final AWS sync operations during site pipeline runs.

# How can this be tested?
This functionality has already been tested in QA by manually setting the variable in the web UI, this PR is just finalizing that change.
