### PR TITLE
Add keycloak vars for MIT Open

### DIFF
--- a/pillar/heroku/mitopen.sls
+++ b/pillar/heroku/mitopen.sls
@@ -33,6 +33,8 @@
       'SSO_URL': 'sso-qa.odl.mit.edu',
       'TIKA_SERVER_ENDPOINT': 'https://tika-qa.odl.mit.edu',
       'env_stage': 'qa',
+      'KEYCLOAK_BASE_URL': 'https://sso-qa.odl.mit.edu',
+      'KEYCLOAK_REALM_NAME': 'olapps',
       },
     'production': {
       'app_log_level': 'INFO',
@@ -67,6 +69,8 @@
       'SSO_URL': 'sso.odl.mit.edu',
       'TIKA_SERVER_ENDPOINT': 'https://tika-production.odl.mit.edu',
       'env_stage': 'production',
+      'KEYCLOAK_BASE_URL': 'https://sso.odl.mit.edu',
+      'KEYCLOAK_REALM_NAME': 'olapps',
       }
 } %}
 {% set env_data = env_dict[environment] %}
@@ -180,6 +184,8 @@ heroku:
     AUTHORIZATION_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/auth
     ACCESS_TOKEN_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/token
     USERINFO_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/userinfo
+    KEYCLOAK_BASE_URL: {{ env_data.KEYCLOAK_BASE_URL }}
+    KEYCLOAK_REALM_NAME: {{ env_data.KEYCLOAK_REALM_NAME }}
 
 schedule:
   refresh_{{ env_data.app_name }}_configs:


### PR DESCRIPTION
# What are the relevant tickets?
Followup to https://github.com/mitodl/mit-open/pull/194 for https://github.com/mitodl/mit-open/issues/130

# Description (What does it do?)
This PR adds `KEYCLOAK_BASE_URL` and `KEYCLOAK_REALM_NAME` for MIT Open. These vars were introduced to MIT Open in https://github.com/mitodl/mit-open/pull/194, but never made it into RC or prod. Currently, https://mit-open-rc.odl.mit.edu/logout redirects to incorrect URL (`http://mit-keycloak-base-url.edu`).

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
I have not really tested this. Happy for advice there. Modeled after the corresponding old open-discussions https://github.com/mitodl/salt-ops/pull/1593

# Additional Context
The corresponding PR for old open-discussion (https://github.com/mitodl/salt-ops/pull/1593) only added the values for CI and RC, but not prod, since old discussions is a live site in prod.

In contrast, **I did include prod** for this PR since MIT Open isn't live.