### PR TITLE
Add MICROMASTERS_CATALOG_API_URL to mitopen env

### DIFF
--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -110,6 +110,7 @@ heroku:
     MAILGUN_KEY: __vault__::secret-operations/global/mailgun-api-key>data>value
     MAILGUN_SENDER_DOMAIN: {{ env_data.MAILGUN_SENDER_DOMAIN }}
     MAILGUN_URL: https://api.mailgun.net/v3/{{ env_data.MAILGUN_SENDER_DOMAIN }}
+    MICROMASTERS_CATALOG_API_URL: https://{{ etl_micromasters_host }}/api/v0/catalog/
     MITPE_BASE_URL: https://professional.mit.edu/
     EDX_LEARNING_COURSE_BUCKET_NAME: {{ env_data.EDX_LEARNING_COURSE_BUCKET_NAME }}
     MITX_ONLINE_BASE_URL: https://mitxonline.mit.edu/


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/144

# Description (What does it do?)
Adds `MICROMASTERS_CATALOG_API_URL` to env settings for mit-open, value based on this pre-existing line:

```
{% set etl_micromasters_host = salt.sdb.get('sdb://consul/open-{}-etl-micromasters-host'.format(environment)) %}
```

Devops question: Is `sdb://consul/open-{}-etl-micromasters-host` set for mit-open?  Should be the same as for open-discussions.

