### PR TITLE
add remaining SSO URLs to discussions.sls

### DIFF
--- a/pillar/heroku/discussions.sls
+++ b/pillar/heroku/discussions.sls
@@ -315,6 +315,9 @@ heroku:
     OIDC_ENDPOINT: https://{{ env_data.SSO_URL }}/realms/olapps
     SOCIAL_AUTH_OL_OIDC_KEY: ol-open-discussions-client
     SOCIAL_AUTH_OL_OIDC_SECRET: __vault__::secret-operations/sso/open-discussions>data>client_secret
+    ACCESS_TOKEN_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/token
+    AUTHORIZATION_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/auth
+    USERINFO_URL: https://{{ env_data.SSO_URL }}/realms/olapps/protocol/openid-connect/userinfo
 
 schedule:
   refresh_{{ env_data.app_name }}_configs:


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up for https://github.com/mitodl/salt-ops/issues/1614

### Description (What does it do?)
In https://github.com/mitodl/salt-ops/pull/1615, we added some missing OIDC configuration for `open-discussions`. This PR adds a few more settings that were missing

### How can this be tested?
Deploy to RC and test